### PR TITLE
Critters and Innocents and CombatPawns, Oh My

### DIFF
--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -95,23 +95,24 @@ static function bool IsCombatRobot(class<Actor> a)
         !ClassIsChildOf(a, class'#var(prefix)CleanerBot');
 }
 
-// Returns True if the class is an animal that will never fight
-static function bool IsCritter(class<Actor> a)
-{
-    return
-        ClassIsChildOf(a, class'#var(prefix)Animal') &&
-        !ClassIsChildOf(a, class'#var(prefix)Doberman') &&
-        !ClassIsChildOf(a, class'#var(prefix)Gray') &&
-        !ClassIsChildOf(a, class'#var(prefix)Greasel') &&
-        !ClassIsChildOf(a, class'#var(prefix)Karkian');
-}
-
 static function bool IsCombatAnimal(class<Actor> a)
 {
-    return ClassIsChildOf(a, class'#var(prefix)Animal') && !IsCritter(a);
+    return
+        ClassIsChildOf(a, class'#var(prefix)Animal') && (
+            ClassIsChildOf(a, class'#var(prefix)Doberman') ||
+            ClassIsChildOf(a, class'#var(prefix)Gray') ||
+            ClassIsChildOf(a, class'#var(prefix)Greasel') ||
+            ClassIsChildOf(a, class'#var(prefix)Karkian')
+        );
 }
 
-// Returns True if the class will ever fight, even if some instances won't
+// Returns True if the class is an animal that never starts as an enemy
+static function bool IsCritter(class<Actor> a)
+{
+    return ClassIsChildOf(a, class'#var(prefix)Animal') && !IsCombatAnimal(a);
+}
+
+// Returns True if the class ever starts as an enemy, even if some instances don't
 static function bool IsCombatPawn(class<Actor> a)
 {
     return IsHuman(a) || IsCombatRobot(a) || IsCombatAnimal(a);

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -118,6 +118,11 @@ static function bool IsCritter(class<Actor> a)
         );
 }
 
+static function bool IsSwappable(class<Actor> a)
+{
+    return IsCombatActor(a) && !ClassIsChildOf(a, class'Merchant');
+}
+
 function bool IsInitialEnemy(ScriptedPawn p)
 {
     local int i;

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -100,7 +100,7 @@ static function bool IsCritter(class<Actor> a)
 {
     return
         ClassIsChildOf(a, class'#var(prefix)Animal') &&
-        !ClassIsChildOf(a, class'#var(prefix)Dog') &&
+        !ClassIsChildOf(a, class'#var(prefix)Doberman') &&
         !ClassIsChildOf(a, class'#var(prefix)Gray') &&
         !ClassIsChildOf(a, class'#var(prefix)Greasel') &&
         !ClassIsChildOf(a, class'#var(prefix)Karkian');

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -101,7 +101,7 @@ static function bool IsCombatAnimal(class<Actor> a)
 }
 
 // Returns true if the class will ever fight, even if some instances won't
-static function bool IsCombatActor(class<Actor> a)
+static function bool IsCombatPawn(class<Actor> a)
 {
     return IsHuman(a) || IsCombatRobot(a) || IsCombatAnimal(a);
 }
@@ -120,7 +120,7 @@ static function bool IsCritter(class<Actor> a)
 
 static function bool IsSwappable(class<Actor> a)
 {
-    return IsCombatActor(a) && !ClassIsChildOf(a, class'Merchant');
+    return IsCombatPawn(a) && !ClassIsChildOf(a, class'Merchant');
 }
 
 function bool IsInitialEnemy(ScriptedPawn p)

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -118,7 +118,7 @@ static function bool IsCombatPawn(class<Actor> a)
     return IsHuman(a) || IsCombatRobot(a) || IsCombatAnimal(a);
 }
 
-static function bool IsSwappable(class<Actor> a)
+static function bool IsRelevantPawn(class<Actor> a)
 {
     return IsCombatPawn(a) && !ClassIsChildOf(a, class'Merchant');
 }

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -95,27 +95,26 @@ static function bool IsCombatRobot(class<Actor> a)
         !ClassIsChildOf(a, class'#var(prefix)CleanerBot');
 }
 
+// Returns True if the class is an animal that will never fight
+static function bool IsCritter(class<Actor> a)
+{
+    return
+        ClassIsChildOf(a, class'#var(prefix)Animal') &&
+        !ClassIsChildOf(a, class'#var(prefix)Dog') &&
+        !ClassIsChildOf(a, class'#var(prefix)Gray') &&
+        !ClassIsChildOf(a, class'#var(prefix)Greasel') &&
+        !ClassIsChildOf(a, class'#var(prefix)Karkian');
+}
+
 static function bool IsCombatAnimal(class<Actor> a)
 {
     return ClassIsChildOf(a, class'#var(prefix)Animal') && !IsCritter(a);
 }
 
-// Returns true if the class will ever fight, even if some instances won't
+// Returns True if the class will ever fight, even if some instances won't
 static function bool IsCombatPawn(class<Actor> a)
 {
     return IsHuman(a) || IsCombatRobot(a) || IsCombatAnimal(a);
-}
-
-static function bool IsCritter(class<Actor> a)
-{
-    return
-        ClassIsChildOf(a, class'#var(prefix)Animal') &&
-        (
-            !ClassIsChildOf(a, class'#var(prefix)Doberman') &&
-            !ClassIsChildOf(a, class'#var(prefix)Gray') &&
-            !ClassIsChildOf(a, class'#var(prefix)Greasel') &&
-            !ClassIsChildOf(a, class'#var(prefix)Karkian')
-        );
 }
 
 static function bool IsSwappable(class<Actor> a)

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -86,12 +86,36 @@ static function bool IsRobot(class<Actor> a)
     return ClassIsChildOf(a, class'Robot');
 }
 
-static function bool IsCritter(Actor a)
+static function bool IsCombatRobot(class<Actor> a)
 {
-    if( #var(prefix)CleanerBot(a) != None ) return true;
-    if( #var(prefix)MedicalBot(a) != None || #var(prefix)RepairBot(a) != None || Merchant(a) != None ) return true;
-    if( #var(prefix)Animal(a) == None ) return false;
-    return #var(prefix)Doberman(a) == None && #var(prefix)Gray(a) == None && #var(prefix)Greasel(a) == None && #var(prefix)Karkian(a) == None;
+    return
+        IsRobot(a) &&
+        !ClassIsChildOf(a, class'#var(prefix)MedicalBot') &&
+        !ClassIsChildOf(a, class'#var(prefix)RepairBot') &&
+        !ClassIsChildOf(a, class'#var(prefix)CleanerBot');
+}
+
+static function bool IsCombatAnimal(class<Actor> a)
+{
+    return ClassIsChildOf(a, class'#var(prefix)Animal') && !IsCritter(a);
+}
+
+// Returns true if the class will ever fight, even if some instances won't
+static function bool IsCombatActor(class<Actor> a)
+{
+    return IsHuman(a) || IsCombatRobot(a) || IsCombatAnimal(a);
+}
+
+static function bool IsCritter(class<Actor> a)
+{
+    return
+        ClassIsChildOf(a, class'#var(prefix)Animal') &&
+        (
+            !ClassIsChildOf(a, class'#var(prefix)Doberman') &&
+            !ClassIsChildOf(a, class'#var(prefix)Gray') &&
+            !ClassIsChildOf(a, class'#var(prefix)Greasel') &&
+            !ClassIsChildOf(a, class'#var(prefix)Karkian')
+        );
 }
 
 function bool IsInitialEnemy(ScriptedPawn p)

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -401,7 +401,7 @@ function NYC_04_CheckPaulRaid()
 
     foreach AllActors(class'ScriptedPawn', p) {
         if( PaulDenton(p) != None ) continue;
-        if( !IsSwappable(p.class) ) continue;
+        if( !IsRelevantPawn(p.class) ) continue;
         if( p.bHidden ) continue;
         if( p.GetAllianceType('Player') != ALLIANCE_Hostile ) continue;
         p.bStasis = false;

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -401,7 +401,8 @@ function NYC_04_CheckPaulRaid()
 
     foreach AllActors(class'ScriptedPawn', p) {
         if( PaulDenton(p) != None ) continue;
-        if( IsCritter(p) ) continue;
+        if( !IsCombatActor(p.class) ) continue;
+        if( Merchant(p) != None) continue;
         if( p.bHidden ) continue;
         if( p.GetAllianceType('Player') != ALLIANCE_Hostile ) continue;
         p.bStasis = false;

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -401,8 +401,7 @@ function NYC_04_CheckPaulRaid()
 
     foreach AllActors(class'ScriptedPawn', p) {
         if( PaulDenton(p) != None ) continue;
-        if( !IsCombatActor(p.class) ) continue;
-        if( Merchant(p) != None) continue;
+        if( !IsSwappable(p.class) ) continue;
         if( p.bHidden ) continue;
         if( p.GetAllianceType('Player') != ALLIANCE_Hostile ) continue;
         p.bStasis = false;

--- a/DXRModules/DeusEx/Classes/DXREnemies.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemies.uc
@@ -205,7 +205,7 @@ function RandoEnemies(int percent, int hidden_percent)
             RandomizeSize(p);
         }
 
-        if( !IsCombatActor(p.class) || Merchant(p) != None ) continue;
+        if( !IsSwappable(p.class) ) continue;
         if( HasItemSubclass(p, class'Weapon') == false ) continue;//don't randomize neutral npcs that don't already have weapons
 
         enemies[num_enemies++] = p;

--- a/DXRModules/DeusEx/Classes/DXREnemies.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemies.uc
@@ -205,7 +205,7 @@ function RandoEnemies(int percent, int hidden_percent)
             RandomizeSize(p);
         }
 
-        if( IsCritter(p) ) continue;
+        if( !IsCombatActor(p.class) || Merchant(p) != None ) continue;
         if( HasItemSubclass(p, class'Weapon') == false ) continue;//don't randomize neutral npcs that don't already have weapons
 
         enemies[num_enemies++] = p;
@@ -283,7 +283,7 @@ function RandomizeSP(ScriptedPawn p, int percent)
         p.RaiseAlarm = RAISEALARM_BeforeFleeing;
     }
 
-    if( IsCritter(p) ) return; // only give random weapons to humans and robots
+    if( !IsHuman(p.class) && !IsCombatRobot(p.class) ) return; // only give random weapons to humans and robots
     // TODO: if p.bIsFemale then give only 1 handed weapons?
     if( p.IsA('MJ12Commando') || p.IsA('WIB') ) return;
 

--- a/DXRModules/DeusEx/Classes/DXREnemies.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemies.uc
@@ -205,7 +205,7 @@ function RandoEnemies(int percent, int hidden_percent)
             RandomizeSize(p);
         }
 
-        if( !IsSwappable(p.class) ) continue;
+        if( !IsRelevantPawn(p.class) ) continue;
         if( HasItemSubclass(p, class'Weapon') == false ) continue;//don't randomize neutral npcs that don't already have weapons
 
         enemies[num_enemies++] = p;

--- a/DXRModules/DeusEx/Classes/DXREnemies.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemies.uc
@@ -285,7 +285,7 @@ function RandomizeSP(ScriptedPawn p, int percent)
 
     if( !IsHuman(p.class) && !IsCombatRobot(p.class) ) return; // only give random weapons to humans and robots
     // TODO: if p.bIsFemale then give only 1 handed weapons?
-    if( p.IsA('MJ12Commando') || p.IsA('WIB') ) return;
+    if( p.IsA('MJ12Commando') || (!#defined(injections) && p.IsA('WIB')) ) return;
 
     if( IsHuman(p.class)) {
         if(!p.bImportant) {

--- a/DXRModules/DeusEx/Classes/DXREnemiesShuffle.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemiesShuffle.uc
@@ -115,7 +115,7 @@ function SwapScriptedPawns(int percent, bool enemies)
     {
         if( a.bHidden || a.bStatic ) continue;
         if( a.bImportant || a.bIsSecretGoal ) continue;
-        if( !IsSwappable(a.class) ) continue;
+        if( !IsRelevantPawn(a.class) ) continue;
         if( IsInitialEnemy(a) != enemies ) continue;
         if( !chance_single(percent) ) continue;
         if( a.Region.Zone.bWaterZone || a.Region.Zone.bPainZone ) continue;

--- a/DXRModules/DeusEx/Classes/DXREnemiesShuffle.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemiesShuffle.uc
@@ -115,7 +115,8 @@ function SwapScriptedPawns(int percent, bool enemies)
     {
         if( a.bHidden || a.bStatic ) continue;
         if( a.bImportant || a.bIsSecretGoal ) continue;
-        if( IsCritter(a) ) continue;
+        if( !IsCombatActor(a.class) ) continue;
+        if( Merchant(a) != None ) continue;
         if( IsInitialEnemy(a) != enemies ) continue;
         if( !chance_single(percent) ) continue;
         if( a.Region.Zone.bWaterZone || a.Region.Zone.bPainZone ) continue;

--- a/DXRModules/DeusEx/Classes/DXREnemiesShuffle.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemiesShuffle.uc
@@ -115,8 +115,7 @@ function SwapScriptedPawns(int percent, bool enemies)
     {
         if( a.bHidden || a.bStatic ) continue;
         if( a.bImportant || a.bIsSecretGoal ) continue;
-        if( !IsCombatActor(a.class) ) continue;
-        if( Merchant(a) != None ) continue;
+        if( !IsSwappable(a.class) ) continue;
         if( IsInitialEnemy(a) != enemies ) continue;
         if( !chance_single(percent) ) continue;
         if( a.Region.Zone.bWaterZone || a.Region.Zone.bPainZone ) continue;

--- a/DXRModules/DeusEx/Classes/DXREnemyRespawn.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemyRespawn.uc
@@ -51,7 +51,7 @@ function PostFirstEntry()
 function SaveRespawn(ScriptedPawn p, out int i)
 {
     local int a;
-    if( !IsSwappable(p.class) ) return;
+    if( !IsRelevantPawn(p.class) ) return;
     if( p.bImportant || p.bInvincible || p.bHidden ) return;
 #ifdef gmdx
     if( SpiderBot2(p) != None && SpiderBot2(p).bUpsideDown ) return;

--- a/DXRModules/DeusEx/Classes/DXREnemyRespawn.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemyRespawn.uc
@@ -51,7 +51,7 @@ function PostFirstEntry()
 function SaveRespawn(ScriptedPawn p, out int i)
 {
     local int a;
-    if( IsCritter(p) ) return;
+    if( IsCritter(p.class) ) return;
     if( p.bImportant || p.bInvincible || p.bHidden ) return;
 #ifdef gmdx
     if( SpiderBot2(p) != None && SpiderBot2(p).bUpsideDown ) return;

--- a/DXRModules/DeusEx/Classes/DXREnemyRespawn.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemyRespawn.uc
@@ -51,7 +51,7 @@ function PostFirstEntry()
 function SaveRespawn(ScriptedPawn p, out int i)
 {
     local int a;
-    if( IsCritter(p.class) ) return;
+    if( !IsSwappable(p.class) ) return;
     if( p.bImportant || p.bInvincible || p.bHidden ) return;
 #ifdef gmdx
     if( SpiderBot2(p) != None && SpiderBot2(p).bUpsideDown ) return;

--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -669,9 +669,9 @@ function _AddPawnDeath(ScriptedPawn victim, optional Actor Killer, optional coer
 
             //Were they an ally?  Skip on NSF HQ, because that's kind of a bait
             if (
-                    !isInitialPlayerEnemy(victim) && //Must have not been an enemy initially
-                    IsHuman(victim.class) && //There's no such thing as an innocent Cat
-                    ( dxr.localURL!="04_NYC_NSFHQ" || dxr.flagbase.GetBool('NSFSignalSent')==False ) //Not on the NSF HQ map, or if it is, before you send the signal (kludgy)
+                !isInitialPlayerEnemy(victim) && //Must have not been an enemy initially
+                IsHuman(victim.class) && //There's no such thing as an innocent Cat
+                ( dxr.localURL!="04_NYC_NSFHQ" || dxr.flagbase.GetBool('NSFSignalSent')==False ) //Not on the NSF HQ map, or if it is, before you send the signal (kludgy)
             ) {
                 _MarkBingo("AlliesKilled");
             }

--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -668,12 +668,20 @@ function _AddPawnDeath(ScriptedPawn victim, optional Actor Killer, optional coer
             class'DXRStats'.static.AddKill(player());
 
             //Were they an ally?  Skip on NSF HQ, because that's kind of a bait
-            if (!isInitialPlayerEnemy(victim) && !IsCritter(victim) &&  //Must have not been an enemy initially
-                 (dxr.localURL!="04_NYC_NSFHQ" || (dxr.localURL=="04_NYC_NSFHQ" && dxr.flagbase.GetBool('DL_SimonsPissed_Played')==False)) //Not on the NSF HQ map, or if it is, before you send the signal (kludgy)
-                 ){
+            if (
+                    !isInitialPlayerEnemy(victim) &&  //Must have not been an enemy initially
+                    IsHuman(victim.class) && //There's no such thing as an innocent Cat
+                    (
+                        //Not on the NSF HQ map, or if it is, before you send the signal (kludgy)
+                        dxr.localURL!="04_NYC_NSFHQ" ||
+                        (
+                            dxr.localURL=="04_NYC_NSFHQ" &&
+                            dxr.flagbase.GetBool('DL_SimonsPissed_Played')==False
+                        )
+                    )
+                ) {
                 _MarkBingo("AlliesKilled");
             }
-
         }
         if (damageType=="stomped" && IsHuman(victim.class)){ //If you stomp a human to death...
             _MarkBingo("HumanStompDeath");

--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -671,7 +671,7 @@ function _AddPawnDeath(ScriptedPawn victim, optional Actor Killer, optional coer
             if (
                     !isInitialPlayerEnemy(victim) && //Must have not been an enemy initially
                     IsHuman(victim.class) && //There's no such thing as an innocent Cat
-                    ( dxr.localURL!="04_NYC_NSFHQ" || dxr.flagbase.GetBool('DL_SimonsPissed_Played')==False ) //Not on the NSF HQ map, or if it is, before you send the signal (kludgy)
+                    ( dxr.localURL!="04_NYC_NSFHQ" || dxr.flagbase.GetBool('NSFSignalSent')==False ) //Not on the NSF HQ map, or if it is, before you send the signal (kludgy)
             ) {
                 _MarkBingo("AlliesKilled");
             }

--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -669,17 +669,10 @@ function _AddPawnDeath(ScriptedPawn victim, optional Actor Killer, optional coer
 
             //Were they an ally?  Skip on NSF HQ, because that's kind of a bait
             if (
-                    !isInitialPlayerEnemy(victim) &&  //Must have not been an enemy initially
+                    !isInitialPlayerEnemy(victim) && //Must have not been an enemy initially
                     IsHuman(victim.class) && //There's no such thing as an innocent Cat
-                    (
-                        //Not on the NSF HQ map, or if it is, before you send the signal (kludgy)
-                        dxr.localURL!="04_NYC_NSFHQ" ||
-                        (
-                            dxr.localURL=="04_NYC_NSFHQ" &&
-                            dxr.flagbase.GetBool('DL_SimonsPissed_Played')==False
-                        )
-                    )
-                ) {
+                    ( dxr.localURL!="04_NYC_NSFHQ" || dxr.flagbase.GetBool('DL_SimonsPissed_Played')==False ) //Not on the NSF HQ map, or if it is, before you send the signal (kludgy)
+            ) {
                 _MarkBingo("AlliesKilled");
             }
         }

--- a/DXRando/DeusEx/Classes/DXRandoCrowdControlEffects.uc
+++ b/DXRando/DeusEx/Classes/DXRandoCrowdControlEffects.uc
@@ -1555,7 +1555,7 @@ function bool CanSwapEnemies()
     {
         if( a.bHidden || a.bStatic ) continue;
         if( a.bImportant || a.bIsSecretGoal ) continue;
-        if( ccLink.ccModule.IsCritter(a) ) continue;
+        if( !ccLink.ccModule.IsSwappable(a.class) ) continue;
         if( !ccLink.ccModule.IsInitialEnemy(a) ) continue;
         if( a.Region.Zone.bWaterZone || a.Region.Zone.bPainZone ) continue;
         if( #var(prefix)Robot(a) != None && a.Orders == 'Idle' ) continue;

--- a/DXRando/DeusEx/Classes/DXRandoCrowdControlEffects.uc
+++ b/DXRando/DeusEx/Classes/DXRandoCrowdControlEffects.uc
@@ -1555,7 +1555,7 @@ function bool CanSwapEnemies()
     {
         if( a.bHidden || a.bStatic ) continue;
         if( a.bImportant || a.bIsSecretGoal ) continue;
-        if( !ccLink.ccModule.IsSwappable(a.class) ) continue;
+        if( !ccLink.ccModule.IsRelevantPawn(a.class) ) continue;
         if( !ccLink.ccModule.IsInitialEnemy(a) ) continue;
         if( a.Region.Zone.bWaterZone || a.Region.Zone.bPainZone ) continue;
         if( #var(prefix)Robot(a) != None && a.Orders == 'Idle' ) continue;


### PR DESCRIPTION
* Makes `IsCritter` only return `True` for Animal classes that never start as an enemy
* Adds several new `Is[thing]` functions
* Fixes the "Kill [N] Innocents" bingo goal so that it counts for any friendly human, and nothing else
  * Makes it so that UNATCO troops immediately don't count for the innocents goal after sending the distress signal
* Allows WIBs to have their weapons swapped