### PR TITLE
Loot Refusal

### DIFF
--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -1620,3 +1620,12 @@ static function bool ChangeInitialAlliance(ScriptedPawn pawn, Name allianceName,
 
     return true;
 }
+
+static function bool IsRefused(class<Inventory> type, optional out int strIdx)
+{
+    local DataStorage datastorage;
+
+    datastorage = class'DataStorage'.static.GetObj(class'DXRando'.default.dxr);
+    strIdx = InStr(datastorage.GetConfigKey("item_refusals"), "," $ type.name $ ",");
+    return strIdx != -1;
+}

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -1620,12 +1620,3 @@ static function bool ChangeInitialAlliance(ScriptedPawn pawn, Name allianceName,
 
     return true;
 }
-
-static function bool IsRefused(class<Inventory> type, optional out int strIdx)
-{
-    local DataStorage datastorage;
-
-    datastorage = class'DataStorage'.static.GetObj(class'DXRando'.default.dxr);
-    strIdx = InStr(datastorage.GetConfigKey("item_refusals"), "," $ type.name $ ",");
-    return strIdx != -1;
-}

--- a/DXRFixes/DeusEx/Classes/Carcass.uc
+++ b/DXRFixes/DeusEx/Classes/Carcass.uc
@@ -155,6 +155,9 @@ function Frob(Actor Frobber, Inventory frobWith)
     local DeusExPlayer player;
     local POVCorpse corpse;
     local DataStorage datastorage;
+    local DeusExWeapon weap;
+    local Ammo playerAmmo;
+    local int newAmmoAmmout, ammoAdded;
 
     //log("DeusExCarcass::Frob()--------------------------------");
 
@@ -227,7 +230,18 @@ function Frob(Actor Frobber, Inventory frobWith)
             nextItem = item.Inventory;
 
             if (InStr(datastorage.GetConfigKey("item_refusals"), "," $ item.class.name $ ",") != -1) {
-                // TODO: remove ammo from weapons and give it to the player
+                weap = DeusExWeapon(item);
+                if (weap != None) {
+                    playerAmmo = Ammo(player.FindInventoryType(weap.AmmoName));
+                    if (playerAmmo == None) {
+                        playerAmmo = player.Spawn(weap.AmmoName);
+                        playerAmmo.GiveTo(player);
+                    }
+                    newAmmoAmmout = Min(playerAmmo.MaxAmmo, playerAmmo.AmmoAmount + weap.PickupAmmoCount);
+                    ammoAdded = newAmmoAmmout - playerAmmo.AmmoAmount;
+                    playerAmmo.AmmoAmount = newAmmoAmmout;
+                    weap.PickupAmmoCount -= ammoAdded;
+                }
                 TossItem(item);
                 bFoundSomething = true;
             } else if(TryLootItem(player, item)) {

--- a/DXRFixes/DeusEx/Classes/Carcass.uc
+++ b/DXRFixes/DeusEx/Classes/Carcass.uc
@@ -261,7 +261,7 @@ function bool TryLootItem(DeusExPlayer player, Inventory item)
     local Weapon weap;
     local Ammo playerAmmo;
 
-    if (class'DXRActorsBase'.static.IsRefused(item.class)) {
+    if (class'DXRLoadouts'.static.IsRefused(item.class)) {
         weap = Weapon(item);
         if (weap != None && weap.AmmoName != class'AmmoNone') {
             playerAmmo = Ammo(player.FindInventoryType(weap.AmmoName));

--- a/DXRFixes/DeusEx/Classes/Carcass.uc
+++ b/DXRFixes/DeusEx/Classes/Carcass.uc
@@ -126,13 +126,12 @@ function Destroyed()
 }
 
 //Toss the item, but not very hard
-function TossItem(Inventory inv, DeusExPlayer Frobber){
-    local float xVel,yVel;
+function TossItem(Inventory inv){
     local vector velocity;
 
     DeleteInventory(inv);
     class'DXRActorsBase'.static.ThrowItem(inv, 0.5);
-    inv.SetLocation( Location + vect(0,0,20));
+    inv.SetLocation(Location + vect(0,0,20));
 
     velocity.X = ((FRand() - 0.5) * 2);
     velocity.Y = ((FRand() - 0.5) * 2);
@@ -155,6 +154,7 @@ function Frob(Actor Frobber, Inventory frobWith)
     local bool bFoundSomething;
     local DeusExPlayer player;
     local POVCorpse corpse;
+    local DataStorage datastorage;
 
     //log("DeusExCarcass::Frob()--------------------------------");
 
@@ -216,6 +216,8 @@ function Frob(Actor Frobber, Inventory frobWith)
 
     if (Inventory != None && player != None)
     {
+        datastorage = class'DataStorage'.static.GetObj(class'DXRando'.default.dxr);
+
         item = Inventory;
         startItem = item;
 
@@ -223,8 +225,15 @@ function Frob(Actor Frobber, Inventory frobWith)
         {
             //player.ClientMessage(self@"=> item="$item);
             nextItem = item.Inventory;
-            if(TryLootItem(player, item))
+
+            if (InStr(datastorage.GetConfigKey("item_refusals"), "," $ item.class.name $ ",") != -1) {
+                // TODO: remove ammo from weapons and give it to the player
+                TossItem(item);
                 bFoundSomething = true;
+            } else if(TryLootItem(player, item)) {
+                bFoundSomething = true;
+            }
+
             item = nextItem;
         }
         until ((item == None) || (item == startItem));
@@ -313,7 +322,7 @@ function bool TryLootItem(DeusExPlayer player, Inventory item)
             {
                 player.ClientMessage(Sprintf(msgCannotPickup, invItem.itemName));
                 //Also toss the item out of the carcass
-                TossItem(item,player);
+                TossItem(item);
             }
         }
         else
@@ -427,7 +436,7 @@ function bool TryLootWeapon(DeusExPlayer player, DeusExWeapon item)
         {
             player.ClientMessage(Sprintf(player.InventoryFull, item.itemName));
             //Also toss the item out of the carcass
-            TossItem(item,player);
+            TossItem(item);
             return true;
         }
 
@@ -439,7 +448,7 @@ function bool TryLootWeapon(DeusExPlayer player, DeusExWeapon item)
             player.ClientMessage(Sprintf(player.InventoryFull, item.itemName));
 
             //Also toss the item out of the carcass
-            TossItem(item,player);
+            TossItem(item);
             return true;
         }
 
@@ -527,7 +536,7 @@ function bool TryLootRegularItem(DeusExPlayer player, Inventory item)
             player.ClientMessage(Item.PickupMessage @ Item.itemArticle @ Item.itemName, 'Pickup');
             PlaySound(Item.PickupSound);
         } else {
-            TossItem(item,player);
+            TossItem(item);
         }
         return true;
     }

--- a/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
+++ b/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
@@ -1,5 +1,8 @@
 class PersonaScreenInventory injects PersonaScreenInventory;
 
+var PersonaActionButtonWindow btnGarbage;
+var PersonaActionButtonWindow btnAutoconsume;
+
 function SelectInventory(PersonaItemButton buttonPressed)
 {
     Super.SelectInventory(buttonPressed);
@@ -128,4 +131,143 @@ event DescendantRemoved(Window descendant)
         }
     }
     Super.DescendantRemoved(descendant);
+}
+
+function CreateButtons()
+{
+	local PersonaButtonBarWindow winActionButtons;
+
+	winActionButtons = PersonaButtonBarWindow(winClient.NewChild(Class'PersonaButtonBarWindow'));
+	winActionButtons.SetPos(9, 339);
+	winActionButtons.SetWidth(267);
+
+	btnAutoconsume = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
+	btnAutoconsume.SetButtonText("AutoUse");
+
+	btnGarbage = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
+	btnGarbage.SetButtonText("Trash");
+
+	btnDrop = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
+	btnDrop.SetButtonText(DropButtonLabel);
+
+	btnUse = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
+	btnUse.SetButtonText(UseButtonLabel);
+
+	btnEquip = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
+	btnEquip.SetButtonText(EquipButtonLabel);
+}
+
+function EnableButtons()
+{
+	local Inventory inv;
+
+	// Make sure all the buttons exist!
+	if ((btnAutoconsume == None) || (btnGarbage == None) || (btnDrop == None) || (btnEquip == None) || (btnUse == None))
+		return;
+
+	if (selectedItem == None) {
+		btnGarbage.DisableWindow();
+		btnDrop.DisableWindow();
+		btnEquip.DisableWindow();
+		btnUse.DisableWindow();
+        btnAutoconsume.DisableWindow();
+	} else {
+		btnGarbage.EnableWindow();
+		btnEquip.EnableWindow();
+		btnUse.EnableWindow();
+        btnAutoconsume.EnableWindow();
+		btnGarbage.EnableWindow();
+		btnDrop.EnableWindow();
+
+		inv = Inventory(selectedItem.GetClientObject());
+
+		if (inv != None) {
+			// Anything can be dropped, except the NanoKeyRing
+			btnDrop.EnableWindow();
+
+			if (inv.IsA('WeaponMod')) {
+				btnChangeAmmo.DisableWindow();
+				btnUse.DisableWindow();
+		        btnAutoconsume.DisableWindow();
+			} else if (inv.IsA('NanoKeyRing')) {
+				btnChangeAmmo.DisableWindow();
+				btnDrop.DisableWindow();
+				btnEquip.DisableWindow();
+				btnUse.DisableWindow();
+		        btnAutoconsume.DisableWindow();
+                btnGarbage.EnableWindow();
+			}
+			// Augmentation Upgrade Cannisters cannot be used
+			// on this screen
+			else if ( inv.IsA('AugmentationUpgradeCannister') ) {
+				btnUse.DisableWindow();
+		        btnAutoconsume.DisableWindow();
+				btnChangeAmmo.DisableWindow();
+			}
+			// Ammo can't be used or equipped
+			else if ( inv.IsA('Ammo') ) {
+				btnUse.DisableWindow();
+		        btnAutoconsume.DisableWindow();
+				btnEquip.DisableWindow();
+                btnGarbage.DisableWindow();
+			} else {
+				if ((inv == player.inHand ) || (inv == player.inHandPending))
+					btnEquip.SetButtonText(UnequipButtonLabel);
+				else
+					btnEquip.SetButtonText(EquipButtonLabel);
+			}
+		}
+		else {
+			btnChangeAmmo.DisableWindow();
+			btnDrop.DisableWindow();
+			btnEquip.DisableWindow();
+			btnUse.DisableWindow();
+		    btnAutoconsume.DisableWindow();
+		}
+
+        if (
+            SoyFood(inv) == None &&
+            Candybar(inv) == None &&
+            Sodacan(inv) == None &&
+            LiquorBottle(inv) == None &&
+            Liquor40oz(inv) == None &&
+            WineBottle(inv) == None
+            // anyone ignorant enough to do this with cigarettes/zyme needs to be stopped
+        ) {
+            btnAutoconsume.DisableWindow();
+        }
+	}
+}
+
+function bool ButtonActivated(Window buttonPressed)
+{
+    local bool ret;
+
+    if (buttonPressed == btnGarbage) {
+        Garbage();
+        return true;
+    }
+    if (buttonPressed == btnAutoconsume) {
+        Autoconsume();
+        return true;
+    }
+
+    ret = Super.ButtonActivated(buttonPressed);
+    if (PersonaAmmoDetailButton(buttonPressed) != None) {
+        btnDrop.DisableWindow();
+        btnGarbage.DisableWindow();
+        btnEquip.DisableWindow();
+        btnUse.DisableWindow();
+        btnAutoconsume.DisableWindow();
+    }
+    return ret;
+}
+
+function Garbage()
+{
+    player.ClientMessage("ButtonActivated trash button pressed");
+}
+
+function Autoconsume() {
+    player.ClientMessage("ButtonActivated autouse button pressed");
 }

--- a/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
+++ b/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
@@ -237,6 +237,8 @@ function Refuse()
     local Pickup droppedItem;
     local string item_refusals, leftPart, rightPart;
     local int strIdx;
+    local Vector x, y, z;
+    local Vector dropVect;
 
     datastorage = class'DataStorage'.static.GetObj(class'DXRando'.default.dxr);
     inv = Inventory(selectedItem.GetClientObject());
@@ -251,9 +253,20 @@ function Refuse()
         if (Pickup(inv) == None) {
             DropSelectedItem();
         } else {
-            droppedItem = Pickup(player.Spawn(inv.class)); // TODO: drop the item a bit in front of the player as in vanilla
+            droppedItem = Pickup(player.Spawn(inv.class));
             droppedItem.numCopies = Pickup(inv).numCopies;
             inv.Destroy();
+
+            GetAxes(player.Rotation, x, y, z);
+            dropVect = player.Location + (player.CollisionRadius + 2.0 * droppedItem.CollisionRadius) * x;
+            dropVect.z += player.BaseEyeHeight; // TODO: change drop height based on where the player is looking
+
+            if (player.FastTrace(dropVect)) {
+                droppedItem.DropFrom(dropVect);
+                droppedItem.bFixedRotationDir = true;
+                droppedItem.RotationRate.Pitch = (32768 - Rand(65536)) * 4.0;
+                droppedItem.RotationRate.Yaw = (32768 - Rand(65536)) * 4.0;
+            }
         }
     } else {
         leftPart = Left(item_refusals, strIdx);

--- a/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
+++ b/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
@@ -247,9 +247,14 @@ function Garbage()
     inv = Inventory(selectedItem.GetClientObject());
 
     item_refusals = datastorage.GetConfigKey("item_refusals");
-    if (item_refusals == "") item_refusals = ",";
-    item_refusals = item_refusals $ inv.class.name $ ",";
-    datastorage.SetConfig("item_refusals", item_refusals, 2147483647);
+    if (InStr(item_refusals, "," $ inv.class.name $ ",") == -1) {
+        if (item_refusals == "") item_refusals = ",";
+        item_refusals = item_refusals $ inv.class.name $ ",";
+        datastorage.SetConfig("item_refusals", item_refusals, 2147483647);
+    }
 
+    DropSelectedItem();
+
+    log("item_refusals: " $ item_refusals);
     player.ClientMessage("ButtonActivated new item_refusals: " $ item_refusals);
 }

--- a/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
+++ b/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
@@ -234,6 +234,7 @@ function Refuse()
 {
     local DataStorage datastorage;
     local Inventory inv;
+    local Pickup droppedItem;
     local string item_refusals, leftPart, rightPart;
     local int strIdx;
 
@@ -246,7 +247,14 @@ function Refuse()
     if (strIdx == -1) {
         if (item_refusals == "") item_refusals = ",";
         item_refusals = item_refusals $ inv.class.name $ ",";
-        DropSelectedItem(); // TODO: drop all for stackables
+
+        if (Pickup(inv) == None) {
+            DropSelectedItem();
+        } else {
+            droppedItem = Pickup(player.Spawn(inv.class)); // TODO: drop the item a bit in front of the player as in vanilla
+            droppedItem.numCopies = Pickup(inv).numCopies;
+            inv.Destroy();
+        }
     } else {
         leftPart = Left(item_refusals, strIdx);
         rightPart = Right(item_refusals, Len(item_refusals) - (strIdx + Len(inv.class.name) + 1));

--- a/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
+++ b/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
@@ -234,7 +234,7 @@ function bool ButtonActivated(Window buttonPressed)
 function Refuse()
 {
     local DataStorage datastorage;
-    local Inventory inv;
+    local Inventory item;
     local Pickup droppedItem;
     local string item_refusals, leftPart, rightPart;
     local int strIdx;
@@ -242,21 +242,25 @@ function Refuse()
     local Vector dropVect;
 
     datastorage = class'DataStorage'.static.GetObj(class'DXRando'.default.dxr);
-    inv = Inventory(selectedItem.GetClientObject());
+    item = Inventory(selectedItem.GetClientObject());
 
     item_refusals = datastorage.GetConfigKey("item_refusals");
 
-    strIdx = InStr(item_refusals, "," $ inv.class.name $ ",");
-    if (strIdx == -1) {
+    if (class'DXRActorsBase'.static.IsRefused(item.class, strIdx)) {
+        leftPart = Left(item_refusals, strIdx);
+        rightPart = Right(item_refusals, Len(item_refusals) - (strIdx + Len(item.class.name) + 1));
+        item_refusals = leftPart $ rightPart;
+        btnRefusal.SetButtonText(RefuseLabel);
+    } else {
         if (item_refusals == "") item_refusals = ",";
-        item_refusals = item_refusals $ inv.class.name $ ",";
+        item_refusals = item_refusals $ item.class.name $ ",";
 
-        if (Pickup(inv) == None) {
+        if (Pickup(item) == None) {
             DropSelectedItem();
         } else {
-            droppedItem = Pickup(player.Spawn(inv.class));
-            droppedItem.numCopies = Pickup(inv).numCopies;
-            inv.Destroy();
+            droppedItem = Pickup(player.Spawn(item.class));
+            droppedItem.numCopies = Pickup(item).numCopies;
+            item.Destroy();
 
             GetAxes(player.Rotation, x, y, z);
             dropVect = player.Location + (player.CollisionRadius + 2.0 * droppedItem.CollisionRadius) * x;
@@ -269,11 +273,6 @@ function Refuse()
                 droppedItem.RotationRate.Yaw = (32768 - Rand(65536)) * 4.0;
             }
         }
-    } else {
-        leftPart = Left(item_refusals, strIdx);
-        rightPart = Right(item_refusals, Len(item_refusals) - (strIdx + Len(inv.class.name) + 1));
-        item_refusals = leftPart $ rightPart;
-        btnRefusal.SetButtonText(RefuseLabel);
     }
 
     datastorage.SetConfig("item_refusals", item_refusals, 2147483647);

--- a/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
+++ b/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
@@ -167,15 +167,15 @@ function EnableButtons()
     btnRefusal.SetButtonText(RefuseLabel);
 
 	if (selectedItem == None) {
-		btnRefusal.DisableWindow();
 		btnDrop.DisableWindow();
+		btnRefusal.DisableWindow();
 		btnEquip.DisableWindow();
 		btnUse.DisableWindow();
 	} else {
-		btnRefusal.EnableWindow();
 		btnEquip.EnableWindow();
 		btnUse.EnableWindow();
 		btnDrop.EnableWindow();
+		btnRefusal.EnableWindow();
 
 		inv = Inventory(selectedItem.GetClientObject());
 
@@ -189,9 +189,9 @@ function EnableButtons()
 
             if (NanoKeyRing(inv) != None) {
                 btnDrop.DisableWindow();
+                btnRefusal.DisableWindow();
 				btnEquip.DisableWindow();
 				btnUse.DisableWindow();
-                btnRefusal.DisableWindow();
 			} else {
                 if (WeaponMod(inv) != None || AugmentationUpgradeCannister(inv) != None) {
                     btnUse.DisableWindow();
@@ -202,11 +202,12 @@ function EnableButtons()
                         btnEquip.SetButtonText(EquipButtonLabel);
                 }
             }
+            log("debug inv: " $ inv);
 		} else {
 			btnDrop.DisableWindow();
+		    btnRefusal.DisableWindow();
 			btnEquip.DisableWindow();
 			btnUse.DisableWindow();
-		    btnRefusal.EnableWindow();
 		}
 	}
 }

--- a/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
+++ b/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
@@ -141,7 +141,7 @@ function CreateButtons()
 	winActionButtons.SetWidth(267);
 
 	btnGarbage = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
-	btnGarbage.SetButtonText("Trash");
+	btnGarbage.SetButtonText("|&Trash");
 
 	btnDrop = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
 	btnDrop.SetButtonText(DropButtonLabel);
@@ -187,7 +187,7 @@ function EnableButtons()
 				btnDrop.DisableWindow();
 				btnEquip.DisableWindow();
 				btnUse.DisableWindow();
-                btnGarbage.EnableWindow();
+                btnGarbage.DisableWindow();
 			}
 			// Augmentation Upgrade Cannisters cannot be used
 			// on this screen

--- a/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
+++ b/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
@@ -1,7 +1,6 @@
 class PersonaScreenInventory injects PersonaScreenInventory;
 
 var PersonaActionButtonWindow btnGarbage;
-var PersonaActionButtonWindow btnAutoconsume;
 
 function SelectInventory(PersonaItemButton buttonPressed)
 {
@@ -141,9 +140,6 @@ function CreateButtons()
 	winActionButtons.SetPos(9, 339);
 	winActionButtons.SetWidth(267);
 
-	btnAutoconsume = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
-	btnAutoconsume.SetButtonText("AutoUse");
-
 	btnGarbage = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
 	btnGarbage.SetButtonText("Trash");
 
@@ -162,7 +158,7 @@ function EnableButtons()
 	local Inventory inv;
 
 	// Make sure all the buttons exist!
-	if ((btnAutoconsume == None) || (btnGarbage == None) || (btnDrop == None) || (btnEquip == None) || (btnUse == None))
+	if ((btnGarbage == None) || (btnDrop == None) || (btnEquip == None) || (btnUse == None))
 		return;
 
 	if (selectedItem == None) {
@@ -170,12 +166,10 @@ function EnableButtons()
 		btnDrop.DisableWindow();
 		btnEquip.DisableWindow();
 		btnUse.DisableWindow();
-        btnAutoconsume.DisableWindow();
 	} else {
 		btnGarbage.EnableWindow();
 		btnEquip.EnableWindow();
 		btnUse.EnableWindow();
-        btnAutoconsume.EnableWindow();
 		btnGarbage.EnableWindow();
 		btnDrop.EnableWindow();
 
@@ -188,26 +182,22 @@ function EnableButtons()
 			if (inv.IsA('WeaponMod')) {
 				btnChangeAmmo.DisableWindow();
 				btnUse.DisableWindow();
-		        btnAutoconsume.DisableWindow();
 			} else if (inv.IsA('NanoKeyRing')) {
 				btnChangeAmmo.DisableWindow();
 				btnDrop.DisableWindow();
 				btnEquip.DisableWindow();
 				btnUse.DisableWindow();
-		        btnAutoconsume.DisableWindow();
                 btnGarbage.EnableWindow();
 			}
 			// Augmentation Upgrade Cannisters cannot be used
 			// on this screen
 			else if ( inv.IsA('AugmentationUpgradeCannister') ) {
 				btnUse.DisableWindow();
-		        btnAutoconsume.DisableWindow();
 				btnChangeAmmo.DisableWindow();
 			}
 			// Ammo can't be used or equipped
 			else if ( inv.IsA('Ammo') ) {
 				btnUse.DisableWindow();
-		        btnAutoconsume.DisableWindow();
 				btnEquip.DisableWindow();
                 btnGarbage.DisableWindow();
 			} else {
@@ -222,20 +212,7 @@ function EnableButtons()
 			btnDrop.DisableWindow();
 			btnEquip.DisableWindow();
 			btnUse.DisableWindow();
-		    btnAutoconsume.DisableWindow();
 		}
-
-        if (
-            SoyFood(inv) == None &&
-            Candybar(inv) == None &&
-            Sodacan(inv) == None &&
-            LiquorBottle(inv) == None &&
-            Liquor40oz(inv) == None &&
-            WineBottle(inv) == None
-            // anyone ignorant enough to do this with cigarettes/zyme needs to be stopped
-        ) {
-            btnAutoconsume.DisableWindow();
-        }
 	}
 }
 
@@ -247,10 +224,6 @@ function bool ButtonActivated(Window buttonPressed)
         Garbage();
         return true;
     }
-    if (buttonPressed == btnAutoconsume) {
-        Autoconsume();
-        return true;
-    }
 
     ret = Super.ButtonActivated(buttonPressed);
     if (PersonaAmmoDetailButton(buttonPressed) != None) {
@@ -258,16 +231,25 @@ function bool ButtonActivated(Window buttonPressed)
         btnGarbage.DisableWindow();
         btnEquip.DisableWindow();
         btnUse.DisableWindow();
-        btnAutoconsume.DisableWindow();
     }
     return ret;
 }
 
 function Garbage()
 {
-    player.ClientMessage("ButtonActivated trash button pressed");
-}
+    local DXRando dxr;
+    local DataStorage datastorage;
+    local Inventory inv;
+    local string item_refusals;
 
-function Autoconsume() {
-    player.ClientMessage("ButtonActivated autouse button pressed");
+    foreach player.AllActors(class'DXRando', dxr) break;
+    datastorage = class'DataStorage'.static.GetObj(dxr);
+    inv = Inventory(selectedItem.GetClientObject());
+
+    item_refusals = datastorage.GetConfigKey("item_refusals");
+    if (item_refusals == "") item_refusals = ",";
+    item_refusals = item_refusals $ inv.class.name $ ",";
+    datastorage.SetConfig("item_refusals", item_refusals, 2147483647);
+
+    player.ClientMessage("ButtonActivated new item_refusals: " $ item_refusals);
 }


### PR DESCRIPTION
Adds a button to the inventory window to let players add inventory items to a list of refused items, meaning they'll be dropped from corpses rather than added to the player's inventory. If the item is a weapon, its ammo will still be looted before the weapon is dropped. If the item is picked up again (which can be done from anything other than a corpse), it can be removed from the list by the same button.