### PR TITLE
Added "DXRFixup" module to address issue #17

### DIFF
--- a/DeusEx/Classes/DXRFixup.uc
+++ b/DeusEx/Classes/DXRFixup.uc
@@ -63,24 +63,17 @@ function AnyEntry()
     
 }
 
-function ReEntry()
-{
-    Super.ReEntry();
-    doFixup();
-}
-
 function doFixup()
 {
     local Actor a;
     local ScriptedPawn p;
-    local name flagName;
     local bool boolFlag;
+    local bool recruitedFlag;
     
     switch(dxr.localURL)
     {
         case "06_HONGKONG_TONGBASE":
-            flagName = dxr.Player.rootWindow.StringToName("QuickLetPlayerIn");
-            boolFlag = dxr.Player.flagBase.GetBool(flagName);
+            boolFlag = dxr.Player.flagBase.GetBool('QuickLetPlayerIn');
             foreach AllActors(class'Actor', a)
             {
                 switch(string(a.Tag))
@@ -89,27 +82,34 @@ function doFixup()
                         ScriptedPawn(a).ChangeAlly(dxr.Player.Alliance,1,False);
                         break;
                         
-                    case "TracerTong":
-                    case "AlexJacobson":
-                    case "JaimeReyes":                        
+                    case "TracerTong":                      
                         if ( boolFlag == True )
                         {
-                            ScriptedPawn(a).bInWorld=True;
-                            a.bHidden = False;
-                            a.bBlockPlayers = True;
-                            a.BindName = string(a.Tag);  //Re-enables conversations with them.
-                            l("BindName reset to "$a.BindName);
-                            ScriptedPawn(a).ConBindEvents();                        
+                            ScriptedPawn(a).EnterWorld();                    
                         } else {
-                            ScriptedPawn(a).bInWorld=False;
-                            a.bHidden = True;
-                            a.bBlockPlayers = False;
-                            l("BindName was "$a.BindName);
-                            a.BindName = "";  //Disables conversations with them.
+                            ScriptedPawn(a).LeaveWorld();
+                        }
+                        break;
+                    case "AlexJacobson":
+                        recruitedFlag = dxr.Player.flagBase.GetBool('JacobsonRecruited');
+                        if ( boolFlag == True && recruitedFlag == True)
+                        {
+                            ScriptedPawn(a).EnterWorld();                    
+                        } else {
+                            ScriptedPawn(a).LeaveWorld();
+                        }
+                        break;
+                    case "JaimeReyes":
+                        recruitedFlag = dxr.Player.flagBase.GetBool('JaimeRecruited');
+                        if ( boolFlag == True && recruitedFlag == True)
+                        {
+                            ScriptedPawn(a).EnterWorld();                    
+                        } else {
+                            ScriptedPawn(a).LeaveWorld();
                         }
                         break;
                     case "Operation1":
-                        DataLinkTrigger(a).checkFlag = flagName;
+                        DataLinkTrigger(a).checkFlag = 'QuickLetPlayerIn';
                         break;
                     case "TurnOnTheKillSwitch":
                         if (boolFlag == True)

--- a/DeusEx/Classes/DXRFixup.uc
+++ b/DeusEx/Classes/DXRFixup.uc
@@ -1,0 +1,154 @@
+class DXRFixup expands DXRBase;
+
+function FirstEntry()
+{
+    local Actor a;
+    local ScriptedPawn p;
+
+    Super.FirstEntry();
+    
+    switch(dxr.localURL)
+    {
+        case "06_HONGKONG_TONGBASE":
+            foreach AllActors(class'Actor', a)
+            {
+                switch(string(a.Tag))
+                {
+                    case "AlexGone":
+                    case "TracerGone":
+                    case "JaimeGone":
+                        a.Destroy();
+                        break;
+                    case "Breakintocompound":
+                    case "LumpathPissed":
+                        Trigger(a).bTriggerOnceOnly = False;
+                        break;
+                    default:
+                        break;
+                }
+            }    
+            break;
+        case "06_HONGKONG_WANCHAI_MARKET":
+            foreach AllActors(class'Actor', a)
+            {
+                switch(string(a.Tag))
+                {
+                    case "DummyKeypad01":
+                        a.Destroy();
+                        break;
+                    case "BasementKeypad":
+                    case "GateKeypad":
+                        a.bHidden=False;
+                        break;    
+                    case "Breakintocompound":
+                    case "LumpathPissed":
+                        Trigger(a).bTriggerOnceOnly = False;
+                        break;
+                    default:
+                        break;
+                }
+            }
+            
+            break;
+        default:
+            break;
+    }
+}
+
+function AnyEntry()
+{
+    Super.AnyEntry();
+    
+    doFixup();
+    
+}
+
+function ReEntry()
+{
+    Super.ReEntry();
+    doFixup();
+}
+
+function doFixup()
+{
+    local Actor a;
+    local ScriptedPawn p;
+    local name flagName;
+    local bool boolFlag;
+    
+    switch(dxr.localURL)
+    {
+        case "06_HONGKONG_TONGBASE":
+            flagName = dxr.Player.rootWindow.StringToName("QuickLetPlayerIn");
+            boolFlag = dxr.Player.flagBase.GetBool(flagName);
+            foreach AllActors(class'Actor', a)
+            {
+                switch(string(a.Tag))
+                {
+                    case "TriadLumPath":
+                        ScriptedPawn(a).ChangeAlly(dxr.Player.Alliance,1,False);
+                        break;
+                        
+                    case "TracerTong":
+                    case "AlexJacobson":
+                    case "JaimeReyes":                        
+                        if ( boolFlag == True )
+                        {
+                            ScriptedPawn(a).bInWorld=True;
+                            a.bHidden = False;
+                            a.bBlockPlayers = True;
+                            a.BindName = string(a.Tag);  //Re-enables conversations with them.
+                            l("BindName reset to "$a.BindName);
+                            ScriptedPawn(a).ConBindEvents();                        
+                        } else {
+                            ScriptedPawn(a).bInWorld=False;
+                            a.bHidden = True;
+                            a.bBlockPlayers = False;
+                            l("BindName was "$a.BindName);
+                            a.BindName = "";  //Disables conversations with them.
+                        }
+                        break;
+                    case "Operation1":
+                        DataLinkTrigger(a).checkFlag = flagName;
+                        break;
+                    case "TurnOnTheKillSwitch":
+                        if (boolFlag == True)
+                        {
+                            Trigger(a).TriggerType = TT_PlayerProximity;                        
+                        } else {
+                            Trigger(a).TriggerType = TT_ClassProximity;
+                            Trigger(a).ClassProximityType = class'Teleporter';//Impossible, thus disabling it
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }    
+            break;
+        case "06_HONGKONG_WANCHAI_MARKET":
+            foreach AllActors(class'Actor', a)
+            {
+                switch(string(a.Tag))
+                {
+                    case "TriadLumPath":
+                    case "TriadLumPath1":
+                    case "TriadLumPath2":
+                    case "TriadLumPath3":
+                    case "TriadLumPath4":
+                    case "TriadLumPath5":
+                    case "GordonQuick":
+                    
+                        ScriptedPawn(a).ChangeAlly(dxr.Player.Alliance,1,False);
+                        break;
+                }
+            }
+
+            break;
+        default:
+            break;
+    }
+}
+
+defaultproperties
+{
+}

--- a/DeusEx/Classes/DXRando.uc
+++ b/DeusEx/Classes/DXRando.uc
@@ -103,6 +103,7 @@ function LoadModules()
     LoadModule(class'DXRAugmentations');
     LoadModule(class'DXRSwapItems');
     LoadModule(class'DXRReduceItems');
+    LoadModule(class'DXRFixup');
 
     RunTests();
 }


### PR DESCRIPTION
I've added a new module which is intended for hardcoded fixes to issues present in the base game that get exacerbated by the randomizer.

Current issues addressed:
1) Keypad at Luminous Path compound gate and by the painting in the basement are now always the real keypad rather than a dummy one sometimes

2) In both the outside Luminous Path compound and in Tong's Lab, the triad members will attack you if you break in without Gordon Quick's permission.  In the base game, they are permanently hostile to you after that.  The fixup module now makes them friendly again if you leave the map and come back, as well as allowing them to become hostile again if you still didn't get permission from Gordon (Thus roughly maintaining the same behaviour while not entirely softlocking you)

3) Tracer Tong, Alex Jacobson, and Jaime Reyes are no longer permanently despawned if you enter Tong's Lab without having gotten permission to enter from Gordon Quick.  Instead, they are hidden and you can't talk to them while you don't have permission (In case you were to kill all the triad members while trying to force your way in).  Once Gordon says you can go in, they should appear as they normally would and talk to you as expected.  This bit is still a bit kludgy, as your crosshairs still go green when you point at where they should be (While they're hidden), and it seems you can sometimes still hear them walking around.  There may be further tweaking that can be done on this front to improve how it works, but for now it stops progression until you have permission to be there, and maintains the same behaviour as before (roughly)

This fixes issue #17 