### PR TITLE
Standing lamp light move to the top

### DIFF
--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -809,7 +809,7 @@ static function FixConversationAddNote(Conversation c, string textSnippet)
 
 function SetAllLampsState(bool type1, bool type2, bool type3, optional Vector loc, optional float rad)
 {
-#ifdev vanilla
+#ifdef vanilla
     local #var(prefix)Lamp lmp;
 
     if (class'MenuChoice_AutoLamps'.default.enabled == false)

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -207,13 +207,9 @@ function PreFirstEntry()
     FixBeamLaserTriggers();
     SpawnDatacubes();
     AntiEpilepsy();
+
+    foreach AllActors(class'#var(prefix)Lamp', lmp) lmp.InitLight();
     SetAllLampsState(true, true, true);
-    foreach AllActors(class'#var(prefix)Lamp', lmp) {
-        lmp.LightHue = lmp.Default.LightHue;
-        lmp.LightSaturation = lmp.Default.LightSaturation;
-        lmp.LightBrightness = lmp.Default.LightBrightness;
-        lmp.LightRadius = lmp.Default.LightRadius;
-    }
 
     SetSeed( "DXRFixup PreFirstEntry missions" );
     if(#defined(mapfixes))
@@ -671,7 +667,6 @@ function SpawnDatacubes()
 #endif
 
         if( dc != None ){
-            dc.SetCollision(true,false,false);
             if(dxr.flags.settings.infodevices > 0)
                 GlowUp(dc);
             dc.plaintext = add_datacubes[i].text;
@@ -807,23 +802,6 @@ static function FixConversationAddNote(Conversation c, string textSnippet)
     }
 }
 
-function SetLampState(#var(prefix)Lamp lmp, bool turnOn) // could maybe go in DXRLamp if it existed
-{
-    if (turnOn) {
-        lmp.bOn = True;
-        lmp.LightType = LT_Steady;
-        // lmp.PlaySound(sound'Switch4ClickOn');
-        lmp.bUnlit = True;
-        lmp.ScaleGlow = 3.0;
-    } else if (lmp.bOn) {
-        lmp.bOn = False;
-        lmp.LightType = LT_None;
-        // lmp.PlaySound(sound'Switch4ClickOff');
-        lmp.bUnlit = False;
-        lmp.ResetScaleGlow();
-    }
-}
-
 function SetAllLampsState(bool type1, bool type2, bool type3, optional Vector loc, optional float rad)
 {
     local #var(prefix)Lamp lmp;
@@ -833,11 +811,19 @@ function SetAllLampsState(bool type1, bool type2, bool type3, optional Vector lo
 
     if (rad == 0.0) {
         foreach AllActors(class'#var(prefix)Lamp', lmp) {
-            SetLampState(lmp, (#var(prefix)Lamp1(lmp) != None && type1) || (#var(prefix)Lamp2(lmp) != None && type2) || (#var(prefix)Lamp3(lmp) != None && type3));
+            lmp.SetState(
+                (Lamp1(lmp) != None && type1) ||
+                (Lamp2(lmp) != None && type2) ||
+                (Lamp3(lmp) != None && type3)
+            );
         }
     } else {
         foreach RadiusActors(class'#var(prefix)Lamp', lmp, rad, loc * coords_mult) {
-            SetLampState(lmp, (#var(prefix)Lamp1(lmp) != None && type1) || (#var(prefix)Lamp2(lmp) != None && type2) || (#var(prefix)Lamp3(lmp) != None && type3));
+            lmp.SetState(
+                (Lamp1(lmp) != None && type1) ||
+                (Lamp2(lmp) != None && type2) ||
+                (Lamp3(lmp) != None && type3)
+            );
         }
     }
 }

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -208,12 +208,12 @@ function PreFirstEntry()
     SpawnDatacubes();
     AntiEpilepsy();
 
-    if (#defined(vanilla)) {
-        foreach AllActors(class'#var(prefix)Lamp', lmp) {
-            lmp.InitLight();
-        }
+#ifdef vanilla
+    foreach AllActors(class'#var(prefix)Lamp', lmp) {
+        lmp.InitLight();
     }
     SetAllLampsState(true, true, true);
+#endif
 
     SetSeed( "DXRFixup PreFirstEntry missions" );
     if(#defined(mapfixes))
@@ -809,9 +809,10 @@ static function FixConversationAddNote(Conversation c, string textSnippet)
 
 function SetAllLampsState(bool type1, bool type2, bool type3, optional Vector loc, optional float rad)
 {
+#ifdev vanilla
     local #var(prefix)Lamp lmp;
 
-    if (class'MenuChoice_AutoLamps'.default.enabled == false || #defined(vanilla) == false)
+    if (class'MenuChoice_AutoLamps'.default.enabled == false)
         return;
 
     if (rad == 0.0) {
@@ -831,4 +832,5 @@ function SetAllLampsState(bool type1, bool type2, bool type3, optional Vector lo
             );
         }
     }
+#endif
 }

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -208,7 +208,11 @@ function PreFirstEntry()
     SpawnDatacubes();
     AntiEpilepsy();
 
-    foreach AllActors(class'#var(prefix)Lamp', lmp) lmp.InitLight();
+    if (#defined(vanilla)) {
+        foreach AllActors(class'#var(prefix)Lamp', lmp) {
+            lmp.InitLight();
+        }
+    }
     SetAllLampsState(true, true, true);
 
     SetSeed( "DXRFixup PreFirstEntry missions" );
@@ -807,7 +811,7 @@ function SetAllLampsState(bool type1, bool type2, bool type3, optional Vector lo
 {
     local #var(prefix)Lamp lmp;
 
-    if (class'MenuChoice_AutoLamps'.default.enabled == false || #defined(revision || gmdx))
+    if (class'MenuChoice_AutoLamps'.default.enabled == false || #defined(vanilla) == false)
         return;
 
     if (rad == 0.0) {

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -667,6 +667,7 @@ function SpawnDatacubes()
 #endif
 
         if( dc != None ){
+            dc.SetCollision(true,false,false);
             if(dxr.flags.settings.infodevices > 0)
                 GlowUp(dc);
             dc.plaintext = add_datacubes[i].text;

--- a/DXRando/DeusEx/Classes/DXRLamp.uc
+++ b/DXRando/DeusEx/Classes/DXRLamp.uc
@@ -1,0 +1,27 @@
+class DXRLamp injects #var(prefix)Lamp;
+
+// should always be called when first entering a map
+function InitLight()
+{
+    LightHue = Default.LightHue;
+    LightSaturation = Default.LightSaturation;
+    LightBrightness = Default.LightBrightness;
+    LightRadius = Default.LightRadius;
+
+    SetState(bOn);
+}
+
+function SetState(bool turnOn)
+{
+    if (turnOn) {
+        bOn = True;
+        LightType = LT_Steady;
+        bUnlit = True;
+        ScaleGlow = 3.0;
+    } else if (bOn) {
+        bOn = False;
+        LightType = LT_None;
+        bUnlit = False;
+        ResetScaleGlow();
+    }
+}

--- a/DXRando/DeusEx/Classes/DXRLamp2.uc
+++ b/DXRando/DeusEx/Classes/DXRLamp2.uc
@@ -22,7 +22,7 @@ function InitLight()
         lt.LightSaturation = 160;
         lt.LightBrightness = 255;
         // increasing the radius to 25 causes weird flickering on a couch in the Free Clinic, probably elsewhere
-        lt.LightRadius = 20;
+        lt.LightRadius = 15;
     }
 
     SetState(bOn);

--- a/DXRando/DeusEx/Classes/DXRLamp2.uc
+++ b/DXRando/DeusEx/Classes/DXRLamp2.uc
@@ -17,6 +17,7 @@ function InitLight()
         loc.z += CollisionHeight * 1.35;
 
         lt = Spawn(class'DynamicLight',,, loc);
+        lt.SetBase(self);
 
         lt.LightHue = default.LightHue;
         lt.LightSaturation = default.LightSaturation;

--- a/DXRando/DeusEx/Classes/DXRLamp2.uc
+++ b/DXRando/DeusEx/Classes/DXRLamp2.uc
@@ -1,17 +1,65 @@
 //=============================================================================
-// Lamp2 except Warm White.  Fuck daylight bulbs.
+// Lamp2 except with a warm white light at the top.
+// Fuck daylight bulbs.
 // Localization files overwrite the ItemName,
 // so really force it to not be halogen
 //=============================================================================
 class DXRLamp2 injects #var(prefix)Lamp2;
+
+var DynamicLight lt;
+
+function InitLight()
+{
+    local vector loc;
+
+    if (lt == None) {
+        lt = Spawn(class'DynamicLight');
+
+        lt.SetPhysics(PHYS_None);
+        lt.SetCollisionSize(0.0, 0.0);
+
+        loc = Location;
+        loc.z += CollisionHeight * 1.47;
+        lt.SetLocation(loc);
+
+        lt.LightHue=44;
+        lt.LightSaturation = 160;
+        lt.LightBrightness = 255;
+        // increasing the radius to 25 causes weird flickering on a couch in the Free Clinic, probably elsewhere
+        lt.LightRadius = 20;
+
+        lt.Mesh = None;
+    }
+
+    SetState(bOn);
+}
+
+function SetState(bool turnOn)
+{
+    if (turnOn) {
+        bOn = true;
+        lt.LightType = LT_Steady;
+        bUnlit = True;
+        ScaleGlow = 3.0;
+    } else {
+        bOn = false;
+        lt.LightType = LT_None;
+        bUnlit = False;
+        ResetScaleGlow();
+    }
+
+    LightType = LT_NONE;
+}
+
+function Frob(Actor frobber, Inventory frobWith)
+{
+    Super.Frob(frobber, frobWith);
+    SetState(bOn);
+}
 
 defaultproperties
 {
      ItemName="Stand Lamp"
      FamiliarName="Stand Lamp"
      UnfamiliarName="Stand Lamp"
-     LightHue=44
-     LightSaturation=160
-     // increasing the radius to 25 causes weird flickering on a couch in the Free Clinic, probably elsewhere
-     LightRadius=15
 }

--- a/DXRando/DeusEx/Classes/DXRLamp2.uc
+++ b/DXRando/DeusEx/Classes/DXRLamp2.uc
@@ -13,11 +13,10 @@ function InitLight()
     local vector loc;
 
     if (lt == None) {
-        lt = Spawn(class'DynamicLight');
-
         loc = Location;
         loc.z += CollisionHeight * 1.35;
-        lt.SetLocation(loc);
+
+        lt = Spawn(class'DynamicLight',,, loc);
 
         lt.LightHue=44;
         lt.LightSaturation = 160;
@@ -51,6 +50,8 @@ function Frob(Actor frobber, Inventory frobWith)
     Super.Frob(frobber, frobWith);
     SetState(bOn);
 }
+
+function Destroyed() { if (lt != None) lt.Destroy(); }
 
 defaultproperties
 {

--- a/DXRando/DeusEx/Classes/DXRLamp2.uc
+++ b/DXRando/DeusEx/Classes/DXRLamp2.uc
@@ -18,11 +18,10 @@ function InitLight()
 
         lt = Spawn(class'DynamicLight',,, loc);
 
-        lt.LightHue=44;
-        lt.LightSaturation = 160;
-        lt.LightBrightness = 255;
-        // increasing the radius to 25 causes weird flickering on a couch in the Free Clinic, probably elsewhere
-        lt.LightRadius = 15;
+        lt.LightHue = default.LightHue;
+        lt.LightSaturation = default.LightSaturation;
+        lt.LightBrightness = default.LightBrightness;
+        lt.LightRadius = default.LightRadius;
     }
 
     SetState(bOn);
@@ -55,7 +54,12 @@ function Destroyed() { if (lt != None) lt.Destroy(); }
 
 defaultproperties
 {
-     ItemName="Stand Lamp"
-     FamiliarName="Stand Lamp"
-     UnfamiliarName="Stand Lamp"
+    ItemName="Stand Lamp"
+    FamiliarName="Stand Lamp"
+    UnfamiliarName="Stand Lamp"
+    LightHue=44;
+    LightSaturation = 160;
+    LightBrightness = 255;
+    // increasing the radius to ~21-25 causes weird flickering on a couch in the Free Clinic, probably elsewhere
+    LightRadius = 15;
 }

--- a/DXRando/DeusEx/Classes/DXRLamp2.uc
+++ b/DXRando/DeusEx/Classes/DXRLamp2.uc
@@ -15,11 +15,8 @@ function InitLight()
     if (lt == None) {
         lt = Spawn(class'DynamicLight');
 
-        lt.SetPhysics(PHYS_None);
-        lt.SetCollisionSize(0.0, 0.0);
-
         loc = Location;
-        loc.z += CollisionHeight * 1.47;
+        loc.z += CollisionHeight * 1.35;
         lt.SetLocation(loc);
 
         lt.LightHue=44;
@@ -27,8 +24,6 @@ function InitLight()
         lt.LightBrightness = 255;
         // increasing the radius to 25 causes weird flickering on a couch in the Free Clinic, probably elsewhere
         lt.LightRadius = 20;
-
-        lt.Mesh = None;
     }
 
     SetState(bOn);

--- a/DXRando/DeusEx/Classes/DynamicLight.uc
+++ b/DXRando/DeusEx/Classes/DynamicLight.uc
@@ -1,0 +1,8 @@
+class DynamicLight extends Light;
+
+defaultproperties
+{
+    bStatic=false
+    bNoDelete=false
+    bMovable=true
+}


### PR DESCRIPTION
Standing Lamps now have a `DynamicLight` that sits at the top and otherwise behaves like the lamp's vanilla light (but is still warmer, Astro). Its normal light is disabled.

Adds a `DXRLamp` class.
* It has an `InitLight` function that should always be called on first map entry. This was already being done in `DXRFixup`, the code is just moved here. Importantly, it allows `Lamp2`s to create their `DynamicLight` and to disable their regular light immediately, without requiring any checks for lamp type in `DXRFixup`.
* It has a `SetState` function, which previously existed in `DXRFixup`. Again, this function needs to be different now in `DXRLamp2`.