### PR TITLE
NSFHQ loop start fixes

### DIFF
--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -248,7 +248,7 @@ function PreFirstEntryMapFixes()
         foreach AllActors(class'#var(prefix)FlagTrigger', ft) {
             if (ft.event == 'MainGates') {
                 // Increase the radius to extend around the corner for NSFHQ starts
-                ft.SetCollisionSize(6600.0, ft.CollisionHeight);
+                ft.SetCollisionSize(7000.0, ft.CollisionHeight);
             }
         }
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -244,6 +244,14 @@ function PreFirstEntryMapFixes()
     case "04_NYC_STREET":
         pg=Spawn(class'#var(prefix)PigeonGenerator',,, vectm(-1849,286,-487));//Near free clinic
         pg.MaxCount=3;
+
+        foreach AllActors(class'#var(prefix)FlagTrigger', ft) {
+            if (ft.event == 'MainGates') {
+                // Increase the radius to extend around the corner for NSFHQ starts
+                ft.SetCollisionSize(6600.0, ft.CollisionHeight);
+            }
+        }
+
         break;
     }
 }

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -427,6 +427,8 @@ static function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase
     switch(start_flag) {
         case 45:
             flagbase.SetBool('PaulInjured_Played',true,,-1);
+            flagbase.SetBool('KnowsSmugglerPassword',true,,-1); // Paul ordinarily tells you the password if you don't know it
+            flagbase.SetBool('GatesOpen',true,,5);
             break;
 
         case 65:


### PR DESCRIPTION
For NSFHQ loop starts:
* Opens the gate to NFSHQ so the player isn't stuck there
* Gives the player the Smuggler password, which Paul would have told them