### PR TITLE
v1.4.9  added DXRMissions for moving goals and starting locations

### DIFF
--- a/DeusEx/Classes/DXRActorsBase.uc
+++ b/DeusEx/Classes/DXRActorsBase.uc
@@ -28,6 +28,7 @@ function CheckConfig()
 
 function SwapAll(name classname)
 {
+    local Actor temp[4096];
     local Actor a, b;
     local int num, i, slot;
 
@@ -36,26 +37,13 @@ function SwapAll(name classname)
     foreach AllActors(class'Actor', a )
     {
         if( SkipActor(a, classname) ) continue;
-        num++;
+        temp[num++] = a;
     }
 
-    foreach AllActors(class'Actor', a )
-    {
-        if( SkipActor(a, classname) ) continue;
-
-        i=0;
+    for(i=0; i<num; i++) {
         slot=rng(num-1);// -1 because we skip ourself
-        foreach AllActors(class'Actor', b )
-        {
-            if( a == b ) continue;
-            if( SkipActor(b, classname) ) continue;
-
-            if(i==slot) {
-                Swap(a, b);
-                break;
-            }
-            i++;
-        }
+        if(slot >= i) slot++;
+        Swap(temp[i], temp[slot]);
     }
 }
 
@@ -286,6 +274,7 @@ static function SetActorScale(Actor a, float scale)
 
 function vector GetRandomPosition(optional vector target, optional float mindist, optional float maxdist)
 {
+    local PathNode temp[1024];
     local PathNode p;
     local int i, num, slot;
     local float dist;
@@ -297,19 +286,11 @@ function vector GetRandomPosition(optional vector target, optional float mindist
         dist = VSize(p.Location-target);
         if( dist < mindist ) continue;
         if( dist > maxdist ) continue;
-        num++;
+        temp[num++] = p;
     }
+    if( num == 0 ) return target;
     slot = rng(num);
-    foreach AllActors(class'PathNode', p) {
-        dist = VSize(p.Location-target);
-        if( dist < mindist ) continue;
-        if( dist > maxdist ) continue;
-        if(i==slot) {
-            return p.Location;
-        }
-        i++;
-    }
-    return target;
+    return temp[num].Location;
 }
 
 function vector GetCloserPosition(vector target, vector current, optional float maxdist)

--- a/DeusEx/Classes/DXRActorsBase.uc
+++ b/DeusEx/Classes/DXRActorsBase.uc
@@ -47,7 +47,7 @@ function SwapAll(name classname)
     }
 }
 
-function vector AbsEach(vector v)
+static function vector AbsEach(vector v)
 {// not a real thing in math? but it's convenient
     v.X = abs(v.X);
     v.Y = abs(v.Y);
@@ -55,7 +55,7 @@ function vector AbsEach(vector v)
     return v;
 }
 
-function bool AnyGreater(vector a, vector b)
+static function bool AnyGreater(vector a, vector b)
 {
     return a.X > b.X || a.Y > b.Y || a.Z > b.Z;
 }
@@ -67,18 +67,18 @@ function bool CarriedItem(Actor a)
     return a.Owner != None && a.Owner.IsA('Pawn');
 }
 
-function bool IsHuman(Actor a)
+static function bool IsHuman(Actor a)
 {
     return HumanMilitary(a) != None || HumanThug(a) != None || HumanCivilian(a) != None;
 }
 
-function bool IsCritter(Actor a)
+static function bool IsCritter(Actor a)
 {
     if( Animal(a) == None ) return false;
     return Doberman(a) == None && Gray(a) == None && Greasel(a) == None && Karkian(a) == None;
 }
 
-function bool HasItem(Pawn p, class c)
+static function bool HasItem(Pawn p, class c)
 {
     local ScriptedPawn sp;
     local int i;
@@ -96,7 +96,7 @@ function bool HasItem(Pawn p, class c)
     return p.FindInventoryType(c) != None;
 }
 
-function bool HasMeleeWeapon(Pawn p)
+static function bool HasMeleeWeapon(Pawn p)
 {
     return HasItem(p, class'WeaponBaton')
         || HasItem(p, class'WeaponCombatKnife')
@@ -105,7 +105,7 @@ function bool HasMeleeWeapon(Pawn p)
         || HasItem(p, class'WeaponNanoSword');
 }
 
-function bool IsMeleeWeapon(Inventory item)
+static function bool IsMeleeWeapon(Inventory item)
 {
     return item.IsA('WeaponBaton')
         || item.IsA('WeaponCombatKnife')

--- a/DeusEx/Classes/DXRActorsBase.uc
+++ b/DeusEx/Classes/DXRActorsBase.uc
@@ -290,7 +290,7 @@ function vector GetRandomPosition(optional vector target, optional float mindist
     }
     if( num == 0 ) return target;
     slot = rng(num);
-    return temp[num].Location;
+    return temp[slot].Location;
 }
 
 function vector GetCloserPosition(vector target, vector current, optional float maxdist)

--- a/DeusEx/Classes/DXRActorsBase.uc
+++ b/DeusEx/Classes/DXRActorsBase.uc
@@ -309,6 +309,7 @@ function vector GetRandomPosition(optional vector target, optional float mindist
         }
         i++;
     }
+    return target;
 }
 
 function vector GetCloserPosition(vector target, vector current, optional float maxdist)

--- a/DeusEx/Classes/DXRActorsBase.uc
+++ b/DeusEx/Classes/DXRActorsBase.uc
@@ -44,9 +44,10 @@ function SwapAll(name classname)
         if( SkipActor(a, classname) ) continue;
 
         i=0;
-        slot=rng(num-1);
+        slot=rng(num-1);// -1 because we skip ourself
         foreach AllActors(class'Actor', b )
         {
+            if( a == b ) continue;
             if( SkipActor(b, classname) ) continue;
 
             if(i==slot) {

--- a/DeusEx/Classes/DXRAugmentations.uc
+++ b/DeusEx/Classes/DXRAugmentations.uc
@@ -86,10 +86,12 @@ function static Name PickRandomAug(DXRando dxr)
 
 function RandoAug(Augmentation a)
 {
+    local int oldseed;
     local string s;
     if( AugSpeed(a) != None || AugLight(a) != None ) return;
-    dxr.SetSeed( dxr.Crc(dxr.seed $ "RandoAug " $ a.class.name ) );
+    oldseed = dxr.SetSeed( dxr.Crc(dxr.seed $ "RandoAug " $ a.class.name ) );
     s = RandoLevelValues(a.LevelValues, a.default.LevelValues, min_aug_str, max_aug_str);
     if( InStr(a.Description, s) == -1 )
         a.Description = a.Description $ "|n|n" $ s;
+    dxr.SetSeed(oldseed);
 }

--- a/DeusEx/Classes/DXRBannedItems.uc
+++ b/DeusEx/Classes/DXRBannedItems.uc
@@ -1,5 +1,5 @@
 class DXRBannedItems extends DXRBase;
-
+//maybe this stuff should be globalconfig so it could be statically requested?
 var config string stick_with_the_prod_player_message;
 var config string stick_with_the_prod_bans[10];
 var config string stick_with_the_prod_allows[10];

--- a/DeusEx/Classes/DXRBannedItems.uc
+++ b/DeusEx/Classes/DXRBannedItems.uc
@@ -111,3 +111,37 @@ function bool ban(DeusExPlayer player, Inventory item)
         }
     }
 }
+
+function AddStartingEquipment(Pawn p)
+{
+    local class<DeusExWeapon> wclass;
+    local Ammo a;
+    local DeusExWeapon w;
+    local int i;
+
+    if( dxr.flags.banneditems == 1 || dxr.flags.banneditems == 2 ) {
+        wclass = class'WeaponProd';
+        if( class'DXRActorsBase'.static.HasItem(p, wclass) )
+            return;
+
+        w = p.Spawn(wclass, p);
+        w.GiveTo(p);
+        w.SetBase(p);
+
+        if( w.AmmoName != None ) {
+            a = p.spawn(w.AmmoName);
+            w.AmmoType = a;
+            w.AmmoType.InitialState='Idle2';
+            w.AmmoType.GiveTo(p);
+            w.AmmoType.SetBase(p);
+        }
+
+        for(i=0; i < ArrayCount(w.AmmoNames); i++) {
+            if(rng(3) == 0 && w.AmmoNames[i] != None) {
+                a = p.spawn(w.AmmoNames[i]);
+                a.GiveTo(p);
+                a.SetBase(p);
+            }
+        }
+    }
+}

--- a/DeusEx/Classes/DXRBase.uc
+++ b/DeusEx/Classes/DXRBase.uc
@@ -6,7 +6,7 @@ var config int config_version;
 
 function Init(DXRando tdxr)
 {
-    l(".Init() " $ tdxr.localURL);
+    l(Self$".Init()");
     dxr = tdxr;
     CheckConfig();
 }
@@ -22,22 +22,22 @@ function CheckConfig()
 
 function FirstEntry()
 {
-    l(".FirstEntry() " $ dxr.localURL);
+    l(Self$".FirstEntry()");
 }
 
 function AnyEntry()
 {
-    l(".AnyEntry() " $ dxr.localURL);
+    l(Self$".AnyEntry()");
 }
 
 function ReEntry()
 {
-    l(".ReEntry() " $ dxr.localURL);
+    l(Self$".ReEntry()");
 }
 
 function PreTravel()
 {
-    l(".PreTravel() " $ dxr.localURL);
+    l(Self$".PreTravel()");
     dxr = None;
     SetTimer(0, False);
 }
@@ -48,14 +48,14 @@ function Timer()
 
 event Destroyed()
 {
-    l(".Destroyed() " $ dxr.localURL);
+    l(Self$".Destroyed()");
     dxr = None;
     Super.Destroyed();
 }
 
-function SetSeed(coerce string name)
+function int SetSeed(coerce string name)
 {
-    dxr.SetSeed( dxr.Crc(dxr.seed $ "MS_" $ dxr.dxInfo.MissionNumber $ dxr.localURL $ name) );
+    return dxr.SetSeed( dxr.Crc(dxr.seed $ "MS_" $ dxr.dxInfo.MissionNumber $ dxr.localURL $ name) );
 }
 
 function int rng(int max)
@@ -65,7 +65,10 @@ function int rng(int max)
 
 function float rngf()
 {// 0 to 1.0
-    return float(dxr.rng(1000001))/1000000.0;
+    local float f;
+    f = float(dxr.rng(100001))/100000.0;
+    //l("rngf() "$f);
+    return f;
 }
 
 function float rngfn()

--- a/DeusEx/Classes/DXRBase.uc
+++ b/DeusEx/Classes/DXRBase.uc
@@ -6,7 +6,7 @@ var config int config_version;
 
 function Init(DXRando tdxr)
 {
-    l(".Init()");
+    l(".Init() " $ tdxr.localURL);
     dxr = tdxr;
     CheckConfig();
 }
@@ -22,22 +22,22 @@ function CheckConfig()
 
 function FirstEntry()
 {
-    l(".FirstEntry()");
+    l(".FirstEntry() " $ dxr.localURL);
 }
 
 function AnyEntry()
 {
-    l(".AnyEntry()");
+    l(".AnyEntry() " $ dxr.localURL);
 }
 
 function ReEntry()
 {
-    l(".ReEntry()");
+    l(".ReEntry() " $ dxr.localURL);
 }
 
 function PreTravel()
 {
-    l(".PreTravel()");
+    l(".PreTravel() " $ dxr.localURL);
     dxr = None;
     SetTimer(0, False);
 }
@@ -48,7 +48,7 @@ function Timer()
 
 event Destroyed()
 {
-    l(".Destroyed()");
+    l(".Destroyed() " $ dxr.localURL);
     dxr = None;
     Super.Destroyed();
 }
@@ -162,7 +162,7 @@ function err(string message)
 
 function int RunTests()
 {
-    l(".RunTests()");
+    l(".RunTests() " $ dxr.localURL);
     return 0;
 }
 

--- a/DeusEx/Classes/DXRBase.uc
+++ b/DeusEx/Classes/DXRBase.uc
@@ -96,7 +96,9 @@ function string RandoLevelValues(out float LevelValues[4], float DefaultLevelVal
         else if( i>0 && DefaultLevelValues[i-1] > DefaultLevelValues[i] && LevelValues[i] > min_val ) LevelValues[i] = min_val;
         min_val = LevelValues[i];
         if( i>0 ) s = s $ ", ";
-        s = s $ int(LevelValues[i]/DefaultLevelValues[i]*100.0) $ "%";
+
+        if( LevelValues[i] == DefaultLevelValues[i] ) s = s $ "100%";
+        else s = s $ int(LevelValues[i]/DefaultLevelValues[i]*100.0) $ "%";
     }
     s = s $ ")";
     return s;

--- a/DeusEx/Classes/DXREnemies.uc
+++ b/DeusEx/Classes/DXREnemies.uc
@@ -148,30 +148,46 @@ function RandoMedBotsRepairBots(int medbots, int repairbots)
 {
     local RepairBot r;
     local MedicalBot m;
+    local Datacube d;
 
     if( medbots > -1 ) {
         foreach AllActors(class'MedicalBot', m) {
             m.Destroy();
+        }
+        foreach AllActors(class'Datacube', d) {
+            if( d.textTag == '01_Datacube09' ) d.Destroy();
         }
     }
     if( repairbots > -1 ) {
         foreach AllActors(class'RepairBot', r) {
             r.Destroy();
         }
+        foreach AllActors(class'Datacube', d) {
+            if( d.textTag == '03_Datacube11' ) d.Destroy();
+        }
     }
 
+    SetSeed( "RandoMedBots" );
     if( chance_single(medbots) ) {
-        SpawnNewPawn(class'MedicalBot');
+        m = MedicalBot(SpawnNewActor(class'MedicalBot'));
+        d = Datacube(SpawnNewActor(class'Datacube', m.Location, 16*50, 16*200));//minimum 50 feet away, maximum 200 feet away
+        d.textTag = '01_Datacube09';
+        d.bAddToVault = false;
     }
+
+    SetSeed( "RandoRepairBots" );
     if( chance_single(repairbots) ) {
-        SpawnNewPawn(class'RepairBot');
+        r = RepairBot(SpawnNewActor(class'RepairBot'));
+        d = Datacube(SpawnNewActor(class'Datacube', m.Location, 16*50, 16*200));
+        d.textTag = '03_Datacube11';
+        d.bAddToVault = false;
     }
 }
 
-function Pawn SpawnNewPawn(class<Pawn> c)
+function Actor SpawnNewActor(class<Actor> c, optional vector target, optional float mindist, optional float maxdist)
 {
     local vector loc;
-    loc = GetRandomPosition();
+    loc = GetRandomPosition(target, mindist, maxdist);
     loc.X += rngfn() * 50;
     loc.Y += rngfn() * 50;
     return Spawn(c,,, loc );

--- a/DeusEx/Classes/DXREnemies.uc
+++ b/DeusEx/Classes/DXREnemies.uc
@@ -165,7 +165,12 @@ function SwapScriptedPawns()
         if( IsCritter(a) ) continue;
 
         i=0;
-        slot=rng(num-1);// -1 because we skip ourself
+        slot=rng(num);// -1 because we skip ourself, but +1 for vanilla
+        if(slot==0) {
+            l("not swapping "$a);
+            continue;
+        }
+        slot--;
         foreach AllActors(class'ScriptedPawn', b )
         {
             if( a == b ) continue;

--- a/DeusEx/Classes/DXREnemies.uc
+++ b/DeusEx/Classes/DXREnemies.uc
@@ -139,8 +139,42 @@ function AddRandomEnemyType(string t, int c)
 function FirstEntry()
 {
     Super.FirstEntry();
+    RandoMedBotsRepairBots(dxr.flags.medbots, dxr.flags.repairbots);
     RandoEnemies(dxr.flags.enemiesrandomized);
     //SwapScriptedPawns();
+}
+
+function RandoMedBotsRepairBots(int medbots, int repairbots)
+{
+    local RepairBot r;
+    local MedicalBot m;
+
+    if( medbots > -1 ) {
+        foreach AllActors(class'MedicalBot', m) {
+            m.Destroy();
+        }
+    }
+    if( repairbots > -1 ) {
+        foreach AllActors(class'RepairBot', r) {
+            r.Destroy();
+        }
+    }
+
+    if( chance_single(medbots) ) {
+        SpawnNewPawn(class'MedicalBot');
+    }
+    if( chance_single(repairbots) ) {
+        SpawnNewPawn(class'RepairBot');
+    }
+}
+
+function Pawn SpawnNewPawn(class<Pawn> c)
+{
+    local vector loc;
+    loc = GetRandomPosition();
+    loc.X += rngfn() * 50;
+    loc.Y += rngfn() * 50;
+    return Spawn(c,,, loc );
 }
 
 function SwapScriptedPawns()

--- a/DeusEx/Classes/DXREnemies.uc
+++ b/DeusEx/Classes/DXREnemies.uc
@@ -165,9 +165,10 @@ function SwapScriptedPawns()
         if( IsCritter(a) ) continue;
 
         i=0;
-        slot=rng(num-1);
+        slot=rng(num-1);// -1 because we skip ourself
         foreach AllActors(class'ScriptedPawn', b )
         {
+            if( a == b ) continue;
             if( b.bHidden || b.bStatic ) continue;
             if( b.bImportant ) continue;
             if( IsCritter(b) ) continue;

--- a/DeusEx/Classes/DXREnemies.uc
+++ b/DeusEx/Classes/DXREnemies.uc
@@ -428,12 +428,12 @@ function int RunTests()
     for(i=0; i < ArrayCount(randomweapons); i++ ) {
         total += randomweapons[i].chance;
     }
-    results += test( total <= 100, "config randomweapons chances, check total "$total);
+    results += testint( total, 100, "config randomweapons chances, check total "$total);
     total=0;
     for(i=0; i < ArrayCount(randommelees); i++ ) {
         total += randommelees[i].chance;
     }
-    results += test( total <= 100, "config randommelees chances, check total "$total);
+    results += testint( total, 100, "config randommelees chances, check total "$total);
 
     return results;
 }

--- a/DeusEx/Classes/DXRFixup.uc
+++ b/DeusEx/Classes/DXRFixup.uc
@@ -128,8 +128,10 @@ function AnyEntry()
 
 function Timer()
 {
+    local PaulDenton paul;
     local BlackHelicopter chopper;
     local Music m;
+    local int i;
     Super.Timer();
 
     switch(dxr.dxInfo.missionNumber) {
@@ -147,6 +149,23 @@ function Timer()
 
     switch(dxr.localURL)
     {
+        case "04_NYC_HOTEL":
+            if( dxr.player.flagBase.GetBool('M04RaidBegan') ) {
+                foreach AllActors(class'PaulDenton', paul) {
+                    paul.bInvincible = false;
+                    i = 400;
+                    paul.Health = i;
+                    paul.HealthArmLeft = i;
+                    paul.HealthArmRight = i;
+                    paul.HealthHead = i;
+                    paul.HealthLegLeft = i;
+                    paul.HealthLegRight = i;
+                    paul.HealthTorso = i;
+                    paul.ChangeAlly('Player', 1, true);
+                }
+                SetTimer(0, false);
+            }
+            break;
         case "08_NYC_STREET":
             if ( dxr.Player.flagBase.GetBool('StantonDowd_Played') )
             {
@@ -303,6 +322,7 @@ function NYC_04_AnyEntry()
     switch (dxr.localURL)
     {
         case "04_NYC_HOTEL":
+            SetTimer(1.0, True);
             if(dxr.Player.flagBase.GetBool('NSFSignalSent')) {
                 dxr.Player.flagBase.SetBool('PaulInjured_Played', true,, 5);
             }

--- a/DeusEx/Classes/DXRFixup.uc
+++ b/DeusEx/Classes/DXRFixup.uc
@@ -225,6 +225,14 @@ function Airfield_FirstEntry()
     
     switch (dxr.localURL)
     {
+        case "03_NYC_BATTERYPARK":
+            foreach AllActors(class'Actor', a) {
+                if( a.name == 'NanoKey0' ) {
+                    a.Destroy();
+                    break;
+                }
+            }
+            break;
         case "03_NYC_AirfieldHeliBase":
             foreach AllActors(class'Mover',m) {
                 // call the elevator at the end of the level when you open the appropriate door

--- a/DeusEx/Classes/DXRFixup.uc
+++ b/DeusEx/Classes/DXRFixup.uc
@@ -86,6 +86,8 @@ function FirstEntry()
         case 3:
             Airfield_FirstEntry();
             break;
+        case 5:
+            Jailbreak_FirstEntry();
         case 6:
             HongKong_FirstEntry();
             break;
@@ -278,6 +280,20 @@ function Airfield_FirstEntry()
                 if( m.Name == 'DeusExMover65' ) m.Tag = 'BathroomDoor';
             }
             AddSwitch( vect(3745, -2593.711914, 140.335358), rot(0, 0, 0), 'BathroomDoor' );
+            break;
+    }
+}
+
+function Jailbreak_FirstEntry()
+{
+    local PaulDenton p;
+
+    switch (dxr.localURL)
+    {
+        case "05_NYC_UNATCOMJ12LAB":
+            foreach AllActors(class'PaulDenton', p) {
+                p.RaiseAlarm = RAISEALARM_Never;// https://www.twitch.tv/die4ever2011/clip/ReliablePerfectMarjoramDxAbomb
+            }
             break;
     }
 }

--- a/DeusEx/Classes/DXRFixup.uc
+++ b/DeusEx/Classes/DXRFixup.uc
@@ -258,12 +258,12 @@ function Airfield_FirstEntry()
             a = _AddActor(Self, class'DynamicBlockPlayer', vect(-3105,-385,-210), rot(0,0,0));
             SetActorScale(a, 1.3);
 
-            _AddActor(Self, class'Valve', vect(-3080,-395,-173), rot(0,0,16384));
-            a = _AddActor(Self, class'DynamicBlockPlayer', vect(-3080,-395,-173), rot(0,0,0));
+            _AddActor(Self, class'Valve', vect(-3080,-395,-170), rot(0,0,16384));
+            a = _AddActor(Self, class'DynamicBlockPlayer', vect(-3080,-395,-170), rot(0,0,0));
             SetActorScale(a, 1.3);
 
-            _AddActor(Self, class'Valve', vect(-3065,-405,-137), rot(0,0,16384));
-            a = _AddActor(Self, class'DynamicBlockPlayer', vect(-3065,-405,-137), rot(0,0,0));
+            _AddActor(Self, class'Valve', vect(-3065,-405,-130), rot(0,0,16384));
+            a = _AddActor(Self, class'DynamicBlockPlayer', vect(-3065,-405,-130), rot(0,0,0));
             SetActorScale(a, 1.3);
 
             //crates to get back over the beginning of the level

--- a/DeusEx/Classes/DXRFlags.uc
+++ b/DeusEx/Classes/DXRFlags.uc
@@ -88,7 +88,7 @@ function InitDefaults()
     removeinvisiblewalls = 0;
     enemiesrandomized = 25;
     enemyrespawn = 0;
-    infodevices = 0;
+    infodevices = 100;
     dancingpercent = 25;
     skills_disable_downgrades = 0;
     skills_reroll_missions = 0;

--- a/DeusEx/Classes/DXRFlags.uc
+++ b/DeusEx/Classes/DXRFlags.uc
@@ -259,7 +259,7 @@ static function int VersionNumber()
 
 static function string VersionString()
 {
-    return VersionToString(1, 4, 8) $ "";
+    return VersionToString(1, 4, 9) $ " Alpha";
 }
 
 function MaxRando()
@@ -278,8 +278,11 @@ function int RunTests()
     results += testint( dxr.Crc("do you have a single fact to back that up"), -1473827402, "Crc32 test");
 
     SetSeed("smashthestate");
-    for(i=0;i<10;i++)
-        test( rng(100)>=0, "rng(100) >= 0");
+    results += testint( rng(1), 0, "rng(1) is 0");
+    for(i=0;i<10;i++) {
+        results += test( rng(100)>=0, "rng(100) >= 0");
+        results += test( rng(100)<100, "rng(100) < 100");
+    }
 
     return results;
 }

--- a/DeusEx/Classes/DXRFlags.uc
+++ b/DeusEx/Classes/DXRFlags.uc
@@ -280,7 +280,7 @@ static function int VersionNumber()
 
 static function string VersionString()
 {
-    return VersionToString(1, 4, 9) $ " Beta";
+    return VersionToString(1, 4, 9) $ "";
 }
 
 function MaxRando()

--- a/DeusEx/Classes/DXRFlags.uc
+++ b/DeusEx/Classes/DXRFlags.uc
@@ -15,6 +15,7 @@ var int removeinvisiblewalls, enemiesrandomized, enemyrespawn, infodevices;
 var int dancingpercent;
 var int skills_disable_downgrades, skills_reroll_missions, skills_independent_levels;
 var int startinglocations, goals, equipment;//equipment is a multiplier on how many items you get?
+var int medbots, repairbots;//there are 90 levels in the game, so 10% means approximately 9 medbots and 9 repairbots for the whole game, I think the vanilla game has 12 medbots, but they're also placed in smart locations so we might want to give more than that for Normal difficulty
 
 var int undefeatabledoors, alldoors, keyonlydoors, highlightabledoors, doormutuallyinclusive, doorindependent, doormutuallyexclusive;
 
@@ -97,6 +98,8 @@ function InitDefaults()
     startinglocations = 100;
     goals = 100;
     equipment = 1;
+    medbots = 15;
+    repairbots = 15;
 }
 
 function CheckConfig()
@@ -163,6 +166,8 @@ function LoadFlags()
         startinglocations = f.GetInt('Rando_startinglocations');
         goals = f.GetInt('Rando_goals');
         equipment = f.GetInt('Rando_equipment');
+        medbots = f.GetInt('Rando_medbots');
+        repairbots = f.GetInt('Rando_repairbots');
     }
 
     if(stored_version < flagsversion ) {
@@ -217,6 +222,9 @@ function SaveFlags()
     f.SetInt('Rando_goals', goals,, 999);
     f.SetInt('Rando_equipment', equipment,, 999);
 
+    f.SetInt('Rando_medbots', medbots,, 999);
+    f.SetInt('Rando_repairbots', repairbots,, 999);
+
     LogFlags("SaveFlags");
 }
 
@@ -233,7 +241,7 @@ function string StringifyFlags()
         $ ", speedlevel: "$speedlevel$", keysrando: "$keysrando$", doorsmode: "$doorsmode$", doorspickable: "$doorspickable$", doorsdestructible: "$doorsdestructible
         $ ", deviceshackable: "$deviceshackable$", passwordsrandomized: "$passwordsrandomized$", gibsdropkeys: "$gibsdropkeys
         $ ", autosave: "$autosave$", removeinvisiblewalls: "$removeinvisiblewalls$", enemiesrandomized: "$enemiesrandomized$", enemyrespawn: "$enemyrespawn$", infodevices: "$infodevices
-        $ ", startinglocations: "$startinglocations$", goals: "$goals$", equipment: "$equipment$", dancingpercent: "$dancingpercent;
+        $ ", startinglocations: "$startinglocations$", goals: "$goals$", equipment: "$equipment$", dancingpercent: "$dancingpercent$", medbots: "$medbots$", repairbots: "$repairbots;
 }
 
 function int FlagsHash()

--- a/DeusEx/Classes/DXRFlags.uc
+++ b/DeusEx/Classes/DXRFlags.uc
@@ -269,7 +269,7 @@ function MaxRando()
 
 function int RunTests()
 {
-    local int results, i;
+    local int results, i, t;
     results = Super.RunTests();
 
     //this Crc function returns negative numbers
@@ -280,9 +280,12 @@ function int RunTests()
     SetSeed("smashthestate");
     results += testint( rng(1), 0, "rng(1) is 0");
     for(i=0;i<10;i++) {
-        results += test( rng(100)>=0, "rng(100) >= 0");
-        results += test( rng(100)<100, "rng(100) < 100");
+        t=rng(100);
+        results += test( t >=0 && t < 100, "rng(100) got " $t$" >= 0 and < 100");
     }
+    dxr.SetSeed(-111);
+    i = rng(100);
+    results += test( rng(100) != i, "rng(100) != rng(100)");
 
     return results;
 }

--- a/DeusEx/Classes/DXRFlags.uc
+++ b/DeusEx/Classes/DXRFlags.uc
@@ -14,6 +14,7 @@ var int autosave;//0=off, 1=first time entering level, 2=every loading screen
 var int removeinvisiblewalls, enemiesrandomized, enemyrespawn, infodevices;
 var int dancingpercent;
 var int skills_disable_downgrades, skills_reroll_missions, skills_independent_levels;
+var int startinglocations, goals, equipment;//equipment is a multiplier on how many items you get?
 
 var int undefeatabledoors, alldoors, keyonlydoors, highlightabledoors, doormutuallyinclusive, doorindependent, doormutuallyexclusive;
 
@@ -93,6 +94,9 @@ function InitDefaults()
     skills_disable_downgrades = 0;
     skills_reroll_missions = 0;
     skills_independent_levels = 0;
+    startinglocations = 100;
+    goals = 100;
+    equipment = 1;
 }
 
 function CheckConfig()
@@ -155,6 +159,11 @@ function LoadFlags()
     if( stored_version >= VersionToInt(1,4,7) ) {
         banneditems = f.GetInt('Rando_banneditems');
     }
+    if( stored_version >= VersionToInt(1,4,9) ) {
+        startinglocations = f.GetInt('Rando_startinglocations');
+        goals = f.GetInt('Rando_goals');
+        equipment = f.GetInt('Rando_equipment');
+    }
 
     if(stored_version < flagsversion ) {
         l("upgraded flags from "$stored_version$" to "$flagsversion);
@@ -204,6 +213,10 @@ function SaveFlags()
     f.SetInt('Rando_skills_reroll_missions', skills_reroll_missions,, 999);
     f.SetInt('Rando_skills_independent_levels', skills_independent_levels,, 999);
 
+    f.SetInt('Rando_startinglocations', startinglocations,, 999);
+    f.SetInt('Rando_goals', goals,, 999);
+    f.SetInt('Rando_equipment', equipment,, 999);
+
     LogFlags("SaveFlags");
 }
 
@@ -220,7 +233,7 @@ function string StringifyFlags()
         $ ", speedlevel: "$speedlevel$", keysrando: "$keysrando$", doorsmode: "$doorsmode$", doorspickable: "$doorspickable$", doorsdestructible: "$doorsdestructible
         $ ", deviceshackable: "$deviceshackable$", passwordsrandomized: "$passwordsrandomized$", gibsdropkeys: "$gibsdropkeys
         $ ", autosave: "$autosave$", removeinvisiblewalls: "$removeinvisiblewalls$", enemiesrandomized: "$enemiesrandomized$", enemyrespawn: "$enemyrespawn$", infodevices: "$infodevices
-        $ ", dancingpercent: "$dancingpercent;
+        $ ", startinglocations: "$startinglocations$", goals: "$goals$", equipment: "$equipment$", dancingpercent: "$dancingpercent;
 }
 
 function int FlagsHash()
@@ -254,12 +267,12 @@ static function string VersionToString(int major, int minor, int patch)
 
 static function int VersionNumber()
 {
-    return VersionToInt(1, 4, 8);
+    return VersionToInt(1, 4, 9);
 }
 
 static function string VersionString()
 {
-    return VersionToString(1, 4, 9) $ " Alpha";
+    return VersionToString(1, 4, 9) $ " Beta";
 }
 
 function MaxRando()

--- a/DeusEx/Classes/DXRKeys.uc
+++ b/DeusEx/Classes/DXRKeys.uc
@@ -301,6 +301,7 @@ function MoveNanoKeys4()
         num=0;
         foreach AllActors(class'Inventory', a)
         {
+            if( a == k ) continue;
             if( SkipActor(a, 'Inventory') ) continue;
             if( KeyPositionGood(k, a.Location) == False ) continue;
             num++;
@@ -312,7 +313,12 @@ function MoveNanoKeys4()
             num++;
         }*/
 
-        slot=rng(num-1);// -1 because we skip ourself
+        slot=rng(num+1);// +1 for vanilla
+        if(slot==0) {
+            l("not swapping key "$k.KeyID);
+            continue;
+        }
+        slot--;
         i=0;
         l("key "$k.KeyID$" got num "$num);
         foreach AllActors(class'Inventory', a)
@@ -322,7 +328,7 @@ function MoveNanoKeys4()
             if( KeyPositionGood(k, a.Location) == False ) continue;
 
             if(i==slot) {
-                l("swapping key "$k.KeyID$" with "$a.Class);
+                l("swapping key "$k.KeyID$" with "$a);
                 Swap(k, a);
                 break;
             }

--- a/DeusEx/Classes/DXRKeys.uc
+++ b/DeusEx/Classes/DXRKeys.uc
@@ -264,10 +264,11 @@ function MoveNanoKeys()
             if ( AnyGreater( distkey, distdoor ) ) continue;
             num++;
         }
-        slot=rng(num-1);
+        slot=rng(num-1);// -1 because we skip ourself
         i=0;
         foreach AllActors(class'Inventory', a)
         {
+            if( a == k ) continue;
             if( SkipActor(a, 'Inventory') ) continue;
             distkey = AbsEach(a.Location - k.Location);
             distdoor = AbsEach(a.Location - doorloc);
@@ -311,11 +312,12 @@ function MoveNanoKeys4()
             num++;
         }*/
 
-        slot=rng(num-1);
+        slot=rng(num-1);// -1 because we skip ourself
         i=0;
         l("key "$k.KeyID$" got num "$num);
         foreach AllActors(class'Inventory', a)
         {
+            if( a == k ) continue;
             if( SkipActor(a, 'Inventory') ) continue;
             if( KeyPositionGood(k, a.Location) == False ) continue;
 

--- a/DeusEx/Classes/DXRMemes.uc
+++ b/DeusEx/Classes/DXRMemes.uc
@@ -174,13 +174,13 @@ function RandomizeIntro()
     }
     dxr.Player.bHidden = true;
     SwapAll('Actor');
-    dxr.Player.bHidden = false;
     foreach AllActors(class'Actor', a)
     {
         if( a.bHidden ) continue;
         SetActorScale(a, float(rng(1500))/1000 + 0.3);
         a.Fatness = rng(50) + 105;
     }
+    dxr.Player.bHidden = false;
 
     foreach AllActors(class'Tree', t)
     {
@@ -380,7 +380,7 @@ function string _GetRandomActorClass()
     if ( r == i++ ) return "DXLogo";
     if ( r == i++ ) return "DXText";
     if ( r == i++ ) return "Earth";
-    if ( r == i++ ) return "EidosLogo";
+    //if ( r == i++ ) return "EidosLogo";//Warning: SpawnActor failed because class EidosLogo has bStatic or bNoDelete
     if ( r == i++ ) return "EMPGrenade";
     if ( r == i++ ) return "Fan1";
     if ( r == i++ ) return "Fan1Vertical";

--- a/DeusEx/Classes/DXRMemes.uc
+++ b/DeusEx/Classes/DXRMemes.uc
@@ -230,7 +230,7 @@ function string _GetRandomActorClass()
 {
     local int r, i;
 
-    r = rng(501);
+    r = rng(500);
 
     if ( r == i++ ) return "AcousticSensor";
     if ( r == i++ ) return "AdaptiveArmor";
@@ -398,7 +398,7 @@ function string _GetRandomActorClass()
     //if ( r == i++ ) return "FirePlug";
     if ( r == i++ ) return "Fish";
     if ( r == i++ ) return "Fish2";
-    if ( r == i++ ) return "Fishes";
+    //if ( r == i++ ) return "Fishes";//Warning: SpawnActor failed because class Fishes is abstract
     if ( r == i++ ) return "FlagPole";
     if ( r == i++ ) return "Flare";
     if ( r == i++ ) return "Flask";

--- a/DeusEx/Classes/DXRMemes.uc
+++ b/DeusEx/Classes/DXRMemes.uc
@@ -230,7 +230,7 @@ function string _GetRandomActorClass()
 {
     local int r, i;
 
-    r = rng(500);
+    r = rng(499);
 
     if ( r == i++ ) return "AcousticSensor";
     if ( r == i++ ) return "AdaptiveArmor";

--- a/DeusEx/Classes/DXRMenuScreenNewGame.uc
+++ b/DeusEx/Classes/DXRMenuScreenNewGame.uc
@@ -60,15 +60,12 @@ function CopySkills()
     Super.CopySkills();
 
     for(i=1; i<ArrayCount(localSkills); i++) {
+        if( localSkills[i-1] == None ) break;
         localSkills[i-1].next = localSkills[i];
     }
 
-    if(dxr!=None) {
-        //dxrs = dxr.Spawn(class'DXRSkills', None);
-        //dxr.modules[dxr.num_modules] = dxrs;
-        //dxr.num_modules++;
+    if(dxr!=None)
         dxrs = DXRSkills(dxr.FindModule(class'DXRSkills'));
-    }
     if( dxrs != None )
         dxrs.RandoSkills(localSkills[0]);
 }

--- a/DeusEx/Classes/DXRMenuSetupRando.uc
+++ b/DeusEx/Classes/DXRMenuSetupRando.uc
@@ -164,6 +164,12 @@ function BindControls(bool writing, optional string action)
     f.goals = UnpackInt(locations_option);
     id++;
 
+    labels[id] = "Medbots and Repair bots";
+    helptexts[id] = "Percentage chance for a medbot or repair bot to spawn in a map (vanilla is about 14%)";
+    Slider(id, f.medbots, 0, 100, writing);
+    f.repairbots = f.medbots;
+    id++;
+
     if( action == "NEXT" ) InvokeNewGameScreen(combatDifficulty, InitDxr());
 }
 

--- a/DeusEx/Classes/DXRMenuSetupRando.uc
+++ b/DeusEx/Classes/DXRMenuSetupRando.uc
@@ -10,7 +10,7 @@ event InitWindow()
 function BindControls(bool writing, optional string action)
 {
     local DXRFlags f;
-    local string doors_option, skills_option;
+    local string doors_option, skills_option, locations_option;
     local int iDifficulty;
     Super.BindControls(writing, action);
     f = InitFlags();
@@ -146,6 +146,23 @@ function BindControls(bool writing, optional string action)
     labels[id] = "Dancing %";
     helptexts[id] = "How many characters should be dancing.";
     Slider(id, f.dancingpercent, 0, 100, writing);
+    id++;
+
+    labels[id] = "Starting Equipment";
+    helptexts[id] = "How many random items you start with";
+    Slider(id, f.equipment, 0, 10, writing);
+    id++;
+
+    labels[id] = "";
+    locations_option = f.startinglocations $";"$ f.goals;
+    helptexts[id] = "Randomize goal locations, starting locations, or both";
+    EnumOptionString(id, "Randomize Goal and Starting Locations", "100;100", writing, locations_option);
+    EnumOptionString(id, "Randomize Starting Locations", "100;0", writing, locations_option);
+    EnumOptionString(id, "Randomize Goal Locations", "0;100", writing, locations_option);
+    EnumOptionString(id, "Unchanged Goal and Starting Locations", "0;0", writing, locations_option);
+    f.startinglocations = UnpackInt(locations_option);
+    f.goals = UnpackInt(locations_option);
+    id++;
 
     if( action == "NEXT" ) InvokeNewGameScreen(combatDifficulty, InitDxr());
 }

--- a/DeusEx/Classes/DXRMenuSetupRando.uc
+++ b/DeusEx/Classes/DXRMenuSetupRando.uc
@@ -113,13 +113,6 @@ function BindControls(bool writing, optional string action)
     combatDifficulty = float(iDifficulty) / 100.0;
     id++;
 
-    labels[id] = "";
-    helptexts[id] = "What items are banned";
-    EnumOption(id, "No items banned", 0, writing, f.banneditems);
-    EnumOption(id, "Stick With the Prod", 1, writing, f.banneditems);
-    EnumOption(id, "Stick With the Prod Plus", 2, writing, f.banneditems);
-    id++;
-
     labels[id] = "Ammo Drops %";
     helptexts[id] = "Make ammo more scarce.";
     Slider(id, f.ammo, 0, 100, writing);

--- a/DeusEx/Classes/DXRMissions.uc
+++ b/DeusEx/Classes/DXRMissions.uc
@@ -1,0 +1,369 @@
+class DXRMissions extends DXRBase;
+
+//list of actors to remove
+//list of starting positions
+//list of goals to move, with a minimum distance from starting postion? and a radius of triggers to pull with it? list of positions they can be placed in?
+
+struct RemoveActor {
+    var string map_name;
+    var name actor_name;
+};
+var config RemoveActor remove_actors[32];
+
+struct ImportantLocation {
+    var string map_name;
+    var vector location;
+    var rotator rotation;
+    var bool is_player_start;
+    var bool is_goal_position;
+};
+var config ImportantLocation important_locations[64];
+
+struct Goal {
+    var string map_name;
+    var name actor_name;
+    var float group_radius;
+    //var bool move_with_previous;//for chaining things together?
+    //var bool is_movable_actor;
+};
+var config Goal goals[50];
+
+var config bool allow_vanilla;
+
+function CheckConfig()
+{
+    local int i;
+    local string map;
+
+    if( config_version < class'DXRFlags'.static.VersionToInt(1,4,8) ) {
+        allow_vanilla = false;
+
+        i=0;
+        remove_actors[i].map_name = "01_NYC_unatcoisland";
+        remove_actors[i].actor_name = 'PaulDenton0';//because he gives you EZ mode weapons
+        i++;
+
+        remove_actors[i].map_name = "01_NYC_unatcoisland";
+        remove_actors[i].actor_name = 'DataLinkTrigger8';//the "don't leave without talking to Paul" datalink
+        i++;
+
+        remove_actors[i].map_name = "02_nyc_batterypark";
+        remove_actors[i].actor_name = 'AnnaNavarre0';//because she chases you down
+        i++;
+
+        for(i=0; i<ArrayCount(goals); i++) {
+            goals[i].map_name = "";
+            goals[i].group_radius = 0;
+        }
+        for(i=0; i<ArrayCount(important_locations); i++) {
+            important_locations[i].is_player_start = false;
+            important_locations[i].is_goal_position = true;
+            important_locations[i].rotation = rot(0,0,0);
+        }
+
+        i=0;
+
+        map="01_nyc_unatcoisland";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'TerroristCommander0';
+        i++;
+
+        map = "02_nyc_batterypark";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'BarrelAmbrosia0';
+        goals[i].group_radius = 160;
+        i++;
+
+        map = "03_nyc_batterypark";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'HarleyFilben0';
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'BumMale4';
+        goals[i].group_radius = 200;//bring BumFemale2 with him?
+        i++;
+
+        /*map = "03_nyc_airfield";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'Terrorist13';//need to make sure to get rid of his patrol orders
+        i++;*/
+
+        goals[i].map_name = "03_NYC_BrooklynBridgeStation";
+        goals[i].actor_name = 'ThugMale13';
+        i++;
+
+        goals[i].map_name = "03_NYC_BrooklynBridgeStation";
+        goals[i].actor_name = 'JunkieMale1';
+        i++;
+
+        goals[i].map_name = "03_NYC_BrooklynBridgeStation";
+        goals[i].actor_name = 'BumMale2';
+        i++;
+
+        goals[i].map_name = "03_NYC_BrooklynBridgeStation";
+        goals[i].actor_name = 'ThugMale3';
+        i++;
+
+        /*goals[i].map_name = "04_NYC_NSFHQ";
+        goals[i].actor_name = 'ComputerPersonal3';
+        goals[i].group_radius = 16;
+        i++;*/
+
+        /*goals[i].map_name = "04_NYC_NSFHQ";
+        goals[i].actor_name = 'ComputerPersonal4';//or maybe keep it behind the door that ComputerPersonal3 opens?
+        goals[i].group_radius = 16;
+        i++;*/
+
+        /*goals[i].map_name = "";
+        goals[i].actor_name = '';
+        goals[i].group_radius = 0;
+        i++;*/
+        //mission 5 I can move Paul, Jaime, Alex
+        //mission 6 I can move the computer that stores the rom encoding, and opens the UC?
+        //mission 8 stanton dowd, harley filben, joe greene
+        //mission 9 I can kinda move the weld points lol
+        //11 gunther with the computer
+        //12 tiffany?
+        //14 howard strong?
+        //15 ?
+
+        i=0;
+
+        map="01_nyc_unatcoisland";
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-6348.445313,1912.637207,-111.428482);//'PathNode217' near unatco hq
+        important_locations[i].is_player_start = true;
+        important_locations[i].is_goal_position = false;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(1297.173096,-10257.972656,-287.428131);//'PathNode274' near Harley Filben
+        important_locations[i].is_player_start = true;
+        important_locations[i].is_goal_position = false;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(6552.227539,-3246.095703,-447.438049);//'PathNode851' bunker with electricity
+        important_locations[i].is_player_start = true;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(2321.717041,-2045.296753,-159.436096);//'PathNode23' in jail with Gunther
+        important_locations[i].is_player_start = true;
+        important_locations[i].is_goal_position = true;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-2407.206787,205.915558,-128.899979);//'HidePoint6' little hut by nsf bot patrol
+        important_locations[i].rotation = rot(0,30472,0);
+        important_locations[i].is_player_start = true;
+        important_locations[i].is_goal_position = true;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(2931.230957,27.495235,2527.800049);//'TerroristCommander0'
+        important_locations[i].rotation = rot(0,14832,0);
+        important_locations[i].is_player_start = true;
+        i++;
+
+        map = "02_nyc_batterypark";
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-4310.507813,2237.952637,189.843536);//'Light450' 
+        important_locations[i].is_player_start = true;
+        important_locations[i].is_goal_position = true;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(507.282898,-1066.344604,-403.132751);//'BarrelAmbrosia0'
+        important_locations[i].rotation = rot(0,16536,0);
+        important_locations[i].is_player_start = true;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(650.060547,-989.234863,-178.095200);//'PathNode17'
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(58.725319,-446.887207,-416.899323);//'PathNode167'
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-644.152161,-676.281738,-379.581146);//'Cigarettes0' on the table
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-444.113403,-2055.208252,-420.899750);//'PathNode192'
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-4993.205078,1919.453003,-73.239639);//'Light414'
+        important_locations[i].rotation = rot(0,16384,0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-4727.703613,3116.336670,-336.900604);//'PathNode142'
+        i++;
+
+        map = "03_nyc_batterypark";
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-4819.345215,3478.138916,-304.225006);//'HarleyFilben0'
+        important_locations[i].is_player_start = true;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-2763.231689,1370.594604,369.799988);//'BumMale4'
+        important_locations[i].rotation = rot(0,7272,0);
+        important_locations[i].is_player_start = true;
+        i++;
+
+        map = "03_nyc_airfield";
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-2687.128662,2320.010986,63.774998);//'Terrorist13'
+        i++;
+
+        map = "03_NYC_BrooklynBridgeStation";
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(975.220337,1208.224854,111.775002);//'ThugMale13'
+        important_locations[i].rotation = rot(0,43128,0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-1248.503662,-2870.117432,109.675003);//'JunkieMale1'
+        important_locations[i].rotation = rot(0,44456,0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(1003.048767,-2519.280762,111.775002);//'BumMale2'
+        important_locations[i].rotation = rot(0,13576,0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-2978.629639,-2281.836670,415.774994);//'ThugMale3'
+        i++;
+
+        important_locations[i].map_name = "04_NYC_NSFHQ";
+        important_locations[i].location = vect(187.265259,315.583862,1032.054199);//'ComputerPersonal3' computer to align dishes and open the door
+        important_locations[i].rotation = rot(0,16672,0);
+        i++;
+
+        /*important_locations[i].map_name = "04_NYC_NSFHQ";
+        important_locations[i].location = vect(116.650787,400.400024,1032.054199);//'ComputerPersonal4' computer that sends the signal, probably can't risk putting 'ComputerPersonal3' back here
+        important_locations[i].rotation = rot(0,49384,0);
+        i++;*/
+    }
+
+    for(i=0; i<ArrayCount(remove_actors); i++) {
+        remove_actors[i].map_name = Caps(remove_actors[i].map_name);
+    }
+    for(i=0; i<ArrayCount(goals); i++) {
+        goals[i].map_name = Caps(goals[i].map_name);
+    }
+    for(i=0; i<ArrayCount(important_locations); i++) {
+        important_locations[i].map_name = Caps(important_locations[i].map_name);
+    }
+
+    Super.CheckConfig();
+}
+
+function FirstEntry()
+{
+    local Actor a;
+    local int i, k, start, slot, tries, num_ma, num_ps, num_gl;
+    local vector diff;
+    local Actor movable_actors[32];
+    local float movable_actors_radius[32];
+    local ImportantLocation player_starts[32];
+    local ImportantLocation goal_locations[32];
+
+    Super.FirstEntry();
+    SetSeed( "DXRMissions" );
+
+    for(i=0; i<ArrayCount(important_locations); i++) {
+        if( dxr.localURL != important_locations[i].map_name ) continue;
+
+        if( important_locations[i].is_player_start ) {
+            player_starts[num_ps] = important_locations[i];
+            num_ps++;
+        }
+        if( important_locations[i].is_goal_position ) {
+            goal_locations[num_gl] = important_locations[i];
+            num_gl++;
+        }
+    }
+
+    foreach AllActors(class'Actor', a) {
+        for(i=0; i<ArrayCount(remove_actors); i++) {
+            if( dxr.localURL != remove_actors[i].map_name ) continue;
+
+            if( a.name == remove_actors[i].actor_name ) {
+                a.Destroy();
+                break;
+            }
+        }
+
+        for(i=0; i<ArrayCount(goals); i++) {
+            if( dxr.localURL != goals[i].map_name ) continue;
+
+            if( a.name == goals[i].actor_name ) {
+                movable_actors[num_ma] = a;
+                movable_actors_radius[num_ma] = goals[i].group_radius;
+                num_ma++;
+            }
+        }
+    }
+
+    if( allow_vanilla == true && num_ps > 0 ) {
+        player_starts[num_ps].location = dxr.Player.location;
+        player_starts[num_ps].rotation = dxr.Player.rotation;
+        num_ps++;
+    }
+
+    if( num_ps > 0 ) {
+        start = rng(num_ps);
+        dxr.Player.SetLocation(player_starts[start].location);
+        dxr.Player.SetRotation(player_starts[start].rotation);
+
+        for(i=0; i<num_gl; i++) {
+            diff = player_starts[start].location - goal_locations[i].location;
+            if( VSize(diff) < 160 ) {
+                goal_locations[i] = goal_locations[num_gl-1];
+                num_gl--;
+                i--;
+            }
+        }
+    }
+
+    for(i=0; i<num_ma && num_gl>0; i++) {
+        slot = rng(num_gl);
+        diff = goal_locations[slot].location - movable_actors[i].location;
+        if( allow_vanilla == false && num_gl > 1 && VSize(diff) < 16 && tries<100 ) {
+            tries++;
+            l(movable_actors[i] $ ", vanilla not allowed, num_gl==" $ num_gl $ ", tries=="$tries);
+            i--;
+            continue;
+        }
+        if( movable_actors_radius[i] >= 0.1 ) {
+            foreach RadiusActors(class'Actor', a, movable_actors_radius[i], movable_actors[i].location) {
+                if( NavigationPoint(a) != None ) continue;
+                if( Light(a) != None ) continue;
+                a.SetLocation( a.location + diff );
+                a.SetPhysics(PHYS_Falling);
+            }
+        }
+        //if current orders are patrolling, set orders to standing?
+        movable_actors[i].SetLocation(goal_locations[slot].location);
+        movable_actors[i].SetRotation(goal_locations[slot].rotation);
+        movable_actors[i].SetPhysics(PHYS_Falling);
+        goal_locations[slot] = goal_locations[num_gl-1];
+        num_gl--;
+    }
+
+}
+
+function AnyEntry()
+{
+    Super.AnyEntry();
+}
+
+//tests to ensure that there are more goal locations than movable actors

--- a/DeusEx/Classes/DXRMissions.uc
+++ b/DeusEx/Classes/DXRMissions.uc
@@ -81,15 +81,18 @@ function CheckConfig()
         goals[i].map_name = map;
         goals[i].actor_name = 'BarrelAmbrosia0';
         goals[i].group_radius = 160;
+        goals[i].allow_vanilla = true;
         i++;
 
         map = "03_nyc_batterypark";
         goals[i].map_name = map;
         goals[i].actor_name = 'HarleyFilben0';
+        goals[i].allow_vanilla = true;
         i++;
 
         goals[i].map_name = map;
         goals[i].actor_name = 'BumMale4';
+        goals[i].allow_vanilla = true;
         i++;
 
         goals[i].map_name = map;
@@ -106,22 +109,27 @@ function CheckConfig()
         map = "03_NYC_BrooklynBridgeStation";
         goals[i].map_name = map;
         goals[i].actor_name = 'ThugMale13';
+        goals[i].allow_vanilla = true;
         i++;
 
         goals[i].map_name = map;
         goals[i].actor_name = 'JunkieMale1';
+        goals[i].allow_vanilla = true;
         i++;
 
         goals[i].map_name = map;
         goals[i].actor_name = 'BumMale2';
+        goals[i].allow_vanilla = true;
         i++;
 
         goals[i].map_name = map;
         goals[i].actor_name = 'ThugMale3';
+        goals[i].allow_vanilla = true;
         i++;
 
         goals[i].map_name = map;
         goals[i].actor_name = 'BumMale3';
+        goals[i].allow_vanilla = true;
         i++;
 
         map = "04_NYC_NSFHQ";
@@ -137,10 +145,28 @@ function CheckConfig()
         goals[i].physics = PHYS_None;
         i++;
 
+        map = "05_NYC_UnatcoMJ12Lab";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'PaulDenton0';
+        goals[i].allow_vanilla = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'PaulDentonCarcass0';
+        goals[i].allow_vanilla = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DataLinkTrigger6';
+        goals[i].allow_vanilla = true;
+        goals[i].move_with_previous = true;
+        i++;
+
         map = "09_nyc_graveyard";
         goals[i].map_name = map;
         goals[i].actor_name = 'BreakableWall1';
         goals[i].physics = PHYS_None;
+        goals[i].allow_vanilla = true;
         i++;
 
         goals[i].map_name = map;
@@ -219,13 +245,12 @@ function CheckConfig()
         goals[i].actor_name = '';
         goals[i].group_radius = 0;
         i++;*/
-        //mission 4 the computers, should allow_vanilla, might need to take special care for Datacube0 and Datacube4, they already needed fixing anyways cause they were always in the same place
-        //mission 5 I can move Paul, Jaime, Alex
-        //mission 6 I can move the computer that stores the rom encoding, and opens the UC?
-        //mission 8 stanton dowd, harley filben, joe greene
-        //11 gunther with the computer, the fake mechanic
-        //12 tiffany?
-        //14 howard strong?
+        //mission 5 I can move Paul, Jaime, Alex... I can put PaulDenton0/PaulDentonCarcass0 in the nanotech lab, robot maintenance, or armory? probably can't put him in sight of any enemies
+        //mission 6 I can move the computer that stores the rom encoding, and opens the UC (nowhere good to put it though)?
+        //mission 8 stanton dowd near smuggler's back door past the basketball court? in the alley where sandra was?
+        //11 gunther with the computer to vault, WiB's room, kitchen, barracks, chapel... the fake mechanic near lucius, morpheus, aquarium
+        //12 tiffany? in the bathroom or in the truck?
+        //14 howard strong? 
         //15 ?
 
         i=0;
@@ -425,20 +450,32 @@ function CheckConfig()
         important_locations[i].rotation = rot(0, 16384, 0);
         i++;
 
-        map = "09_nyc_graveyard";
+        map = "05_NYC_UnatcoMJ12Lab";
         /*important_locations[i].map_name = map;
-        important_locations[i].location = vect(-1753.464600, -370.122009, -300);//''
+        important_locations[i].location = vect(-4088.201172, 807.195679, -100.860603);//robot maintenance
+        important_locations[i].rotation = rot(0, 0, 0);
         i++;*/
 
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-8548.773438, 1074.370850, -20.860909);//armory
+        important_locations[i].rotation = rot(0, 0, 0);
+        i++;
+
+        map = "09_nyc_graveyard";
         important_locations[i].map_name = map;
         important_locations[i].location = vect(-283.503448, -787.867920, -184);//'PathNode108' in the tunnels
         important_locations[i].rotation = rot(0, 0, -32768);
         i++;
 
-        /*important_locations[i].map_name = map;
-        important_locations[i].location = vect();//''
-        important_locations[i].rotation = rot();
-        i++;*/
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-766.879333, 501.505676, -88.109619);//'BioelectricCell0' in the grave
+        important_locations[i].rotation = rot(0, 0, -32768);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-1530, 845, -107);//'PathNode96' in the other tunnels
+        important_locations[i].rotation = rot(0, 0, -32768);
+        i++;
 
         map = "09_nyc_shipbelow";
         important_locations[i].map_name = map;
@@ -637,8 +674,15 @@ function bool MoveActor(Actor a, vector loc, rotator rotation, EPhysics p)
 
     sp = ScriptedPawn(a);
     if( sp != None && sp.Orders == 'Patrolling' ) {
-        sp.Orders = 'Wandering';
+        //sp.Orders = 'Wandering';
+        sp.SetOrders('Wandering');
     }
+    /*if( sp != None && sp.Orders == 'Standing' ) {
+        sp.SetOrders('Standing', 'Start', false);
+        //sp.InitializeHomeBase();
+    }*/
+    sp.HomeLoc = sp.Location;
+    sp.HomeRot = vector(sp.Rotation);
 
     return true;
 }

--- a/DeusEx/Classes/DXRMissions.uc
+++ b/DeusEx/Classes/DXRMissions.uc
@@ -168,11 +168,25 @@ function CheckConfig()
         goals[i].physics = PHYS_None;
         i++;
 
-        goals[i].map_name = map;
-        goals[i].actor_name = 'ComputerPersonal4';
+        /*goals[i].map_name = map;
+        goals[i].actor_name = 'ComputerPersonal4';//this computer behind the door is finicky because you can't be standing inside the FlagTriggers while the flag is being set, it won't retrigger to check, which is why the map has the triggers all over the place
         goals[i].allow_vanilla = true;
         goals[i].physics = PHYS_None;
         i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'FlagTrigger5';
+        goals[i].move_with_previous = true;
+        goals[i].physics = PHYS_None;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DataLinkTrigger7';
+        goals[i].move_with_previous = true;
+        goals[i].physics = PHYS_None;
+        goals[i].group_radius = 1;
+        i++;*/
 
         map = "05_NYC_UnatcoMJ12Lab";
         goals[i].map_name = map;

--- a/DeusEx/Classes/DXRMissions.uc
+++ b/DeusEx/Classes/DXRMissions.uc
@@ -83,6 +83,10 @@ function CheckConfig()
             important_locations[i].is_goal_position = true;
             important_locations[i].rotation = rot(0,0,0);
         }
+        for(i=0; i < ArrayCount(randomitems); i++ ) {
+            randomitems[i].type = "";
+            randomitems[i].chance = 0;
+        }
 
         i=0;
 
@@ -255,14 +259,70 @@ function CheckConfig()
         goals[i].allow_vanilla = true;
         i++;
 
-        /*goals[i].map_name = map;
-        goals[i].actor_name = '';
-        goals[i].group_radius = 0;
+        map = "11_paris_cathedral";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'ComputerPersonal0';//
+        goals[i].allow_vanilla = true;
+        goals[i].physics = PHYS_None;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'GuntherHermann0';//
+        goals[i].move_with_previous = true;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'OrdersTrigger0';//
+        goals[i].move_with_previous = true;
+        goals[i].physics = PHYS_None;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'GoalCompleteTrigger0';//
+        goals[i].move_with_previous = true;
+        goals[i].physics = PHYS_None;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'SkillAwardTrigger3';//
+        goals[i].move_with_previous = true;
+        goals[i].physics = PHYS_None;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'FlagTrigger2';//
+        goals[i].move_with_previous = true;
+        goals[i].physics = PHYS_None;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DataLinkTrigger8';//
+        goals[i].move_with_previous = true;
+        goals[i].physics = PHYS_None;
+        goals[i].group_radius = 1;
+        i++;
+
+        /*map = "11_paris_everett";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'Mechanic0';//fake mechanic, Ray, talking to him early skips all the everett dialog
+        goals[i].allow_vanilla = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'OrdersTrigger3';//
+        goals[i].move_with_previous = true;
+        goals[i].physics = PHYS_None;
         i++;*/
-        //mission 5 I can move Paul, Jaime, Alex... I can put PaulDenton0/PaulDentonCarcass0 in the nanotech lab, robot maintenance, or armory? probably can't put him in sight of any enemies
+
+        //mission 5 I can move Alex
         //mission 6 I can move the computer that stores the rom encoding, and opens the UC (nowhere good to put it though)?
         //mission 8 stanton dowd near smuggler's back door past the basketball court? in the alley where sandra was?
-        //11 gunther with the computer to vault, WiB's room, kitchen, barracks, chapel... the fake mechanic near lucius, morpheus, aquarium
+        //11 everett? the fake mechanic near lucius, morpheus, aquarium
         //12 tiffany? in the bathroom or in the truck?
         //14 howard strong? 
         //15 ?
@@ -537,10 +597,30 @@ function CheckConfig()
         important_locations[i].rotation = rot(3800, 16384, 0);
         i++;
 
-        for(i=0; i < ArrayCount(randomitems); i++ ) {
-            randomitems[i].type = "";
-            randomitems[i].chance = 0;
-        }
+        map = "11_paris_cathedral";
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(2990.853516, 30.971684, -392.498993);//barracks
+        important_locations[i].rotation = rot(0, 16384, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(1860.275635, -9.666374, -371.286804);//chapel
+        important_locations[i].rotation = rot(0, 16384, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(1511.325317, -3204.465088, -680.498413);//kitchen
+        important_locations[i].rotation = rot(0, 32768, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(3480.141602, -3180.397949, -704.496704);//vault
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(3527.593750, -1992.829834, -100.499969);//WiB room
+        important_locations[i].rotation = rot(0, -16384, 0);
+        i++;
 
         i=0;
 
@@ -613,9 +693,9 @@ function FirstEntry()
 {
     local Actor a;
     local int i, k, start, slot, tries, num_ma, num_ps, num_gl;
+    local bool success;
     local vector loc, diff;
     local Actor movable_actors[32];
-    //local float movable_actors_radius[32];
     local Goal local_goals[32];
     local ImportantLocation player_starts[32];
     local ImportantLocation goal_locations[32];
@@ -671,6 +751,7 @@ function FirstEntry()
     }
 
     if( dxr.flags.startinglocations > 0 && num_ps > 0 ) {
+        l("randomizing starting location, num_ps == "$num_ps);
         start = rng(num_ps);
         dxr.Player.SetLocation(player_starts[start].location);
         dxr.Player.SetRotation(player_starts[start].rotation);
@@ -686,6 +767,8 @@ function FirstEntry()
     }
 
     if( dxr.flags.goals == 0 ) return;
+
+    l("randomizing goals, num_ma=="$num_ma$", num_gl=="$num_gl);
 
     for(i=0; i<num_ma && num_gl>0; i++) {
         if( local_goals[i].move_with_previous == true ) continue;
@@ -713,13 +796,16 @@ function FirstEntry()
             foreach RadiusActors(class'Actor', a, local_goals[i].group_radius, loc ) {
                 if( NavigationPoint(a) != None ) continue;
                 if( Light(a) != None ) continue;
-                MoveActor(a, a.location + diff, a.rotation, local_goals[i].physics);
+                success = MoveActor(a, a.location + diff, a.rotation, local_goals[i].physics);
+                if( success == false ) MoveActor(a, goal_locations[slot].location, a.rotation, local_goals[i].physics);
             }
         }
 
         for(k=i+1; k<num_ma; k++) {
             if( local_goals[k].move_with_previous == false ) break;
-            MoveActor(movable_actors[k], movable_actors[k].location + diff, goal_locations[slot].rotation, local_goals[k].physics);
+            success = false;
+            if( local_goals[k].group_radius ~= 0.0 ) success = MoveActor(movable_actors[k], movable_actors[k].location + diff, goal_locations[slot].rotation, local_goals[k].physics);
+            if( success == false ) MoveActor(movable_actors[k], goal_locations[slot].location, goal_locations[slot].rotation, local_goals[k].physics);
         }
 
         goal_locations[slot] = goal_locations[num_gl-1];
@@ -752,16 +838,11 @@ function bool MoveActor(Actor a, vector loc, rotator rotation, EPhysics p)
     if(p == PHYS_None) a.bCollideWorld = oldbCollideWorld;
 
     sp = ScriptedPawn(a);
-    if( sp != None && sp.Orders == 'Patrolling' ) {
-        //sp.Orders = 'Wandering';
-        sp.SetOrders('Wandering');
+    if( sp != None ) {
+        if( sp.Orders == 'Patrolling' ) sp.SetOrders('Wandering');
+        sp.HomeLoc = sp.Location;
+        sp.HomeRot = vector(sp.Rotation);
     }
-    /*if( sp != None && sp.Orders == 'Standing' ) {
-        sp.SetOrders('Standing', 'Start', false);
-        //sp.InitializeHomeBase();
-    }*/
-    sp.HomeLoc = sp.Location;
-    sp.HomeRot = vector(sp.Rotation);
 
     return true;
 }

--- a/DeusEx/Classes/DXRMissions.uc
+++ b/DeusEx/Classes/DXRMissions.uc
@@ -48,7 +48,7 @@ function CheckConfig()
 
         i=0;
         remove_actors[i].map_name = "01_NYC_unatcoisland";
-        remove_actors[i].actor_name = 'PaulDenton0';//because he gives you EZ mode weapons
+        remove_actors[i].actor_name = 'OrdersTrigger2';//the order that makes Paul run to you
         i++;
 
         remove_actors[i].map_name = "01_NYC_unatcoisland";
@@ -63,13 +63,9 @@ function CheckConfig()
         remove_actors[i].actor_name = 'DataLinkTrigger8';//the "don't leave without talking to Paul" datalink
         i++;
 
-        remove_actors[i].map_name = "02_nyc_batterypark";
-        remove_actors[i].actor_name = 'AnnaNavarre0';//because she chases you down
-        i++;
-
-        /*remove_actors[i].map_name = "09_NYC_GRAVEYARD";
+        remove_actors[i].map_name = "09_NYC_GRAVEYARD";
         remove_actors[i].actor_name = 'Barrel0';//barrel next to the transmitter thing, idk what it does but it explodes when I move it
-        i++;*/
+        i++;
 
         for(i=0; i<ArrayCount(goals); i++) {
             goals[i].map_name = "";
@@ -945,6 +941,7 @@ function CheckConfig()
 function FirstEntry()
 {
     local Actor a;
+    local AnnaNavarre anna;
     local int i, k, start, slot, tries, num_ma, num_ps, num_gl;
     local bool success;
     local vector loc, diff;
@@ -956,7 +953,13 @@ function FirstEntry()
     Super.FirstEntry();
 
     if( dxr.localURL == "01_NYC_UNATCOISLAND" ) {
+        dxr.flags.f.SetBool('MeetPaul_Played', true,, 2);
         RandoStartingEquipment(dxr.player);
+    }
+    if( dxr.localURL == "02_NYC_BATTERYPARK" ) {
+        foreach AllActors(class'AnnaNavarre', anna) {
+            anna.SetOrders('Standing');
+        }
     }
 
     SetSeed( "DXRMissions" );

--- a/DeusEx/Classes/DXRMissions.uc
+++ b/DeusEx/Classes/DXRMissions.uc
@@ -809,6 +809,13 @@ function CheckConfig()
         i++;
 
         important_locations[i].map_name = map;
+        important_locations[i].location = vect(657.233215, 2501.673096, -908.798096);//vanilla start
+        important_locations[i].rotation = rot(0, -16384, 0);
+        important_locations[i].is_goal_position = false;
+        important_locations[i].is_player_start = true;
+        i++;
+
+        important_locations[i].map_name = map;
         important_locations[i].location = vect(6750.350586, 7763.461426, -3092.699951);//exit helicopter
         important_locations[i].rotation = rot(0, 0, 0);
         important_locations[i].is_goal_position = false;
@@ -844,6 +851,28 @@ function CheckConfig()
 
         important_locations[i].map_name = map;
         important_locations[i].location = vect(-266.569397, -6868.054199, 775.592590);//6th floor
+        i++;
+
+        map = "15_area51_bunker";
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-1778.574707, 1741.028320, -213.732849);//vanilla start
+        important_locations[i].rotation = rot(0, -12416, 0);
+        important_locations[i].is_goal_position = false;
+        important_locations[i].is_player_start = true;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-493.825836, 3099.697510, -512.897827);//crashed van
+        important_locations[i].rotation = rot(0, 0, 0);
+        important_locations[i].is_goal_position = false;
+        important_locations[i].is_player_start = true;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(1137.405762, -2744.735107, -135.899963);//warehouse? MechanicCarcass
+        important_locations[i].rotation = rot(0, 0, 0);
+        important_locations[i].is_goal_position = false;
+        important_locations[i].is_player_start = true;
         i++;
 
         i=0;

--- a/DeusEx/Classes/DXRMissions.uc
+++ b/DeusEx/Classes/DXRMissions.uc
@@ -180,6 +180,99 @@ function CheckConfig()
         goals[i].move_with_previous = true;
         i++;
 
+        map = "05_NYC_UnatcoHQ";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'AlexJacobson0';
+        goals[i].allow_vanilla = true;
+        i++;
+
+        map = "06_hongkong_mj12lab";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'ComputerPersonal0';
+        goals[i].allow_vanilla = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DataLinkTrigger0';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DataLinkTrigger3';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DataLinkTrigger4';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DataLinkTrigger5';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DataLinkTrigger6';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DataLinkTrigger8';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'FlagTrigger0';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'FlagTrigger1';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'GoalCompleteTrigger0';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'SkillAwardTrigger10';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        goals[i].group_radius = 1;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'ComputerPersonal1';
+        goals[i].allow_vanilla = true;
+        i++;
+
+        /*map = "08_nyc_street";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'StantonDowd0';
+        goals[i].allow_vanilla = true;
+        i++;*/
+
         map = "09_nyc_graveyard";
         goals[i].map_name = map;
         goals[i].actor_name = 'BreakableWall1';
@@ -319,11 +412,9 @@ function CheckConfig()
         goals[i].physics = PHYS_None;
         i++;*/
 
-        //mission 5 I can move Alex
-        //mission 6 I can move the computer that stores the rom encoding, and opens the UC (nowhere good to put it though)?
-        //mission 8 stanton dowd near smuggler's back door past the basketball court? in the alley where sandra was?
+        //mission 6 I can move the computer that opens the UC (nowhere good to put it though)?
         //11 everett? the fake mechanic near lucius, morpheus, aquarium
-        //12 tiffany? in the bathroom or in the truck?
+        //12 maybe the 2 keypads in vandenberg cmd? tiffany? in the bathroom or in the truck?
         //14 howard strong? 
         //15 ?
 
@@ -534,6 +625,62 @@ function CheckConfig()
         important_locations[i].location = vect(-8548.773438, 1074.370850, -20.860909);//armory
         important_locations[i].rotation = rot(0, 0, 0);
         i++;
+
+        map = "05_NYC_UnatcoHQ";
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-2478.156738, -1123.645874, -16.399887);//jail
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(121.921074, 287.711243, 39.599487);//bathroom
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(261.019775, -403.939575, 287.600586);//manderley's bathroom
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(718.820068, 1411.137451, 287.598999);//vending machines
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-666.268066, -460.813965, 463.598083);//office
+        i++;
+
+        map = "06_hongkong_mj12lab";
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-140.163544, 1705.130127, -583.495483);//barracks
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-1273.699951, 803.588745, -792.499512);//radioactive area
+        important_locations[i].rotation = rot(0, 16384, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-1712.699951, -809.700012, -744.500610);//labs
+        important_locations[i].rotation = rot(0, 16384, 0);
+        i++;
+
+        /*map = "08_nyc_street";
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(2850.863525, -873.754883, -720.404785);//smuggler front door
+        important_locations[i].rotation = rot(0, 32768, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(2608.952881, -2765.534912, -448.403107);//basketball court
+        important_locations[i].rotation = rot(0, 32768, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(3756.613525, -4264.618652, -528.401306);//smuggler back door
+        important_locations[i].rotation = rot(0, 16384, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-2372.936035, -568.257813, -464.395020);//alley
+        i++;*/
 
         map = "09_nyc_graveyard";
         important_locations[i].map_name = map;

--- a/DeusEx/Classes/DXRMissions.uc
+++ b/DeusEx/Classes/DXRMissions.uc
@@ -1,4 +1,4 @@
-class DXRMissions extends DXRBase;
+class DXRMissions extends DXRActorsBase;
 
 //list of actors to remove
 //list of starting positions
@@ -17,16 +17,18 @@ struct ImportantLocation {
     var bool is_player_start;
     var bool is_goal_position;
 };
-var config ImportantLocation important_locations[64];
+var config ImportantLocation important_locations[100];
 
 struct Goal {
     var string map_name;
     var name actor_name;
     var float group_radius;
-    //var bool move_with_previous;//for chaining things together?
+    var EPhysics physics;
+    var bool move_with_previous;//for chaining things together?
+    var bool allow_vanilla;
     //var bool is_movable_actor;
 };
-var config Goal goals[50];
+var config Goal goals[64];
 
 var config bool allow_vanilla;
 
@@ -51,9 +53,16 @@ function CheckConfig()
         remove_actors[i].actor_name = 'AnnaNavarre0';//because she chases you down
         i++;
 
+        /*remove_actors[i].map_name = "09_NYC_GRAVEYARD";
+        remove_actors[i].actor_name = 'Barrel0';//barrel next to the transmitter thing, idk what it does but it explodes when I move it
+        i++;*/
+
         for(i=0; i<ArrayCount(goals); i++) {
             goals[i].map_name = "";
             goals[i].group_radius = 0;
+            goals[i].physics = PHYS_Falling;
+            goals[i].move_with_previous = false;
+            goals[i].allow_vanilla = false;
         }
         for(i=0; i<ArrayCount(important_locations); i++) {
             important_locations[i].is_player_start = false;
@@ -81,13 +90,18 @@ function CheckConfig()
 
         goals[i].map_name = map;
         goals[i].actor_name = 'BumMale4';
-        goals[i].group_radius = 200;//bring BumFemale2 with him?
         i++;
 
-        /*map = "03_nyc_airfield";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'BumFemale2';
+        goals[i].move_with_previous = true;
+        i++;
+
+        map = "03_nyc_airfield";
         goals[i].map_name = map;
         goals[i].actor_name = 'Terrorist13';//need to make sure to get rid of his patrol orders
-        i++;*/
+        goals[i].allow_vanilla = true;
+        i++;
 
         map = "03_NYC_BrooklynBridgeStation";
         goals[i].map_name = map;
@@ -120,15 +134,92 @@ function CheckConfig()
         goals[i].group_radius = 16;
         i++;*/
 
-        /*goals[i].map_name = "";
+        map = "09_nyc_graveyard";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'BreakableWall1';
+        goals[i].physics = PHYS_None;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'SkillAwardTrigger2';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'FlagTrigger0';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'TriggerLight0';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'TriggerLight1';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'TriggerLight2';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'AmbientSoundTriggered0';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        i++;
+
+        map = "09_nyc_shipbelow";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DeusExMover40';//weld point
+        goals[i].physics = PHYS_None;
+        goals[i].group_radius = 80;
+        goals[i].allow_vanilla = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DeusExMover16';//weld point
+        goals[i].physics = PHYS_None;
+        goals[i].group_radius = 80;
+        goals[i].allow_vanilla = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DeusExMover33';//weld point
+        goals[i].physics = PHYS_None;
+        goals[i].group_radius = 80;
+        goals[i].allow_vanilla = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DeusExMover31';//weld point
+        goals[i].physics = PHYS_None;
+        goals[i].group_radius = 80;
+        goals[i].allow_vanilla = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DeusExMover32';//weld point
+        goals[i].physics = PHYS_None;
+        goals[i].group_radius = 80;
+        goals[i].allow_vanilla = true;
+        i++;
+
+        /*goals[i].map_name = map;
         goals[i].actor_name = '';
         goals[i].group_radius = 0;
         i++;*/
         //mission 5 I can move Paul, Jaime, Alex
         //mission 6 I can move the computer that stores the rom encoding, and opens the UC?
         //mission 8 stanton dowd, harley filben, joe greene
-        //mission 9 I can kinda move the weld points lol
-        //11 gunther with the computer
+        //11 gunther with the computer, the fake mechanic
         //12 tiffany?
         //14 howard strong?
         //15 ?
@@ -239,8 +330,32 @@ function CheckConfig()
 
         map = "03_nyc_airfield";
         important_locations[i].map_name = map;
-        important_locations[i].location = vect(-2687.128662,2320.010986,63.774998);//'Terrorist13'
+        important_locations[i].location = vect(223.719452, 3689.905273, 15.100115);//'SpawnPoint9' by the gate to nowhere
         i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-2103.891113, 3689.706299, 15.091076);//'PathNode49' under security tower
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-2060.626465, -2013.138672, 15.090023);//'PathNode162' under security tower
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(729.454651, -4151.924805, 15.079981);//'PathNode118' under security tower
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(5215.076660, -4134.674316, 15.090023);//'PathNode188' under security tower
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(941.941895, 283.418152, 15.090023);//'PathNode81' big hanger door
+        i++;
+
+        /*important_locations[i].map_name = map;
+        important_locations[i].location = vect(-2687.128662,2320.010986,63.774998);//'Terrorist13'
+        i++;*/
 
         map = "03_NYC_BrooklynBridgeStation";
         important_locations[i].map_name = map;
@@ -275,15 +390,77 @@ function CheckConfig()
         important_locations[i].location = vect(1755.025391, -847.637695, 382.144287);//'PathNode20' upper level
         i++;
 
-        important_locations[i].map_name = "04_NYC_NSFHQ";
+        map = "04_NYC_NSFHQ";
+        important_locations[i].map_name = map;
         important_locations[i].location = vect(187.265259,315.583862,1032.054199);//'ComputerPersonal3' computer to align dishes and open the door
         important_locations[i].rotation = rot(0,16672,0);
         i++;
 
-        /*important_locations[i].map_name = "04_NYC_NSFHQ";
+        /*important_locations[i].map_name = map;
         important_locations[i].location = vect(116.650787,400.400024,1032.054199);//'ComputerPersonal4' computer that sends the signal, probably can't risk putting 'ComputerPersonal3' back here
         important_locations[i].rotation = rot(0,49384,0);
         i++;*/
+
+        map = "09_nyc_graveyard";
+        /*important_locations[i].map_name = map;
+        important_locations[i].location = vect(-1753.464600, -370.122009, -300);//''
+        i++;*/
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-283.503448, -787.867920, -184);//'PathNode108' in the tunnels
+        important_locations[i].rotation = rot(0, 0, -32768);
+        i++;
+
+        /*important_locations[i].map_name = map;
+        important_locations[i].location = vect();//''
+        important_locations[i].rotation = rot();
+        i++;*/
+
+        map = "09_nyc_shipbelow";
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-384.000000, 1024.000000, -272.000000);//first engine room
+        important_locations[i].rotation = rot(0, 49152, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-3296.000000, -1664.000000, -112.000000);//above bilge pumps room
+        important_locations[i].rotation = rot(0, 81920, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-2480.000000, -448.000000, -144.000000);//hallway above bilge pumps room
+        important_locations[i].rotation = rot(0, 32768, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-3952.000000, 768.000000, -416.000000);//electrical room
+        important_locations[i].rotation = rot(0, 0, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-5664.000000, -928.000000, -432.000000);//helipad room
+        important_locations[i].rotation = rot(0, 16384, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-4336.000000, -150, -176.000000);//storage closet
+        important_locations[i].rotation = rot(0, -16384, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-5152.000000, 1536.000000, -160.000000);//air control
+        important_locations[i].rotation = rot(0, -16384, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-3072.000000, 64.000000, 816.000000);//big fan
+        important_locations[i].rotation = rot(0, 0, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-320.000000, -784.000000, 32.000000);//engine control room
+        important_locations[i].rotation = rot(3800, 16384, 0);
+        i++;
     }
 
     for(i=0; i<ArrayCount(remove_actors); i++) {
@@ -305,7 +482,8 @@ function FirstEntry()
     local int i, k, start, slot, tries, num_ma, num_ps, num_gl;
     local vector diff;
     local Actor movable_actors[32];
-    local float movable_actors_radius[32];
+    //local float movable_actors_radius[32];
+    local Goal local_goals[32];
     local ImportantLocation player_starts[32];
     local ImportantLocation goal_locations[32];
 
@@ -325,6 +503,12 @@ function FirstEntry()
         }
     }
 
+    for(i=0; i<ArrayCount(goals); i++) {
+        if( dxr.localURL != goals[i].map_name ) continue;
+        local_goals[num_ma] = goals[i];
+        num_ma++;
+    }
+
     foreach AllActors(class'Actor', a) {
         for(i=0; i<ArrayCount(remove_actors); i++) {
             if( dxr.localURL != remove_actors[i].map_name ) continue;
@@ -335,13 +519,9 @@ function FirstEntry()
             }
         }
 
-        for(i=0; i<ArrayCount(goals); i++) {
-            if( dxr.localURL != goals[i].map_name ) continue;
-
-            if( a.name == goals[i].actor_name ) {
-                movable_actors[num_ma] = a;
-                movable_actors_radius[num_ma] = goals[i].group_radius;
-                num_ma++;
+        for(i=0; i<num_ma; i++) {
+            if( a.name == local_goals[i].actor_name ) {
+                movable_actors[i] = a;
             }
         }
     }
@@ -368,26 +548,38 @@ function FirstEntry()
     }
 
     for(i=0; i<num_ma && num_gl>0; i++) {
-        slot = rng(num_gl);
+        if( local_goals[i].move_with_previous == true ) continue;
+
+        if( allow_vanilla == true || local_goals[i].allow_vanilla == true ) {
+            slot = rng(num_gl+1);
+            if( slot == 0 ) continue;//don't do anything
+            slot--;
+        }
+        else slot = rng(num_gl);
+        l("moving goal: " $ movable_actors[i] );
+
         diff = goal_locations[slot].location - movable_actors[i].location;
-        if( allow_vanilla == false && num_gl > 1 && VSize(diff) < 16 && tries<100 ) {
+        if( allow_vanilla == false && local_goals[i].allow_vanilla == false && num_gl > 1 && VSize(diff) < 16 && tries<100 ) {
             tries++;
             l(movable_actors[i] $ ", vanilla not allowed, num_gl==" $ num_gl $ ", tries=="$tries);
             i--;
             continue;
         }
-        if( movable_actors_radius[i] >= 0.1 ) {
-            foreach RadiusActors(class'Actor', a, movable_actors_radius[i], movable_actors[i].location) {
+        if( local_goals[i].group_radius >= 0.1 ) {
+            foreach RadiusActors(class'Actor', a, local_goals[i].group_radius, GetCenter(movable_actors[i]) ) {
                 if( NavigationPoint(a) != None ) continue;
                 if( Light(a) != None ) continue;
-                a.SetLocation( a.location + diff );
-                a.SetPhysics(PHYS_Falling);
+                MoveActor(a, a.location + diff, a.rotation, local_goals[i].physics);
             }
         }
         //if current orders are patrolling, set orders to standing?
-        movable_actors[i].SetLocation(goal_locations[slot].location);
-        movable_actors[i].SetRotation(goal_locations[slot].rotation);
-        movable_actors[i].SetPhysics(PHYS_Falling);
+        MoveActor(movable_actors[i], goal_locations[slot].location, goal_locations[slot].rotation, local_goals[i].physics);
+
+        for(k=i+1; k<num_ma; k++) {
+            if( local_goals[k].move_with_previous == false ) break;
+            MoveActor(movable_actors[k], movable_actors[k].location + diff, goal_locations[slot].rotation, local_goals[k].physics);
+        }
+
         goal_locations[slot] = goal_locations[num_gl-1];
         num_gl--;
     }
@@ -397,6 +589,21 @@ function FirstEntry()
 function AnyEntry()
 {
     Super.AnyEntry();
+}
+
+function MoveActor(Actor a, vector loc, rotator rotation, EPhysics p)
+{
+    local ScriptedPawn sp;
+
+    l("moving " $ a $ " from (" $ a.location $ ") to (" $ loc $ ")" );
+    a.SetLocation(loc);
+    a.SetRotation(rotation);
+    a.SetPhysics(p);
+
+    sp = ScriptedPawn(a);
+    if( sp != None && sp.Orders == 'Patrolling' ) {
+        sp.Orders = 'Wandering';
+    }
 }
 
 //tests to ensure that there are more goal locations than movable actors

--- a/DeusEx/Classes/DXRMissions.uc
+++ b/DeusEx/Classes/DXRMissions.uc
@@ -94,8 +94,31 @@ function CheckConfig()
         map = "02_nyc_batterypark";
         goals[i].map_name = map;
         goals[i].actor_name = 'BarrelAmbrosia0';
-        goals[i].group_radius = 160;
         goals[i].allow_vanilla = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'SkillAwardTrigger0';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'GoalCompleteTrigger0';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'FlagTrigger1';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'DataLinkTrigger1';
+        goals[i].physics = PHYS_None;
+        goals[i].move_with_previous = true;
         i++;
 
         map = "03_nyc_batterypark";
@@ -479,9 +502,10 @@ function CheckConfig()
         i++;
 
         important_locations[i].map_name = map;
-        important_locations[i].location = vect(507.282898,-1066.344604,-403.132751);//'BarrelAmbrosia0'
+        important_locations[i].location = vect(353.434570, -1123.060547, -416.488281);//'BarrelAmbrosia0'
         important_locations[i].rotation = rot(0,16536,0);
         important_locations[i].is_player_start = true;
+        important_locations[i].is_goal_position = false;
         i++;
 
         important_locations[i].map_name = map;
@@ -959,6 +983,10 @@ function FirstEntry()
     if( dxr.localURL == "02_NYC_BATTERYPARK" ) {
         foreach AllActors(class'AnnaNavarre', anna) {
             anna.SetOrders('Standing');
+            anna.SetLocation( vect(1082.845703, 1807.538818, 335.101776) );
+            anna.SetRotation( rot(0, -16608, 0) );
+            anna.HomeLoc = anna.Location;
+            anna.HomeRot = vector(anna.Rotation);
         }
     }
 
@@ -1006,6 +1034,7 @@ function FirstEntry()
         num_ps++;
     }
 
+    start = -1;
     if( dxr.flags.startinglocations > 0 && num_ps > 0 ) {
         l("randomizing starting location, num_ps == "$num_ps);
         start = rng(num_ps);
@@ -1014,7 +1043,8 @@ function FirstEntry()
 
         for(i=0; i<num_gl; i++) {
             diff = player_starts[start].location - goal_locations[i].location;
-            if( VSize(diff) < 160 ) {
+            if( VSize(diff) < 16*20 ) {//20 feet
+                l("player starting at ("$player_starts[start].location$"), removing location ("$goal_locations[i].location$")");
                 goal_locations[i] = goal_locations[num_gl-1];
                 num_gl--;
                 i--;
@@ -1029,7 +1059,9 @@ function FirstEntry()
     for(i=0; i<num_ma && num_gl>0; i++) {
         if( local_goals[i].move_with_previous == true ) continue;
 
-        if( allow_vanilla == true || local_goals[i].allow_vanilla == true ) {
+        diff = vect(9999,9999,9999);
+        if( start >= 0 ) diff = player_starts[start].location - movable_actors[i].location;
+        if( VSize(diff) > 16*20 && (allow_vanilla == true || local_goals[i].allow_vanilla == true) ) {
             slot = rng(num_gl+1);
             if( slot == 0 ) continue;//don't do anything
             slot--;
@@ -1050,6 +1082,7 @@ function FirstEntry()
         }
         if( local_goals[i].group_radius >= 0.1 ) {
             foreach RadiusActors(class'Actor', a, local_goals[i].group_radius, loc ) {
+                if( a == dxr.Player ) continue;
                 if( NavigationPoint(a) != None ) continue;
                 if( Light(a) != None ) continue;
                 success = MoveActor(a, a.location + diff, a.rotation, local_goals[i].physics);

--- a/DeusEx/Classes/DXRMissions.uc
+++ b/DeusEx/Classes/DXRMissions.uc
@@ -10,15 +10,6 @@ struct RemoveActor {
 };
 var config RemoveActor remove_actors[32];
 
-struct ImportantLocation {
-    var string map_name;
-    var vector location;
-    var rotator rotation;
-    var bool is_player_start;
-    var bool is_goal_position;
-};
-var config ImportantLocation important_locations[100];
-
 struct Goal {
     var string map_name;
     var name actor_name;
@@ -28,7 +19,16 @@ struct Goal {
     var bool allow_vanilla;
     //var bool is_movable_actor;
 };
-var config Goal goals[64];
+var config Goal goals[100];
+
+struct ImportantLocation {
+    var string map_name;
+    var vector location;
+    var rotator rotation;
+    var bool is_player_start;
+    var bool is_goal_position;
+};
+var config ImportantLocation important_locations[128];
 
 var config bool allow_vanilla;
 
@@ -400,6 +400,25 @@ function CheckConfig()
         goals[i].group_radius = 1;
         i++;
 
+        map = "12_vandenberg_cmd";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'Keypad0';//
+        goals[i].allow_vanilla = true;
+        goals[i].physics = PHYS_None;
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'Keypad1';//
+        goals[i].allow_vanilla = true;
+        goals[i].physics = PHYS_None;
+        i++;
+
+        map = "14_oceanlab_silo";
+        goals[i].map_name = map;
+        goals[i].actor_name = 'HowardStrong0';//
+        goals[i].allow_vanilla = true;
+        i++;
+
         /*map = "11_paris_everett";
         goals[i].map_name = map;
         goals[i].actor_name = 'Mechanic0';//fake mechanic, Ray, talking to him early skips all the everett dialog
@@ -414,8 +433,7 @@ function CheckConfig()
 
         //mission 6 I can move the computer that opens the UC (nowhere good to put it though)?
         //11 everett? the fake mechanic near lucius, morpheus, aquarium
-        //12 maybe the 2 keypads in vandenberg cmd? tiffany? in the bathroom or in the truck?
-        //14 howard strong? 
+        //12 tiffany? in the bathroom or in the truck?
         //15 ?
 
         i=0;
@@ -767,6 +785,65 @@ function CheckConfig()
         important_locations[i].map_name = map;
         important_locations[i].location = vect(3527.593750, -1992.829834, -100.499969);//WiB room
         important_locations[i].rotation = rot(0, -16384, 0);
+        i++;
+
+        map = "12_vandenberg_cmd";
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(1895.174561, 1405.394287, -1656.404175);//hallway across from computer door
+        important_locations[i].rotation = rot(0, 32768, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(444.509338, 1503.229126, -1415.007568);//near elevator
+        important_locations[i].rotation = rot(0, -16384, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-288.769806, 1103.257813, -1984.334717);//near pipes
+        important_locations[i].rotation = rot(0, -16384, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-1276.664063, 1168.599854, -1685.868042);//globe
+        important_locations[i].rotation = rot(0, 16384, 0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(6750.350586, 7763.461426, -3092.699951);//exit helicopter
+        important_locations[i].rotation = rot(0, 0, 0);
+        important_locations[i].is_goal_position = false;
+        important_locations[i].is_player_start = true;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-214.927200, 888.034485, -2043.409302);//near pipes
+        important_locations[i].rotation = rot(0, 0, 0);
+        important_locations[i].is_goal_position = false;
+        important_locations[i].is_player_start = true;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-1879.828003, 1820.156006, -1777.113892);//globe
+        important_locations[i].rotation = rot(0, 0, 0);
+        important_locations[i].is_goal_position = false;
+        important_locations[i].is_player_start = true;
+        i++;
+
+        map = "14_oceanlab_silo";
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-264.838135, -6829.463379, 55.600639);//3rd floor
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-259.846710, -6848.406250, 326.598969);//4th floor
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-271.341187, -6832.150391, 535.596741);//5th floor
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-266.569397, -6868.054199, 775.592590);//6th floor
         i++;
 
         i=0;

--- a/DeusEx/Classes/DXRMissions.uc
+++ b/DeusEx/Classes/DXRMissions.uc
@@ -46,6 +46,14 @@ function CheckConfig()
         i++;
 
         remove_actors[i].map_name = "01_NYC_unatcoisland";
+        remove_actors[i].actor_name = 'DataLinkTrigger0';//find Paul
+        i++;
+
+        remove_actors[i].map_name = "01_NYC_unatcoisland";
+        remove_actors[i].actor_name = 'DataLinkTrigger2';//nsf everywhere? doesn't trigger unless you talk to paul
+        i++;
+
+        remove_actors[i].map_name = "01_NYC_unatcoisland";
         remove_actors[i].actor_name = 'DataLinkTrigger8';//the "don't leave without talking to Paul" datalink
         i++;
 
@@ -550,6 +558,10 @@ function FirstEntry()
 
     Super.FirstEntry();
     SetSeed( "DXRMissions" );
+
+    if( dxr.localURL == "01_NYC_UNATCOISLAND" ) {
+        dxr.player.energy = rngf()*75+25;
+    }
 
     for(i=0; i<ArrayCount(important_locations); i++) {
         if( dxr.localURL != important_locations[i].map_name ) continue;

--- a/DeusEx/Classes/DXRMissions.uc
+++ b/DeusEx/Classes/DXRMissions.uc
@@ -89,20 +89,25 @@ function CheckConfig()
         goals[i].actor_name = 'Terrorist13';//need to make sure to get rid of his patrol orders
         i++;*/
 
-        goals[i].map_name = "03_NYC_BrooklynBridgeStation";
+        map = "03_NYC_BrooklynBridgeStation";
+        goals[i].map_name = map;
         goals[i].actor_name = 'ThugMale13';
         i++;
 
-        goals[i].map_name = "03_NYC_BrooklynBridgeStation";
+        goals[i].map_name = map;
         goals[i].actor_name = 'JunkieMale1';
         i++;
 
-        goals[i].map_name = "03_NYC_BrooklynBridgeStation";
+        goals[i].map_name = map;
         goals[i].actor_name = 'BumMale2';
         i++;
 
-        goals[i].map_name = "03_NYC_BrooklynBridgeStation";
+        goals[i].map_name = map;
         goals[i].actor_name = 'ThugMale3';
+        i++;
+
+        goals[i].map_name = map;
+        goals[i].actor_name = 'BumMale3';
         i++;
 
         /*goals[i].map_name = "04_NYC_NSFHQ";
@@ -217,6 +222,21 @@ function CheckConfig()
         important_locations[i].is_player_start = true;
         i++;
 
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(1082.374023, 1458.807617, 334.248260);//'PathNode68' outside of castle clinton
+        important_locations[i].is_player_start = true;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-4340.930664, 2332.365234, 244.506165);//'Light174' under the vent
+        important_locations[i].is_player_start = true;
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-2968.101563, -1407.404419, 334.242554);//'PathNode0' in front of statue
+        important_locations[i].is_player_start = true;
+        i++;
+
         map = "03_nyc_airfield";
         important_locations[i].map_name = map;
         important_locations[i].location = vect(-2687.128662,2320.010986,63.774998);//'Terrorist13'
@@ -240,6 +260,19 @@ function CheckConfig()
 
         important_locations[i].map_name = map;
         important_locations[i].location = vect(-2978.629639,-2281.836670,415.774994);//'ThugMale3'
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(-988.025696, -3381.119385, 111.600235);//'BumMale3'
+        important_locations[i].rotation = rot(0,-22608,0);
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(2893.466064, -4513.004395, 104.099274);//'SkillAwardTrigger0' near the pipes
+        i++;
+
+        important_locations[i].map_name = map;
+        important_locations[i].location = vect(1755.025391, -847.637695, 382.144287);//'PathNode20' upper level
         i++;
 
         important_locations[i].map_name = "04_NYC_NSFHQ";

--- a/DeusEx/Classes/DXRPasswords.uc
+++ b/DeusEx/Classes/DXRPasswords.uc
@@ -176,7 +176,7 @@ function RandoInfoDevs(int percent)
             num++;
         }
 
-        slot=rng(num-1);
+        slot=rng(num);
         i=0;
         foreach AllActors(class'Inventory', inv)
         {

--- a/DeusEx/Classes/DXRPasswords.uc
+++ b/DeusEx/Classes/DXRPasswords.uc
@@ -150,6 +150,7 @@ function RandoInfoDevs(int percent)
     local int hasPass[64];
     local DeusExTextParser parser;
 
+    //l("RandoInfoDevs percent == "$percent);
     if(percent == 0) return;
 
     foreach AllActors(class'InformationDevices', id)
@@ -176,7 +177,13 @@ function RandoInfoDevs(int percent)
             num++;
         }
 
-        slot=rng(num);
+        l("datacube "$id$" got num "$num);
+        slot=rng(num+1);//+1 for the vanilla location
+        if(slot==0) {
+            l("not swapping infodevice "$ActorToString(id));
+            continue;
+        }
+        slot--;
         i=0;
         foreach AllActors(class'Inventory', inv)
         {
@@ -184,7 +191,7 @@ function RandoInfoDevs(int percent)
             if( InfoPositionGood(id, inv.Location, hasPass) == False ) continue;
 
             if(i==slot) {
-                l("swapping infodevice "$ActorToString(id)$" with "$inv.Class);
+                l("swapping infodevice "$ActorToString(id)$" with "$inv);
                 Swap(id, inv);
                 break;
             }

--- a/DeusEx/Classes/DXRWeapons.uc
+++ b/DeusEx/Classes/DXRWeapons.uc
@@ -28,7 +28,8 @@ function AnyEntry()
 
 function RandoWeapon(DeusExWeapon w)
 {
-    dxr.SetSeed( dxr.Crc(dxr.seed $ "RandoWeapon " $ w.class.name ) );
+    local int oldseed;
+    oldseed = dxr.SetSeed( dxr.Crc(dxr.seed $ "RandoWeapon " $ w.class.name ) );
 
     w.HitDamage = rngrange(float(w.default.HitDamage), min_weapon_dmg, max_weapon_dmg);
     w.ShotTime = rngrange(w.default.ShotTime, min_weapon_shottime, max_weapon_shottime);
@@ -40,4 +41,5 @@ function RandoWeapon(DeusExWeapon w)
     w.AccurateRange = int(f);
     f = w.default.BaseAccuracy * (rngf()+0.5);
     w.BaseAccuracy = f;*/
+    dxr.SetSeed(oldseed);
 }

--- a/DeusEx/Classes/DXRando.uc
+++ b/DeusEx/Classes/DXRando.uc
@@ -57,12 +57,13 @@ function CheckConfig()
 {
     local int i;
 
-    if( config_version < class'DXRFlags'.static.VersionToInt(1,4,8) ) {
+    if( config_version < class'DXRFlags'.static.VersionToInt(1,4,9) ) {
         for(i=0; i < ArrayCount(modules_to_load); i++) {
             modules_to_load[i] = "";
         }
 
         i=0;
+        modules_to_load[i++] = "DXRMissions";
         modules_to_load[i++] = "DXRSwapItems";
         //modules_to_load[i++] = "DXRAddItems";
         modules_to_load[i++] = "DXRFixup";

--- a/DeusEx/Classes/DXRando.uc
+++ b/DeusEx/Classes/DXRando.uc
@@ -69,7 +69,6 @@ function CheckConfig()
         modules_to_load[i++] = "DXRFixup";
         modules_to_load[i++] = "DXRBacktracking";
         modules_to_load[i++] = "DXRKeys";
-        modules_to_load[i++] = "DXREnemies";
         modules_to_load[i++] = "DXRSkills";
         modules_to_load[i++] = "DXRPasswords";
         modules_to_load[i++] = "DXRAugmentations";
@@ -77,6 +76,7 @@ function CheckConfig()
         modules_to_load[i++] = "DXRNames";
         modules_to_load[i++] = "DXRAutosave";
         modules_to_load[i++] = "DXRMemes";
+        modules_to_load[i++] = "DXREnemies";
         modules_to_load[i++] = "DXREntranceRando";
         modules_to_load[i++] = "DXRHordeMode";
         modules_to_load[i++] = "DXRKillBobPage";

--- a/DeusEx/Classes/DXRando.uc
+++ b/DeusEx/Classes/DXRando.uc
@@ -233,7 +233,11 @@ function RandoEnter()
 
 function int SetSeed(int s)
 {
+    local int oldseed;
+    oldseed = newseed;
+    //log("SetSeed old seed == "$newseed$", new seed == "$s);
     newseed = s;
+    return oldseed;
 }
 
 function int rng(int max)

--- a/DeusEx/Classes/MenuSelectDifficulty.uc
+++ b/DeusEx/Classes/MenuSelectDifficulty.uc
@@ -23,18 +23,32 @@ function BindControls(bool writing, optional string action)
     EnumOption(id, "Horde Mode (Beta)", 2, writing, f.gamemode);
     //EnumOption(id, "Kill Bob Page (Alpha)", 3, writing, f.gamemode);
     //EnumOption(id, "How About Some Soy Food?", 6, writing, f.gamemode);
-    if( EnumOption(id, "Stick With the Prod", 4, writing, f.gamemode) ) {
-        //also set the banneditems setting to 1
-        f.banneditems = 1;
-    }
-    if( EnumOption(id, "Stick With the Prod Plus", 5, writing, f.gamemode) ) {
-        f.banneditems = 2;
-    }
     //EnumOption(id, "Max Rando", 7, writing, f.gamemode);
     id++;
 
     labels[id] = "Difficulty";
     helptexts[id] = "Difficulty determines the default settings for the randomizer.";
+    if( (InStr(f.VersionString(), "Alpha")>=0 || InStr(f.VersionString(), "Beta")>=0) && EnumOption(id, "Super Easy QA", 1, writing) ) {
+        difficulty=0;
+        f.doorsmode = f.keyonlydoors + f.doormutuallyinclusive;
+        f.doorsdestructible = 100;
+        f.doorspickable = 100;
+        f.deviceshackable = 100;
+        f.passwordsrandomized = 100;
+        f.infodevices = 100;
+        f.enemiesrandomized = 20;
+        f.skills_disable_downgrades = 0;
+        f.skills_reroll_missions = 0;
+        f.skills_independent_levels = 0;
+        f.minskill = 0;
+        f.maxskill = 1;
+        f.ammo = 100;
+        f.medkits = 100;
+        f.biocells = f.medkits;
+        f.lockpicks = f.medkits;
+        f.multitools = f.medkits;
+        f.speedlevel = 4;
+    }
     if( EnumOption(id, "Easy", 1, writing) ) {
         difficulty=1;
         f.doorsmode = f.keyonlydoors + f.doormutuallyinclusive;
@@ -126,6 +140,14 @@ function BindControls(bool writing, optional string action)
     EnumOption(id, "Every Entry", 2, writing, f.autosave);
     EnumOption(id, "First Entry", 1, writing, f.autosave);
     EnumOption(id, "Off", 0, writing, f.autosave);
+    id++;
+
+    labels[id] = "";
+    helptexts[id] = "What items are banned";
+    EnumOption(id, "No items banned", 0, writing, f.banneditems);
+    EnumOption(id, "Stick With the Prod", 1, writing, f.banneditems);
+    EnumOption(id, "Stick With the Prod Plus", 2, writing, f.banneditems);
+    //EnumOption(id, "Don't Give Me The GEP Gun", 3, writing, f.banneditems);//maybe I can request these from a function like class'DXRBannedItems'.static.GetBannedItemsDescription()
     id++;
 
     labels[id] = "Seed";

--- a/DeusEx/Classes/MenuSelectDifficulty.uc
+++ b/DeusEx/Classes/MenuSelectDifficulty.uc
@@ -41,6 +41,8 @@ function BindControls(bool writing, optional string action)
         f.doorsdestructible = 100;
         f.doorspickable = 100;
         f.deviceshackable = 100;
+        f.passwordsrandomized = 100;
+        f.infodevices = 100;
         f.enemiesrandomized = 20;
         f.skills_disable_downgrades = 0;
         f.skills_reroll_missions = 0;
@@ -60,6 +62,8 @@ function BindControls(bool writing, optional string action)
         f.doorsdestructible = 50;
         f.doorspickable = 50;
         f.deviceshackable = 100;
+        f.passwordsrandomized = 100;
+        f.infodevices = 100;
         f.enemiesrandomized = 35;
         f.skills_disable_downgrades = 0;
         f.skills_reroll_missions = 0;
@@ -79,6 +83,8 @@ function BindControls(bool writing, optional string action)
         f.doorsdestructible = 25;
         f.doorspickable = 25;
         f.deviceshackable = 50;
+        f.passwordsrandomized = 100;
+        f.infodevices = 100;
         f.enemiesrandomized = 50;
         f.skills_disable_downgrades = 5;
         f.skills_reroll_missions = 5;
@@ -98,6 +104,8 @@ function BindControls(bool writing, optional string action)
         f.doorsdestructible = 25;
         f.doorspickable = 25;
         f.deviceshackable = 50;
+        f.passwordsrandomized = 100;
+        f.infodevices = 100;
         f.enemiesrandomized = 70;
         f.skills_disable_downgrades = 5;
         f.skills_reroll_missions = 5;

--- a/DeusEx/Classes/MenuSelectDifficulty.uc
+++ b/DeusEx/Classes/MenuSelectDifficulty.uc
@@ -51,6 +51,8 @@ function BindControls(bool writing, optional string action)
         f.startinglocations = 100;
         f.goals = 100;
         f.equipment = 5;
+        f.medbots = 100;
+        f.repairbots = 100;
     }
     if( EnumOption(id, "Easy", 1, writing) ) {
         difficulty=1;
@@ -75,6 +77,8 @@ function BindControls(bool writing, optional string action)
         f.startinglocations = 100;
         f.goals = 100;
         f.equipment = 2;
+        f.medbots = 20;
+        f.repairbots = 20;
     }
     if( EnumOption(id, "Normal", 0, writing) ) {
         difficulty=1.25;
@@ -99,6 +103,8 @@ function BindControls(bool writing, optional string action)
         f.startinglocations = 100;
         f.goals = 100;
         f.equipment = 1;
+        f.medbots = 15;
+        f.repairbots = 15;
     }
     if( EnumOption(id, "Hard", 2, writing) ) {
         difficulty=1.5;
@@ -123,6 +129,8 @@ function BindControls(bool writing, optional string action)
         f.startinglocations = 100;
         f.goals = 100;
         f.equipment = 1;
+        f.medbots = 10;
+        f.repairbots = 10;
     }
     if( EnumOption(id, "Extreme", 3, writing) ) {
         difficulty=2;
@@ -147,6 +155,8 @@ function BindControls(bool writing, optional string action)
         f.startinglocations = 100;
         f.goals = 100;
         f.equipment = 1;
+        f.medbots = 5;
+        f.repairbots = 5;
     }
     id++;
 

--- a/DeusEx/Classes/MenuSelectDifficulty.uc
+++ b/DeusEx/Classes/MenuSelectDifficulty.uc
@@ -48,6 +48,9 @@ function BindControls(bool writing, optional string action)
         f.lockpicks = f.medkits;
         f.multitools = f.medkits;
         f.speedlevel = 4;
+        f.startinglocations = 100;
+        f.goals = 100;
+        f.equipment = 5;
     }
     if( EnumOption(id, "Easy", 1, writing) ) {
         difficulty=1;
@@ -69,6 +72,9 @@ function BindControls(bool writing, optional string action)
         f.lockpicks = f.medkits;
         f.multitools = f.medkits;
         f.speedlevel = 2;
+        f.startinglocations = 100;
+        f.goals = 100;
+        f.equipment = 2;
     }
     if( EnumOption(id, "Normal", 0, writing) ) {
         difficulty=1.25;
@@ -90,6 +96,9 @@ function BindControls(bool writing, optional string action)
         f.lockpicks = f.medkits;
         f.multitools = f.medkits;
         f.speedlevel = 1;
+        f.startinglocations = 100;
+        f.goals = 100;
+        f.equipment = 1;
     }
     if( EnumOption(id, "Hard", 2, writing) ) {
         difficulty=1.5;
@@ -111,6 +120,9 @@ function BindControls(bool writing, optional string action)
         f.lockpicks = f.medkits;
         f.multitools = f.medkits;
         f.speedlevel = 1;
+        f.startinglocations = 100;
+        f.goals = 100;
+        f.equipment = 1;
     }
     if( EnumOption(id, "Extreme", 3, writing) ) {
         difficulty=2;
@@ -132,6 +144,9 @@ function BindControls(bool writing, optional string action)
         f.lockpicks = f.medkits;
         f.multitools = f.medkits;
         f.speedlevel = 1;
+        f.startinglocations = 100;
+        f.goals = 100;
+        f.equipment = 1;
     }
     id++;
 

--- a/DeusEx/Classes/MenuSelectDifficulty.uc
+++ b/DeusEx/Classes/MenuSelectDifficulty.uc
@@ -181,7 +181,7 @@ function NewGameSetup(float difficulty)
 
 defaultproperties
 {
-    num_rows=5
+    num_rows=6
     num_cols=2
     col_width_odd=160
     col_width_even=220

--- a/DeusEx/Classes/Weapon.uc
+++ b/DeusEx/Classes/Weapon.uc
@@ -6,8 +6,12 @@ function PostBeginPlay()
     _PostBeginPlay();
 
     foreach AllActors(class'DXRWeapons', m) {
+        if(m.dxr == None) {
+            log("m.dxr == None for "$m$"?");
+            continue;
+        }
         m.RandoWeapon(self);
-        break;
+        return;
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Download the `DeusEx.u` file from the releases page here https://github.com/Die4
 
 Then copy the `DeusEx.u` file into your `Deus Ex\System\` folder, which is probably `C:\Program Files (x86)\Steam\steamapps\common\Deus Ex\System` (make a backup of the original `DeusEx.u`)
 
-### Currently in v1.4.8, DXRando randomizes
+### Currently in v1.4.9, DXRando randomizes
+* locations of goals, NPCs, and some starting locations
+* starting equipment, bioelectric energy, and credits
 * adding and changing characters, giving them random names and making some of them dance
 * changing the locations of items/boxes/NanoKeys around the map
 * passwords and passcodes (they get updated in your Goals/Notes screen)
@@ -36,10 +38,10 @@ There are also settings for
 * autosave
 
 #### When you click New Game, you will see this settings screen:
-![options](https://i.imgur.com/XYOCRo3.png)
+![options](https://i.imgur.com/XjYEPPm.png)
 
 #### If you click Next then it will use default settings based on your difficulty choice. But if you click Advanced then you will see these settings:
-![advanced options](https://i.imgur.com/cNxR0UX.png)
+![advanced options](https://i.imgur.com/Jt1g4Ql.png)
 
 For the randomized passwords, you can copy-paste from the Goals/Notes screen.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Then copy the `DeusEx.u` file into your `Deus Ex\System\` folder, which is proba
 * what augmentations are in each canister
 * the strength and lockpick strength for doors
 * the hack strength for keypads
-* the strength of augmentations, skills
+* the strength of augmentations and skills
 * the damage and firing speed of weapons
 
 There are also settings for

--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ I've also made some balance tweaks. Hacking computers now uses bioelectric energ
 
 Recommended to use it with [Kentie's Deus Exe Launcher](http://www.kentie.net/article/dxguide/), or [Han's Launcher](https://coding.hanfling.de/launch/#binaries). Play with OpenGL renderer because the Direct3D renderers have trouble on newer Nvidia drivers unless you use the Deus Ex Speedup Fix mod. The Deus Ex Speedup Fix mod allows you to disable the fps cap (the fps cap in the game can cause stutters, but capping frame rate in nvidia control panel works perfectly) https://steamcommunity.com/sharedfiles/filedetails/?id=2048525175 If you use that mod, then edit your `Documents\Deus Ex\System\DeusEx.ini` file and search for `FPSLimit=` and set it to 0 to manually remove the fps cap because I've noticed that Kentie's Launcher doesn't always do it correctly. If you use the speedup fix then you'll probably want to use the Direct3D 10 or 11 renderer.
 
-Join the Randomizer Central Discord for discussion https://discord.gg/ybMj3vs or message me directly Die4Ever#6351
+Join the discord channel for discussion https://discord.gg/VHMvqD2v8z or message me directly Die4Ever#6351
 
 If you want to play with the `DXRando.ini` config file (in your `Documents\Deus Ex\System\` folder), then you can look at the [wiki for reference](https://github.com/Die4Ever/deus-ex-randomizer/wiki/DXRando.ini-config)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Then copy the `DeusEx.u` file into your `Deus Ex\System\` folder, which is proba
 
 ### Currently in v1.4.9, DXRando randomizes
 * locations of goals, NPCs, and some starting locations
+* medbots and repair bots
 * starting equipment, bioelectric energy, and credits
 * adding and changing characters, giving them random names and making some of them dance
 * changing the locations of items/boxes/NanoKeys around the map
@@ -38,10 +39,10 @@ There are also settings for
 * autosave
 
 #### When you click New Game, you will see this settings screen:
-![options](https://i.imgur.com/XjYEPPm.png)
+![options](https://i.imgur.com/J6lgK7V.png)
 
 #### If you click Next then it will use default settings based on your difficulty choice. But if you click Advanced then you will see these settings:
-![advanced options](https://i.imgur.com/Jt1g4Ql.png)
+![advanced options](https://i.imgur.com/MzLPXxA.png)
 
 For the randomized passwords, you can copy-paste from the Goals/Notes screen.
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ Then copy the `DeusEx.u` file into your `Deus Ex\System\` folder, which is proba
 * medbots and repair bots
 * starting equipment, bioelectric energy, and credits
 * adding and changing characters, giving them random names and making some of them dance
-* changing the locations of items/boxes/NanoKeys around the map
+* changing the locations of items/boxes/NanoKeys/datacubes around the map
 * passwords and passcodes (they get updated in your Goals/Notes screen)
-* the locations of datacubes
 * exp costs for skills
     * option for rerolling every mission
     * option for disabling the Downgrade button on the new game screen, to prevent looking ahead
@@ -27,10 +26,11 @@ Then copy the `DeusEx.u` file into your `Deus Ex\System\` folder, which is proba
 
 There are also settings for
 * new game modes!
+    * Rearranged Levels is in beta, it changes what level each teleporter takes you to, but keeps it within the same mission.
+    * Horde Mode is in beta and mostly I think it just needs balancing.
+* challenge modes!
     * Stick With the Prod means the only weapon you get is the stun prod (hint: throw a crate straight up into the air to break it)
         * Stick With the Prod Plus also allows EMP grenades, gas grenades, scramble grenades, pepper gun, and tranq darts
-    * Horde Mode is in beta and mostly I think it just needs balancing.
-    * Rearranged Levels is in beta, it changes what level each teleporter takes you to, but keeps it within the same mission.
 * making all or some of the doors that normally require a key also lockpickable and/or destructible
 * making all or some keypads hackable.
 * making enemies respawn

--- a/notes/notes.txt
+++ b/notes/notes.txt
@@ -4,6 +4,129 @@ Needed this to run UnrealEd http://download.microsoft.com/download/vb50pro/utili
 // check a 100 foot radius around me for combat
 if ((npc != None) && (VSize(npc.Location - p.Location) < (1600 + npc.CollisionRadius)))
 
+for v1.6 programatically modify conversations ===================
+
+class DataLinkPlay injects DataLinkPlay;
+
+function PlaySpeech( int soundID )
+{
+    log("PlaySpeech("$soundID$")");
+    Super.PlaySpeech( 1 );
+}
+
+function EEventAction SetupEventSpeech( ConEventSpeech event, out String nextLabel )
+{
+    log("SetupEventSpeech: "$event.conSpeech.speech);
+	event.conSpeech.speech = "Prod with the prod!";
+
+    return Super.SetupEventSpeech(event, nextLabel);
+}
+
+
+//=============================================================================
+// ConWindow
+//
+// Used for non-interactive conversations displayed in first-person
+// mode.  This type of conversation can only display spoken text,
+// choices are -not- allowed.  
+//=============================================================================
+
+class ConWindow extends DeusExBaseWindow;
+
+function DisplayText(string text, Actor speakingActor)
+{
+	if (winSpeech == None ) 
+		CreateSpeechWindow();
+
+	winSpeech.SetSpeech(text, speakingActor);
+}
+
+function AppendText(string text)
+{
+	if (winSpeech == None ) 
+		CreateSpeechWindow();
+
+	winSpeech.AppendSpeech(text);
+}
+
+//=============================================================================
+// ConWindowActive
+//
+// Used for third-person, interactive conversations with the PC involved.
+//=============================================================================
+class ConWindowActive extends ConWindow;
+
+// ----------------------------------------------------------------------
+// DisplayChoice()
+//
+// Displays a choice, but sets up the button a little differently than 
+// when displaying normal conversation text
+// ----------------------------------------------------------------------
+
+function DisplayChoice( ConChoice choice )
+{
+	local ConChoiceWindow newButton;
+
+	newButton = CreateConButton( HALIGN_Left, colConTextChoice, colConTextFocus );
+	newButton.SetText( "~ " $ choice.choiceText );
+	newButton.SetUserObject( choice );
+
+	// These next two calls handle highlighting of the choice
+	newButton.SetButtonTextures(,Texture'Solid', Texture'Solid', Texture'Solid');
+	newButton.SetButtonColors(,colConTextChoice, colConTextChoice, colConTextChoice);
+
+	// Add the button
+	AddButton( newButton );
+}
+
+// ----------------------------------------------------------------------
+// DisplaySkillChoice()
+//
+// Displays a Skilled choice, a choice that's only visible if the user
+// has a particular skill at a certain skill level
+// ----------------------------------------------------------------------
+
+function DisplaySkillChoice( ConChoice choice )
+{
+	local ConChoiceWindow newButton;
+
+	newButton = CreateConButton( HALIGN_Left, colConTextSkill, colConTextFocus );
+	newButton.SetText( 	"~  " $ choice.choiceText $ "  (" $ choice.SkillNeeded $ ":" $ choice.SkillLevelNeeded $ ")" );
+	newButton.SetUserObject( choice );
+
+	// Add the button
+	AddButton( newButton );
+}
+
+class ConWindowSpeech extends AlignWindow;
+
+function SetSpeech(String newSpeech, optional Actor speakingActor)
+{
+	if (newSpeech == "")
+	{
+		txtSpeech.SetText("");
+		txtSpeech.Show(False);
+	}
+	else
+	{
+		txtSpeech.SetText(newSpeech);
+
+		// Use a different color for the player's text
+		if ((speakingActor != None) && (DeusExPlayer(speakingActor) != None))
+			txtSpeech.SetTextColor(colConTextPlayer);
+		else	
+			txtSpeech.SetTextColor(colConTextNormal);
+
+		txtSpeech.Show(True);
+	}
+}
+
+function AppendSpeech(String newSpeech)
+{
+	txtSpeech.AppendText(CR() $ CR() $ newSpeech);
+}
+
+
 for v1.5 ========================
 
 else if (localURL == "10_PARIS_METRO")

--- a/notes/notes.txt
+++ b/notes/notes.txt
@@ -414,6 +414,8 @@ https://docs.unrealengine.com/udk/Two/UnrealScriptReference.html
 
 https://web.archive.org/web/20190407081013/http://www.unrealtexture.com/Unreal/Downloads/3DEditing/UnrealEd/Tutorials/unrealwiki-offline/unrealscript.html
 
+https://web.archive.org/web/20201023054944/http://wiki.beyondunreal.com/Legacy:Compiler_Errors
+
 http://www.unrealtexture.com/Unreal/Downloads/3DEditing/UnrealEd/Tutorials/unrealwiki-offline/unrealscript.html
 
 https://ut99.org/viewtopic.php?t=5985


### PR DESCRIPTION
added DXRMissions for moving goals and starting locations (issues #59 and #86), when swapping items skip self in the loop to keep the count correct

removed Paul from the beginning of the game because he gives you EZ mode weapons

fixes #59 
fixes #86 
fixes #87 
fixes #78 
fixes #93 
fixes #90 
fixes #94 