### PR TITLE
v2.6.2 Beta

### DIFF
--- a/DXRBalance/DeusEx/Classes/AugAqualung.uc
+++ b/DXRBalance/DeusEx/Classes/AugAqualung.uc
@@ -7,13 +7,6 @@ function PostPostBeginPlay()
     Description = default.Description;
 }
 
-simulated function SetAutomatic()
-{
-    Super.SetAutomatic();
-    // aqualung doesn't take the penalty for being automatic, this one is just a gift
-    energyRate = default.energyRate;
-}
-
 simulated function bool IsTicked()
 {// aqualung is perfectly automatic
     local bool bWater;
@@ -28,6 +21,8 @@ simulated function bool IsTicked()
 defaultproperties
 {
     bAutomatic=true
+    AutoLength=0
+    AutoEnergyMult=1// no penalty, it's a gift
     MaxLevel=1
     Description="Soda lime exostructures imbedded in the alveoli of the lungs convert CO2 to O2, extending the time an agent can remain underwater.|n|nTECH ONE: Lung capacity is extended moderately.|n|nTECH TWO: An agent can stay underwater indefinitely."
     LevelValues(0)=60.000000

--- a/DXRBalance/DeusEx/Classes/AugCombat.uc
+++ b/DXRBalance/DeusEx/Classes/AugCombat.uc
@@ -26,5 +26,5 @@ simulated function TickUse()
 defaultproperties
 {
     bAutomatic=true
-    AutoLength=2.25// combat aug specifically makes sense to only use energy while active? a little extra so it doesn't fall in between ticks?
+    AutoLength=2.2// combat aug specifically makes sense to only use energy while active? a little extra so it doesn't fall in between ticks?
 }

--- a/DXRBalance/DeusEx/Classes/AugDisplayWindow.uc
+++ b/DXRBalance/DeusEx/Classes/AugDisplayWindow.uc
@@ -308,7 +308,7 @@ function DrawTargetAugmentation(GC gc)
 
     // check 500 feet in front of the player
     target = TraceHoverHint(8000);
-    if(class'MenuChoice_ShowTeleporters'.default.show_teleporters > 1) {
+    if(class'MenuChoice_ShowTeleporters'.default.value > 1) {
 	    tgtTeleporter = #var(prefix)Teleporter(target);
     }
 

--- a/DXRBalance/DeusEx/Classes/AugDisplayWindow.uc
+++ b/DXRBalance/DeusEx/Classes/AugDisplayWindow.uc
@@ -308,8 +308,8 @@ function DrawTargetAugmentation(GC gc)
 
     // check 500 feet in front of the player
     target = TraceHoverHint(8000);
-    if(class'MenuChoice_ShowTeleporters'.default.value > 1) {
-	    tgtTeleporter = #var(prefix)Teleporter(target);
+    if(class'MenuChoice_ShowTeleporters'.static.ShowDescriptions(class'DXRando'.default.dxr.flags.IsReducedRando())) {
+        tgtTeleporter = #var(prefix)Teleporter(target);
     }
 
     // display teleporter destinations

--- a/DXRBalance/DeusEx/Classes/AugHeartLung.uc
+++ b/DXRBalance/DeusEx/Classes/AugHeartLung.uc
@@ -3,4 +3,6 @@ class DXRAugHeartLung injects AugHeartLung;
 defaultproperties
 {
     bAutomatic=true
+    AutoLength=1.2
+    AutoEnergyMult=1
 }

--- a/DXRCore/DeusEx/Classes/DXRBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRBase.uc
@@ -288,6 +288,14 @@ simulated function bool RandoLevelValues(Actor a, float min, float max, float we
 
     s = "(DXRando) " $ word $ ":|n    " $ s;
 
+#ifdef injections
+    if(aug != None && aug.bAutomatic) {
+        s = s $ "|n|nThis aug is automatic";
+        if(aug.AutoLength>0.1) s = s $ ", with a linger time of " $ TrimTrailingZeros(aug.AutoLength) $ " seconds";
+        s = s $ ".";
+    }
+#endif
+
     l("RandoLevelValues "$a$" = "$s);
     ReapplySeed( oldseed );
 

--- a/DXRCore/DeusEx/Classes/DXRando.uc
+++ b/DXRCore/DeusEx/Classes/DXRando.uc
@@ -12,6 +12,7 @@ var int seed, tseed;
 
 var transient private int CrcTable[256]; // for string hashing to do more stable seeding
 
+var DXRando dxr;// singleton reference in default
 var transient DXRBase modules[48];
 var transient int num_modules;
 
@@ -112,6 +113,11 @@ function DXRInit()
     flags.InitCoordsMult();// for some reason flags is loaded too early and doesn't have the new map url
     flags.LoadFlags();
     LoadModules();
+    if(default.dxr != None) {
+        err("overwriting singleton " $ default.dxr $ " with " $ self);
+    }
+    dxr = self;
+    default.dxr = self;// singleton reference
     RandoEnter();
 }
 

--- a/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
+++ b/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
@@ -46,9 +46,9 @@ function ThrowInventory(bool gibbed)
         if( Ammo(item) != None )
             drop = false;
         if( drop ) {
-            class'DXRActorsBase'.static.ThrowItem(item, 1.0);
+            class'DXRActorsBase'.static.ThrowItem(item, 0.3);
             if(gibbed)
-                item.Velocity *= vect(-2, -2, 2);
+                item.Velocity *= vect(-10, -10, 10);
             else
                 item.Velocity *= vect(-1.5, -1.5, 1.5);
         }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -249,6 +249,10 @@ function PreFirstEntryMapFixes()
             hc.bImportant = true;
         }
 
+        if(IsAprilFools()) {
+            Spawnm(class'MahoganyDesk',,, vect(646.848999, 1524.899902, 263.097137), rot(0, -16384, 0));
+        }
+
         break;
 
     case "04_NYC_BATTERYPARK":

--- a/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
@@ -169,5 +169,9 @@ function AfterMoveGoalToLocation(Goal g, GoalLocation Loc)
             $ "|nIf you get really stuck then click on Show Spoilers, Show Nanokeys, or Show Datacubes.";
 
         SpawnDatacubePlaintext(vectm(2801.546387, 171.028091, 2545.382813), rotm(0,0,0), text, true);
+
+        if(ScriptedPawn(g.actors[0].a) != None) {
+            RemoveFears(ScriptedPawn(g.actors[0].a));
+        }
     }
 }

--- a/DXRMissions/DeusEx/Classes/DXRMissionsM06.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsM06.uc
@@ -273,10 +273,6 @@ function AfterMoveGoalToLocation(Goal g, GoalLocation Loc)
 
     if (Loc.name == "Overlook Office") {
         // spawn the MAHOGANY desk (CreateGoal only gets called for different maps)
-        g.actors[1].a = Spawnm(class'#var(prefix)WHDeskOvalOffice',,,Loc.positions[1].pos, Loc.positions[1].rot);
-        if(g.actors[1].a != None) {
-            #var(prefix)WHDeskOvalOffice(g.actors[1].a).ItemName = "Mahogany Desk";
-            #var(prefix)WHDeskOvalOffice(g.actors[1].a).HitPoints *= 4;
-        }
+        g.actors[1].a = Spawnm(class'MahoganyDesk',,,Loc.positions[1].pos, Loc.positions[1].rot);
     }
 }

--- a/DXRMissions/DeusEx/Classes/DXRMissionsM09.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsM09.uc
@@ -334,11 +334,7 @@ function AfterMoveGoalToLocation(Goal g, GoalLocation Loc)
 
     if (g.name=="Bilge Pump Computer" && Loc.name=="Helipad Air Control") {
         // spawn the MAHOGANY desk (CreateGoal only gets called for different maps)
-        g.actors[1].a = Spawnm(class'#var(prefix)WHDeskOvalOffice',,,Loc.positions[1].pos, Loc.positions[1].rot);
-        if(g.actors[1].a != None) {
-            #var(prefix)WHDeskOvalOffice(g.actors[1].a).ItemName = "Mahogany Desk";
-            #var(prefix)WHDeskOvalOffice(g.actors[1].a).HitPoints *= 4;
-        }
+        g.actors[1].a = Spawnm(class'MahoganyDesk',,,Loc.positions[1].pos, Loc.positions[1].rot);
     }
 }
 

--- a/DXRModules/DeusEx/Classes/DXRAugmentations.uc
+++ b/DXRModules/DeusEx/Classes/DXRAugmentations.uc
@@ -329,15 +329,18 @@ simulated function RandoAug(Augmentation a)
         a.Description = add_desc $ "|n|n" $ a.Description;
     }
 
-    if( #var(prefix)AugSpeed(a) != None || #var(prefix)AugLight(a) != None || #var(prefix)AugHeartLung(a) != None
+    if( #var(prefix)AugSpeed(a) != None || #var(prefix)AugLight(a) != None
     || #var(prefix)AugIFF(a) != None || #var(prefix)AugDatalink(a) != None || AugNinja(a) != None )
         return;
 
     aug_value_wet_dry = float(dxr.flags.settings.aug_value_rando) / 100.0;
-    if((#var(prefix)AugVision(a) != None || #var(prefix)AugMuscle(a) != None) && aug_value_wet_dry > 0) {
+    if(( aug_value_wet_dry > 0
+        && ( #var(prefix)AugVision(a) != None || #var(prefix)AugMuscle(a) != None) || #var(prefix)AugHeartLung(a) != None )
+    ) {
         // don't randomize vision aug strength and instead randomize its energy usage
         // so it can be used for speedrun strategies with specific spots to check from
         // aug muscle picking up heavy items is confusing when the strength is randomized, just randomize the energy cost
+        // synth heart, can't randomize its strength, just randomize energy cost
         a.energyRate = int(rngrange(a.default.energyRate, 0.5, 1.5));
         aug_value_wet_dry = 0;
         add_desc = add_desc $ "Energy Rate: "$int(a.energyRate)$" Units/Minute";

--- a/DXRModules/DeusEx/Classes/DXRAutosave.uc
+++ b/DXRModules/DeusEx/Classes/DXRAutosave.uc
@@ -22,7 +22,7 @@ function CheckConfig()
         save_delay = 0.1;
     }
     Super.CheckConfig();
-    autosave_combat = class'MenuChoice_AutosaveCombat'.default.autosave_combat;
+    autosave_combat = class'MenuChoice_AutosaveCombat'.default.value;
 }
 
 function BeginPlay()

--- a/DXRModules/DeusEx/Classes/DXRCameraModes.uc
+++ b/DXRModules/DeusEx/Classes/DXRCameraModes.uc
@@ -1,4 +1,4 @@
-class DXRCameraModes expands DXRActorsBase;
+class DXRCameraModes expands DXRActorsBase transient;
 
 var int tempCameraMode;
 var CCResidentEvilCam reCam;
@@ -121,15 +121,18 @@ function SetCameraMode(int mode)
 {
     local name stateName;
 
-    //player().ClientMessage("tempCameraMode: "$tempCameraMode$"   mode being set: "$mode);
-
     if (player()!=None){
         stateName = player().GetStateName();
 
         //These are the possible states when you're in a cutscene
         if (stateName=='Interpolating' || stateName=='Paralyzed'){
             mode = CM_FirstPerson; //Leave it in first person
+        } else if (stateName=='Dying') {
+            return; // setting camera mode while dying causes your weapon and hand to show after dying
         }
+    } else {
+        err("SetCameraMode no player");
+        return;
     }
 
     switch(mode){

--- a/DXRModules/DeusEx/Classes/DXRDatacubes.uc
+++ b/DXRModules/DeusEx/Classes/DXRDatacubes.uc
@@ -1,15 +1,14 @@
 class DXRDatacubes extends DXRPasswordsBase abstract;
 
 var safe_rule datacubes_rules[16];
-var config float min_hack_adjust, max_hack_adjust;
+var float min_hack_adjust, max_hack_adjust;
 
 function CheckConfig()
 {
     local int i;
-    if( ConfigOlderThan(2,3,4,3) ) {
-        min_hack_adjust = 0.5;
-        max_hack_adjust = 1.5;
-    }
+    min_hack_adjust = 0.4;
+    max_hack_adjust = 1.5;
+
     if(class'DXRMapVariants'.static.IsRevisionMaps(player()))
         revision_datacubes_rules();
     else
@@ -559,8 +558,8 @@ function RandoHacks()
 function _RandoHackable(#var(prefix)HackableDevices h)
 {
     if( h.bHackable ) {
-        h.hackStrength = FClamp(rngrange(h.hackStrength, min_hack_adjust, max_hack_adjust), 0, 1);
-        h.hackStrength = int(h.hackStrength*100)/100.0;
+        h.hackStrength = rngrange(h.hackStrength, min_hack_adjust, max_hack_adjust);
+        h.hackStrength = Clamp(h.hackStrength*100, 1, 100)/100.0;
         h.initialhackStrength = h.hackStrength;
     }
 }
@@ -653,8 +652,8 @@ function MakeAllHackable(int deviceshackable)
         if( h.bHackable == false && chance_single(deviceshackable) ) {
             l("found unhackable device: " $ ActorToString(h) $ ", tag: " $ h.Tag $ " in " $ dxr.localURL);
             h.bHackable = true;
-            h.hackStrength = FClamp(rngrange(1, min_hack_adjust, max_hack_adjust), 0, 1);
-            h.hackStrength = int(h.hackStrength*100)/100.0;
+            h.hackStrength = rngrange(1, min_hack_adjust, max_hack_adjust);
+            h.hackStrength = Clamp(h.hackStrength*100, 1, 100) / 100.0;
             h.initialhackStrength = h.hackStrength;
         }
 

--- a/DXRModules/DeusEx/Classes/DXRDatacubes.uc
+++ b/DXRModules/DeusEx/Classes/DXRDatacubes.uc
@@ -557,7 +557,7 @@ function RandoHacks()
 
 function _RandoHackable(#var(prefix)HackableDevices h)
 {
-    if( h.bHackable ) {
+    if( h.bHackable && h.hackStrength>0 ) {
         h.hackStrength = rngrange(h.hackStrength, min_hack_adjust, max_hack_adjust);
         h.hackStrength = Clamp(h.hackStrength*100, 1, 100)/100.0;
         h.initialhackStrength = h.hackStrength;

--- a/DXRModules/DeusEx/Classes/DXRDoors.uc
+++ b/DXRModules/DeusEx/Classes/DXRDoors.uc
@@ -251,7 +251,7 @@ function RandomizeDoors()
         if(d.minDamageThreshold <= 5)
             d.minDamageThreshold = 0;
 
-        if( d.bPickable ) {
+        if( d.bPickable && d.lockStrength>0 ) {
             d.lockStrength = rngrange(d.lockStrength, min_lock_adjust, max_lock_adjust);
             d.lockStrength = Clamp(d.lockStrength*100, 1, 100)/100.0;
             d.initiallockStrength = d.lockStrength;

--- a/DXRModules/DeusEx/Classes/DXRDoors.uc
+++ b/DXRModules/DeusEx/Classes/DXRDoors.uc
@@ -205,11 +205,11 @@ function CheckConfig()
         break;
     }
 
-    min_lock_adjust=0.5;
+    min_lock_adjust=0.4;
     max_lock_adjust=1.5;
-    min_door_adjust=0.5;
+    min_door_adjust=0.4;
     max_door_adjust=1.5;
-    min_mindmg_adjust=0.35;
+    min_mindmg_adjust=0.3;
     max_mindmg_adjust=1.2;
 
     Super.CheckConfig();
@@ -252,13 +252,13 @@ function RandomizeDoors()
             d.minDamageThreshold = 0;
 
         if( d.bPickable ) {
-            d.lockStrength = FClamp(rngrange(d.lockStrength, min_lock_adjust, max_lock_adjust), 0, 1);
-            d.lockStrength = int(d.lockStrength*100)/100.0;
+            d.lockStrength = rngrange(d.lockStrength, min_lock_adjust, max_lock_adjust);
+            d.lockStrength = Clamp(d.lockStrength*100, 1, 100)/100.0;
             d.initiallockStrength = d.lockStrength;
         }
         if( d.bBreakable ) {
-            d.doorStrength = FClamp(rngrange(d.doorStrength, min_door_adjust, max_door_adjust), 0, 1);
-            d.doorStrength = int(d.doorStrength*100)/100.0;
+            d.doorStrength = rngrange(d.doorStrength, min_door_adjust, max_door_adjust);
+            d.doorStrength = Clamp(d.doorStrength*100, 1, 100)/100.0;
             d.minDamageThreshold = rngrange(d.minDamageThreshold, min_mindmg_adjust, max_mindmg_adjust);
 #ifndef injections
             // without injections we can't augment the highlight window to show mindamagethreshold, so keep it simple for the player
@@ -427,8 +427,8 @@ function MakePickable(#var(DeusExPrefix)Mover d)
     }
     if( d.bPickable == false ) {
         d.bPickable = true;
-        d.lockStrength = FClamp(rngrange(0.8, min_door_adjust, max_door_adjust), 0, 1);
-        d.lockStrength = int(d.lockStrength*100)/100.0;
+        d.lockStrength = rngrange(0.7, min_lock_adjust, max_lock_adjust);
+        d.lockStrength = Clamp(d.lockStrength*100, 1, 100)/100.0;
         d.initiallockStrength = d.lockStrength;
     }
 }

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -259,12 +259,12 @@ function AnyEntry()
 function ShowTeleporters()
 {
     local #var(prefix)Teleporter t;
-    local int show_teleporters;
+    local bool hide;
 
-    show_teleporters = class'MenuChoice_ShowTeleporters'.default.value;
+    hide = ! class'MenuChoice_ShowTeleporters'.static.ShowTeleporters(dxr.flags.IsReducedRando());
 
     foreach AllActors(class'#var(prefix)Teleporter', t) {
-        t.bHidden = !(t.bCollideActors && t.bEnabled && show_teleporters>0);
+        t.bHidden = hide || !t.bCollideActors || !t.bEnabled;
         t.DrawScale = 0.75;
     }
 }

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -261,7 +261,7 @@ function ShowTeleporters()
     local #var(prefix)Teleporter t;
     local int show_teleporters;
 
-    show_teleporters = class'MenuChoice_ShowTeleporters'.default.show_teleporters;
+    show_teleporters = class'MenuChoice_ShowTeleporters'.default.value;
 
     foreach AllActors(class'#var(prefix)Teleporter', t) {
         t.bHidden = !(t.bCollideActors && t.bEnabled && show_teleporters>0);

--- a/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -46,7 +46,7 @@ function CheckConfig()
     local string temp;
     local int i, s;
     local class<Actor> a;
-    if( ConfigOlderThan(2,6,2,3) ) {
+    if( ConfigOlderThan(2,6,2,4) ) {
         mult_items_per_level = 1;
 
         for(i=0; i < ArrayCount(loadouts_order); i++) {
@@ -93,8 +93,8 @@ function CheckConfig()
         item_sets[2].name = "Stick With the Prod Plus";
         item_sets[2].player_message = "Stick with the prod!";
         item_sets[2].bans = "Engine.Weapon,AmmoDart";
-        item_sets[2].allows = "WeaponProd,WeaponEMPGrenade,WeaponGasGrenade,WeaponMiniCrossbow,AmmoDartPoison,WeaponNanoVirusGrenade,WeaponPepperGun,WeaponRubberBaton";
-        item_sets[2].starting_equipments = "WeaponProd,AmmoBattery,WeaponRubberBaton";
+        item_sets[2].allows = "WeaponProd,WeaponEMPGrenade,WeaponGasGrenade,WeaponMiniCrossbow,AmmoDartPoison,WeaponNanoVirusGrenade,WeaponPepperGun,#var(package).WeaponRubberBaton";
+        item_sets[2].starting_equipments = "WeaponProd,AmmoBattery,#var(package).WeaponRubberBaton";
         item_sets[2].starting_augs = "AugStealth,AugMuscle";
         item_sets[2].item_spawns = "WeaponProd,30,WeaponMiniCrossbow,30,WeaponRubberBaton,20";
 

--- a/DXRModules/DeusEx/Classes/DXRMusicPlayer.uc
+++ b/DXRModules/DeusEx/Classes/DXRMusicPlayer.uc
@@ -97,7 +97,7 @@ function ClientSetMusic( playerpawn NewPlayer, music NewSong, byte NewSection, b
 
     p = #var(PlayerPawn)(NewPlayer);
     c = class'MenuChoice_ContinuousMusic';
-    continuous_setting = c.default.continuous_music;
+    continuous_setting = c.default.value;
     rando_music_setting = class'MenuChoice_RandomMusic'.static.IsEnabled(dxr.flags);
     l("ClientSetMusic("$NewSong@NewSection@NewCdTrack@NewTransition$") "$continuous_setting@rando_music_setting@PrevSong@PrevMusicMode@dxr.dxInfo.missionNumber);
 
@@ -213,7 +213,7 @@ function PlayRandomSong(bool setseed)
 
     if(p == None) return;
 
-    continuous_setting = class'MenuChoice_ContinuousMusic'.default.continuous_music;
+    continuous_setting = class'MenuChoice_ContinuousMusic'.default.value;
     rando_music_setting = class'MenuChoice_RandomMusic'.static.IsEnabled(dxr.flags);
     l("AnyEntry 1: "$p@dxr@dxr.dxInfo.missionNumber@continuous_setting@rando_music_setting);
     if( p == None || dxr == None  || (continuous_setting == c.default.disabled && rando_music_setting==false) )

--- a/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminalATM.uc
+++ b/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminalATM.uc
@@ -38,12 +38,12 @@ function ConfigurationChanged()
 
 function CreateKnownAccountsWindow()
 {
-    if( class'MenuChoice_PasswordAutofill'.default.codes_mode < 1 ) return;
+    if( class'MenuChoice_PasswordAutofill'.default.value < 1 ) return;
 
     winKnownShadow = ShadowWindow(NewChild(Class'ShadowWindow'));
 
     winKnownAccounts = ComputerScreenKnownAccounts(NewChild(Class'ComputerScreenKnownAccounts'));
-    if( class'MenuChoice_PasswordAutofill'.default.codes_mode == 2 )
+    if( class'MenuChoice_PasswordAutofill'.default.value == 2 )
         winKnownAccounts.bShowPasswords = true;
     winKnownAccounts.SetNetworkTerminal(Self);
     winKnownAccounts.SetCompOwner(compOwner);

--- a/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminalPersonal.uc
+++ b/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminalPersonal.uc
@@ -34,12 +34,12 @@ function ConfigurationChanged()
 
 function CreateKnownAccountsWindow()
 {
-    if( class'MenuChoice_PasswordAutofill'.default.codes_mode < 1 ) return;
+    if( class'MenuChoice_PasswordAutofill'.default.value < 1 ) return;
 
     winKnownShadow = ShadowWindow(NewChild(Class'ShadowWindow'));
 
     winKnownAccounts = ComputerScreenKnownAccounts(NewChild(Class'ComputerScreenKnownAccounts'));
-    if( class'MenuChoice_PasswordAutofill'.default.codes_mode == 2 )
+    if( class'MenuChoice_PasswordAutofill'.default.value == 2 )
         winKnownAccounts.bShowPasswords = true;
     winKnownAccounts.SetNetworkTerminal(Self);
     winKnownAccounts.SetCompOwner(compOwner);

--- a/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminalSecurity.uc
+++ b/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminalSecurity.uc
@@ -34,12 +34,12 @@ function ConfigurationChanged()
 
 function CreateKnownAccountsWindow()
 {
-    if( class'MenuChoice_PasswordAutofill'.default.codes_mode < 1 ) return;
+    if( class'MenuChoice_PasswordAutofill'.default.value < 1 ) return;
 
     winKnownShadow = ShadowWindow(NewChild(Class'ShadowWindow'));
 
     winKnownAccounts = ComputerScreenKnownAccounts(NewChild(Class'ComputerScreenKnownAccounts'));
-    if( class'MenuChoice_PasswordAutofill'.default.codes_mode == 2 )
+    if( class'MenuChoice_PasswordAutofill'.default.value == 2 )
         winKnownAccounts.bShowPasswords = true;
     winKnownAccounts.SetNetworkTerminal(Self);
     winKnownAccounts.SetCompOwner(compOwner);

--- a/DXRVanilla/DeusEx/Classes/Augmentation.uc
+++ b/DXRVanilla/DeusEx/Classes/Augmentation.uc
@@ -2,6 +2,7 @@ class DXRAugmentation merges Augmentation;
 
 var float LastUsed;
 var float AutoLength;
+var float AutoEnergyMult;
 
 function PostBeginPlay()
 {
@@ -26,7 +27,7 @@ simulated function SetAutomatic()
     if(class'MenuChoice_AutoAugs'.default.enabled) {
         bAutomatic = default.bAutomatic;
         if(bAutomatic) {
-            energyRate = default.energyRate * 2;
+            energyRate = default.energyRate * AutoEnergyMult;
         }
     }
     else {
@@ -104,4 +105,5 @@ defaultproperties
 {
     LastUsed=-100
     AutoLength=5
+    AutoEnergyMult=2
 }

--- a/DXRVanilla/DeusEx/Classes/DXRNetworkTerminal.uc
+++ b/DXRVanilla/DeusEx/Classes/DXRNetworkTerminal.uc
@@ -104,12 +104,12 @@ function CloseScreen(String action)
 
 function CreateKnownAccountsWindow()
 {
-    if( class'MenuChoice_PasswordAutofill'.default.codes_mode < 1 ) return;
+    if( class'MenuChoice_PasswordAutofill'.default.value < 1 ) return;
 
     winKnownShadow = ShadowWindow(NewChild(Class'ShadowWindow'));
 
     winKnownAccounts = ComputerScreenKnownAccounts(NewChild(Class'ComputerScreenKnownAccounts'));
-    if( class'MenuChoice_PasswordAutofill'.default.codes_mode == 2 )
+    if( class'MenuChoice_PasswordAutofill'.default.value == 2 )
         winKnownAccounts.bShowPasswords = true;
     winKnownAccounts.SetNetworkTerminal(Self);
     winKnownAccounts.SetCompOwner(compOwner);

--- a/DXRVanilla/DeusEx/Classes/Weapon.uc
+++ b/DXRVanilla/DeusEx/Classes/Weapon.uc
@@ -765,7 +765,7 @@ function bool HandlePickupQuery(Inventory Item)
                             //Weapons with normal ammo that exists
                             newAmmo = Spawn(defAmmoClass,,,w.Location,w.Rotation);
                             newAmmo.ammoAmount = ammoRemaining;
-                            newAmmo.Velocity = Velocity + VRand() * 280;
+                            newAmmo.Velocity = Velocity + VRand() * 160;
                         } else {
                             w.PickUpAmmoCount = ammoRemaining;
                             defAmmo.AddAmmo(ammoToAdd);

--- a/DXRando/DeusEx/Classes/DXRTeleporterHoverHint.uc
+++ b/DXRando/DeusEx/Classes/DXRTeleporterHoverHint.uc
@@ -69,5 +69,5 @@ function bool ShouldDisplay(float dist)
         return False;
     }
 
-    return (class'MenuChoice_ShowTeleporters'.default.show_teleporters > 1);
+    return (class'MenuChoice_ShowTeleporters'.default.value > 1);
 }

--- a/DXRando/DeusEx/Classes/DXRTeleporterHoverHint.uc
+++ b/DXRando/DeusEx/Classes/DXRTeleporterHoverHint.uc
@@ -69,5 +69,5 @@ function bool ShouldDisplay(float dist)
         return False;
     }
 
-    return (class'MenuChoice_ShowTeleporters'.default.value > 1);
+    return class'MenuChoice_ShowTeleporters'.static.ShowDescriptions(class'DXRando'.default.dxr.flags.IsReducedRando());
 }

--- a/DXRando/DeusEx/Classes/Keypad.uc
+++ b/DXRando/DeusEx/Classes/Keypad.uc
@@ -26,7 +26,7 @@ simulated function ActivateKeypadWindow(DeusExPlayer Hacker, bool bHacked)
 function bool GetInstantSuccess(DeusExPlayer Hacker, bool bHacked)
 {
    if( bHacked ) return true;
-   if( class'MenuChoice_PasswordAutofill'.default.codes_mode == 2 && bCodeKnown ) return true;
+   if( class'MenuChoice_PasswordAutofill'.default.value == 2 && bCodeKnown ) return true;
    return false;
 }
 

--- a/DXRando/DeusEx/Classes/MahoganyDesk.uc
+++ b/DXRando/DeusEx/Classes/MahoganyDesk.uc
@@ -1,0 +1,7 @@
+class MahoganyDesk extends WHDeskOvalOffice;
+
+defaultproperties
+{
+    ItemName="Mahogany Desk"
+    HitPoints=40
+}

--- a/GUI/DeusEx/Classes/DXRMenuUIChoiceBool.uc
+++ b/GUI/DeusEx/Classes/DXRMenuUIChoiceBool.uc
@@ -1,6 +1,7 @@
 class DXRMenuUIChoiceBool extends DXRMenuUIChoiceEnum abstract;
 
 var config bool enabled;
+var bool defaultvalue;
 
 // ----------------------------------------------------------------------
 // SetInitialCycleType()
@@ -36,7 +37,7 @@ function LoadSetting()
 
 function ResetToDefault()
 {
-    enabled = default.enabled;
+    enabled = defaultvalue;
     SetValue(int(enabled));
     SaveSetting();
 }
@@ -46,7 +47,8 @@ function ResetToDefault()
 
 defaultproperties
 {
-    enabled=True;
+    enabled=True
+    defaultvalue=True
     enumText(0)="Disabled"
     enumText(1)="Enabled"
 }

--- a/GUI/DeusEx/Classes/DXRMenuUIChoiceInt.uc
+++ b/GUI/DeusEx/Classes/DXRMenuUIChoiceInt.uc
@@ -1,6 +1,7 @@
 class DXRMenuUIChoiceInt extends DXRMenuUIChoiceEnum abstract;
 
 var config int value;
+var int defaultvalue;
 
 // ----------------------------------------------------------------------
 // SetInitialCycleType()
@@ -36,7 +37,7 @@ function LoadSetting()
 
 function ResetToDefault()
 {
-    value = default.value;
+    value = defaultvalue;
     SetValue(value);
     SaveSetting();
 }
@@ -46,7 +47,8 @@ function ResetToDefault()
 
 defaultproperties
 {
-    value=1;
+    value=1
+    defaultvalue=1
     enumText(0)="Disabled"
     enumText(1)="Enabled"
 }

--- a/GUI/DeusEx/Classes/FrobDisplayWindow.uc
+++ b/GUI/DeusEx/Classes/FrobDisplayWindow.uc
@@ -52,13 +52,13 @@ event StyleChanged()
 
 function bool GetAutoCodes()
 {
-    return class'MenuChoice_PasswordAutofill'.default.codes_mode == 2;
+    return class'MenuChoice_PasswordAutofill'.default.value == 2;
 
 }
 
 function bool GetKnownCodes()
 {
-    return class'MenuChoice_PasswordAutofill'.default.codes_mode >= 1;
+    return class'MenuChoice_PasswordAutofill'.default.value >= 1;
 }
 
 function bool GetShowKeys()

--- a/GUI/DeusEx/Classes/MenuChoice_AutoAugs.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_AutoAugs.uc
@@ -15,6 +15,7 @@ function SaveSetting()
 defaultproperties
 {
     enabled=True
+    defaultvalue=True
     HelpText="Some augmentations will only use energy while in effect."
     actionText="Semi-Automatic Augs"
     enumText(0)="Manual Augs"

--- a/GUI/DeusEx/Classes/MenuChoice_AutoLaser.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_AutoLaser.uc
@@ -3,6 +3,7 @@ class MenuChoice_AutoLaser extends DXRMenuUIChoiceBool;
 defaultproperties
 {
     enabled=True
+    defaultvalue=True
     HelpText="Should laser sights on weapons turn on automatically?"
     actionText="Auto Laser Sight"
     enumText(0)="Disabled"

--- a/GUI/DeusEx/Classes/MenuChoice_AutoWeaponMods.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_AutoWeaponMods.uc
@@ -3,6 +3,7 @@ class MenuChoice_AutoWeaponMods extends DXRMenuUIChoiceBool;
 defaultproperties
 {
     enabled=True
+    defaultvalue=True
     HelpText="Enable or Disable applying weapon mods automatically when picked up.  Mods will be applied to the weapon in your hand if possible when picked up."
     actionText="Auto Weapon Mods"
     enumText(0)="Regular Mods"

--- a/GUI/DeusEx/Classes/MenuChoice_AutosaveCombat.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_AutosaveCombat.uc
@@ -1,39 +1,11 @@
-class MenuChoice_AutosaveCombat extends DXRMenuUIChoiceEnum;
-
-var config int autosave_combat;
-
-function PopulateOptions()
-{
-    enumText[0] = "Wait for combat to finish";
-    enumText[1] = "Autosave immediately";
-}
-
-function SetInitialOption()
-{
-    SetValue(autosave_combat);
-}
-
-function SaveSetting()
-{
-    autosave_combat = GetValue();
-    SaveConfig();
-}
-
-function LoadSetting()
-{
-    SetValue(autosave_combat);
-}
-
-function ResetToDefault()
-{
-    autosave_combat = default.autosave_combat;
-    SetValue(autosave_combat);
-    SaveSetting();
-}
+class MenuChoice_AutosaveCombat extends DXRMenuUIChoiceInt;
 
 defaultproperties
 {
-    autosave_combat=0
+    value=0
+    defaultvalue=0
     HelpText="Should autosave wait for combat to finish?"
     actionText="Autosave During Combat"
+    enumText(0)="Wait for combat to finish"
+    enumText(1)="Autosave immediately"
 }

--- a/GUI/DeusEx/Classes/MenuChoice_ConfirmNoteDelete.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_ConfirmNoteDelete.uc
@@ -6,7 +6,8 @@ class MenuChoice_ConfirmNoteDelete extends DXRMenuUIChoiceBool;
 
 defaultproperties
 {
-     enabled=True;
+     enabled=True
+     defaultvalue=True
      defaultInfoWidth=243
      defaultInfoPosX=203
      HelpText="Confirm when deleting a note"

--- a/GUI/DeusEx/Classes/MenuChoice_ContinuousMusic.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_ContinuousMusic.uc
@@ -2,74 +2,21 @@
 // MenuChoice_ContinuousMusic
 //=============================================================================
 
-class MenuChoice_ContinuousMusic extends DXRMenuUIChoiceEnum;
+class MenuChoice_ContinuousMusic extends DXRMenuUIChoiceInt;
 
-var config int continuous_music;
 var int disabled;
 var int simple;
 var int advanced;
 
-// ----------------------------------------------------------------------
-// PopulateCycleTypes()
-// ----------------------------------------------------------------------
-
-function PopulateOptions()
-{
-    enumText[disabled] = "Normal Music";
-    enumText[simple] = "Continuous Music (Simple)";
-    enumText[advanced] = "Continuous Music";
-}
-
-// ----------------------------------------------------------------------
-// SetInitialCycleType()
-// ----------------------------------------------------------------------
-
-function SetInitialOption()
-{
-    SetValue(continuous_music);
-}
-
-// ----------------------------------------------------------------------
-// SaveSetting()
-// ----------------------------------------------------------------------
-
-function SaveSetting()
-{
-    continuous_music = GetValue();
-    //Not actually a style change, but a reasonable way to tell FrobDisplayWindow to update its flag info...
-    //ChangeStyle();
-    SaveConfig();
-}
-
-// ----------------------------------------------------------------------
-// LoadSetting()
-// ----------------------------------------------------------------------
-
-function LoadSetting()
-{
-    SetValue(continuous_music);
-}
-
-// ----------------------------------------------------------------------
-// ResetToDefault
-// ----------------------------------------------------------------------
-
-function ResetToDefault()
-{
-    continuous_music = default.continuous_music;
-    SetValue(continuous_music);
-    SaveSetting();
-}
-
-// ----------------------------------------------------------------------
-// ----------------------------------------------------------------------
-
 defaultproperties
 {
-    continuous_music=2
+    value=1
+    defaultvalue=1
     disabled=0
-    simple=1
-    advanced=2
+    simple=-9
+    advanced=1
+    enumText(0)="Normal Music"
+    enumText(1)="Continuous Music"
     HelpText="Continue music through loading screens."
     actionText="Continuous Music"
 }

--- a/GUI/DeusEx/Classes/MenuChoice_Epilepsy.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_Epilepsy.uc
@@ -3,6 +3,7 @@ class MenuChoice_Epilepsy extends DXRMenuUIChoiceBool;
 defaultproperties
 {
     enabled=False
+    defaultvalue=False
     HelpText="Enable or Disable Epilepsy-Safe mode.  Flickering or strobing lights will be changed to a soft pulse."
     actionText="Flickering Lights"
     enumText(0)="Regular Lighting"

--- a/GUI/DeusEx/Classes/MenuChoice_FixGlitches.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_FixGlitches.uc
@@ -6,7 +6,8 @@ class MenuChoice_FixGlitches extends DXRMenuUIChoiceBool;
 
 defaultproperties
 {
-    enabled=True;
+    enabled=True
+    defaultvalue=True
     defaultInfoWidth=243
     defaultInfoPosX=203
     HelpText="Fix glitches used for speedruns."

--- a/GUI/DeusEx/Classes/MenuChoice_PasswordAutofill.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_PasswordAutofill.uc
@@ -2,57 +2,19 @@
 // MenuChoice_PasswordAutofill
 //=============================================================================
 
-class MenuChoice_PasswordAutofill extends DXRMenuUIChoiceEnum;
-
-var config int codes_mode;
-
-// ----------------------------------------------------------------------
-// SetInitialCycleType()
-// ----------------------------------------------------------------------
-
-function SetInitialOption()
-{
-    SetValue(codes_mode);
-}
-
-// ----------------------------------------------------------------------
-// SaveSetting()
-// ----------------------------------------------------------------------
+class MenuChoice_PasswordAutofill extends DXRMenuUIChoiceInt;
 
 function SaveSetting()
 {
-    codes_mode = GetValue();
+    Super.SaveSetting();
     //Not actually a style change, but a reasonable way to tell FrobDisplayWindow to update its flag info...
     ChangeStyle();
-    SaveConfig();
 }
-
-// ----------------------------------------------------------------------
-// LoadSetting()
-// ----------------------------------------------------------------------
-
-function LoadSetting()
-{
-    SetValue(codes_mode);
-}
-
-// ----------------------------------------------------------------------
-// ResetToDefault
-// ----------------------------------------------------------------------
-
-function ResetToDefault()
-{
-    codes_mode = default.codes_mode;
-    SetValue(codes_mode);
-    SaveSetting();
-}
-
-// ----------------------------------------------------------------------
-// ----------------------------------------------------------------------
 
 defaultproperties
 {
-    codes_mode=2;
+    value=2;
+    defaultvalue=2
     HelpText="Help with finding randomized passwords from your notes."
     actionText="Password Assistance"
     enumText(0)="No Assistance"

--- a/GUI/DeusEx/Classes/MenuChoice_RandomMusic.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RandomMusic.uc
@@ -23,7 +23,8 @@ static function bool IsEnabled(DXRFlags f)
 
 defaultproperties
 {
-    value=1;
+    value=1
+    defaultvalue=1
     defaultInfoWidth=243
     defaultInfoPosX=203
     HelpText="Randomize game music. This is automatically disabled for Zero Rando and Rando Lite modes."

--- a/GUI/DeusEx/Classes/MenuChoice_ShowKeys.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_ShowKeys.uc
@@ -20,7 +20,8 @@ function SaveSetting()
 
 defaultproperties
 {
-    enabled=True;
+    enabled=True
+    defaultvalue=True
     defaultInfoWidth=243
     defaultInfoPosX=203
     HelpText="Show when doors can be opened with a key"

--- a/GUI/DeusEx/Classes/MenuChoice_ShowNews.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_ShowNews.uc
@@ -7,6 +7,7 @@ class MenuChoice_ShowNews extends DXRMenuUIChoiceBool;
 defaultproperties
 {
     enabled=True
+    defaultvalue=True
     defaultInfoWidth=243
     defaultInfoPosX=203
     HelpText="Show or hide the news on the main menu. Reopen the main menu to take effect."

--- a/GUI/DeusEx/Classes/MenuChoice_ShowTeleporters.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_ShowTeleporters.uc
@@ -10,13 +10,24 @@ function SaveSetting()
     }
 }
 
+static function bool ShowTeleporters(bool bReducedRando)
+{
+    return default.value==1 || default.value==2 || (!bReducedRando && default.value==3);
+}
+
+static function bool ShowDescriptions(bool bReducedRando)
+{
+    return default.value==2 || (!bReducedRando && default.value==3);
+}
+
 defaultproperties
 {
-    value=2
-    defaultvalue=2
+    value=3
+    defaultvalue=3
     enumText(0)="Hidden"
     enumText(1)="Visible without descriptions"
     enumText(2)="Visible with descriptions"
+    enumText(3)="According to Game Mode"
     HelpText="Visible icons for teleporters with text descriptions."
     actionText="Teleporter Icons"
 }

--- a/GUI/DeusEx/Classes/MenuChoice_ShowTeleporters.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_ShowTeleporters.uc
@@ -1,45 +1,22 @@
-class MenuChoice_ShowTeleporters extends DXRMenuUIChoiceEnum;
-
-var config int show_teleporters;
-
-function PopulateOptions()
-{
-    enumText[0] = "Hidden";
-    enumText[1] = "Visible without descriptions";
-    enumText[2] = "Visible with descriptions";
-}
-
-function SetInitialOption()
-{
-    SetValue(show_teleporters);
-}
+class MenuChoice_ShowTeleporters extends DXRMenuUIChoiceInt;
 
 function SaveSetting()
 {
     local DXRFixup f;
-    show_teleporters = GetValue();
-    SaveConfig();
+    Super.SaveSetting();
 
     foreach player.AllActors(class'DXRFixup', f) {
         f.ShowTeleporters();
     }
 }
 
-function LoadSetting()
-{
-    SetValue(show_teleporters);
-}
-
-function ResetToDefault()
-{
-    show_teleporters = default.show_teleporters;
-    SetValue(show_teleporters);
-    SaveSetting();
-}
-
 defaultproperties
 {
-    show_teleporters=2
+    value=2
+    defaultvalue=2
+    enumText(0)="Hidden"
+    enumText(1)="Visible without descriptions"
+    enumText(2)="Visible with descriptions"
     HelpText="Visible icons for teleporters with text descriptions."
     actionText="Teleporter Icons"
 }

--- a/GUI/DeusEx/Classes/MenuChoice_ThrowMelee.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_ThrowMelee.uc
@@ -6,7 +6,8 @@ class MenuChoice_ThrowMelee extends DXRMenuUIChoiceBool;
 
 defaultproperties
 {
-    enabled=True;
+    enabled=True
+    defaultvalue=True
     HelpText="How to handle melee weapons when enemies die."
     actionText="Melee Weapons"
     enumText(0)="Don't Throw"

--- a/GUI/DeusEx/Classes/MenuChoice_ToggleMemes.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_ToggleMemes.uc
@@ -8,6 +8,7 @@ static function bool IsEnabled(DXRFlags f)
 defaultproperties
 {
     value=1
+    defaultvalue=1
     HelpText="Enable or Disable cutscene randomization and a few other things. This is automatically disabled for Zero Rando and Rando Lite modes."
     actionText="Memes"
     enumText(0)="Memes Disabled"


### PR DESCRIPTION
- fix WeaponRubberBaton reference for non vanilla mods
- Rando options menu fix Restore Defaults button
- reduce lower-bound door/keypad strength adjustments
- fearless Leo Gold
- fix death animation showing first person weapon and hand
- reduce melee throw distance when enemies die
- DXRando.default.dxr singleton reference
- Show Teleporters option for "According to Game Mode"
- decrease ammo drop velocities from weapons
- fix for doors and keypads that had 0 strength
- MAHOGANY
- synthetic heart auto tweaks: shorter linger, no more energy penalty
- aug descriptions show auto and linger time