### PR TITLE
Make 'Ton hotel junkie names consistent

### DIFF
--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
@@ -22,6 +22,9 @@ function PreFirstEntryMapFixes()
     local #var(prefix)Button1 button;
     local bool RevisionMaps;
     local bool VanillaMaps;
+    local #var(DeusExPrefix)Carcass dead;
+    local HumanCivilian hc;
+    local int oldSeed;
 
 #ifdef injections
     local #var(prefix)Newspaper np;
@@ -159,6 +162,32 @@ function PreFirstEntryMapFixes()
             Spawn(class'PlaceholderItem',,, vectm(15,-2972,123)); //Kitchen counter
             Spawn(class'PlaceholderItem',,, vectm(-853,-3148,75)); //Crack next to Paul's bed
         }
+
+        oldSeed = SetGlobalSeed("'Ton Hotel Junkie Names " $ dxr.seed);
+        foreach AllActors(class'#var(DeusExPrefix)Carcass', dead) {
+            if (dead.Name == 'JunkieFemaleCarcass0') {
+                if (class'DXRMenuScreenNewGame'.static.HasLDDPInstalled()) {
+                    dead.itemName = "Dead Body (Jenna)";
+                } else {
+                    dead.itemName = "Dead Body (" $ class'DXRNames'.static.RandomName(dxr) $ ")";
+                }
+            } else if (dead.Name == 'JunkieMaleCarcass0') {
+                if (class'DXRMenuScreenNewGame'.static.HasLDDPInstalled()) {
+                    dead.itemName = "Dead Body (Kyle)";
+                } else {
+                    dead.itemName = "Dead Body (" $ class'DXRNames'.static.RandomName(dxr) $ ")";
+                }
+            }
+        }
+        foreach AllActors(class'HumanCivilian', hc) {
+            if (hc.Name == 'LDDPHotelAddict0') {
+                hc.FamiliarName = class'DXRNames'.static.RandomName(dxr);
+                hc.UnfamiliarName = hc.FamiliarName;
+                hc.bImportant = true;
+            }
+        }
+        SetGlobalSeed(oldSeed);
+
         break;
 
     case "02_NYC_STREET":

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -48,7 +48,9 @@ function PreFirstEntryMapFixes()
     local DXRHoverHint hoverHint;
     local DXRMapVariants mapvariants;
     local bool VanillaMaps;
+    local #var(DeusExPrefix)Carcass dead;
     local #var(prefix)HumanCivilian hc;
+    local int oldSeed;
 
     VanillaMaps = class'DXRMapVariants'.static.IsVanillaMaps(player());
 
@@ -100,6 +102,27 @@ function PreFirstEntryMapFixes()
             Spawn(class'PlaceholderItem',,, vectm(15,-2972,123)); //Kitchen counter
             Spawn(class'PlaceholderItem',,, vectm(-853,-3148,75)); //Crack next to Paul's bed
         }
+
+        oldSeed = SetGlobalSeed("'Ton Hotel Junkie Names " $ dxr.seed);
+        foreach AllActors(class'#var(DeusExPrefix)Carcass', dead) {
+            if (dead.Name == 'JunkieFemaleCarcass0') {
+                if (class'DXRMenuScreenNewGame'.static.HasLDDPInstalled()) {
+                    dead.itemName = "Dead Body (Jenna)";
+                } else {
+                    dead.itemName = "Dead Body (" $ class'DXRNames'.static.RandomName(dxr) $ ")";
+                }
+            } else if (dead.Name == 'JunkieMaleCarcass0') {
+                if (class'DXRMenuScreenNewGame'.static.HasLDDPInstalled()) {
+                    dead.itemName = "Dead Body (Kyle)";
+                } else {
+                    dead.itemName = "Dead Body (" $ class'DXRNames'.static.RandomName(dxr) $ ")";
+                }
+            } else if (dead.Name == 'LDDPHotelAddictCarcass0') {
+                dead.itemName = "Dead Body (" $ class'DXRNames'.static.RandomName(dxr) $ ")";
+            }
+        }
+        oldseed = SetGlobalSeed(oldSeed);
+
         break;
 
     case "04_NYC_NSFHQ":


### PR DESCRIPTION
Makes 'Ton hotel junkie names consistent across M02 and M04.

If LDDP is not installed, the dead junkies will have the same randomized names in both missions. If LDDP is installed, the new junkie will have the same randomized name on both maps and the two original dead junkies will be named "Jenna" and "Kyle", which is what he tells us their names are.