### PR TITLE
Rounded combat difficulty display

### DIFF
--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -233,7 +233,7 @@ simulated function DisplayRandoInfoMessage(#var(PlayerPawn) p, float CombatDiffi
     if(bSetSeed > 0)
         str = str $ " (Set Seed)";
 
-    str2= "Difficulty: " $ TrimTrailingZeros(CombatDifficulty)
+    str2= "Difficulty: " $ class'DXRInfo'.static.FloatToString(CombatDifficulty, 3)
 #ifdef injections
             $ ", New Game+ Loops: "$newgameplus_loops
 #endif

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -233,7 +233,7 @@ simulated function DisplayRandoInfoMessage(#var(PlayerPawn) p, float CombatDiffi
     if(bSetSeed > 0)
         str = str $ " (Set Seed)";
 
-    str2= "Difficulty: " $ class'DXRInfo'.static.FloatToString(CombatDifficulty, 3)
+    str2= "Difficulty: " $ FloatToString(CombatDifficulty, 3)
 #ifdef injections
             $ ", New Game+ Loops: "$newgameplus_loops
 #endif


### PR DESCRIPTION
Eventually, the digits are just noise.
![image](https://github.com/Die4Ever/deus-ex-randomizer/assets/17994307/008e3f81-51a0-4fe8-836c-ad0a4689137c)

Even three decimals is probably more than necessary, but I like that it better implies that the combat difficulty is being calculated rather than being preset.