### PR TITLE
Add default refusal options to the Gameplay settings menu

### DIFF
--- a/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -480,6 +480,7 @@ simulated function PlayerLogin(#var(PlayerPawn) p)
     class'MenuChoice_RefuseUseless'.static.SetRefusals();
     class'MenuChoice_RefuseFoodDrink'.static.SetRefusals();
     class'MenuChoice_RefuseMelee'.static.SetRefusals();
+    class'MenuChoice_RefuseMisc'.static.SetRefusals();
 }
 
 simulated function PlayerRespawn(#var(PlayerPawn) p)

--- a/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -477,10 +477,12 @@ simulated function PlayerLogin(#var(PlayerPawn) p)
     Super.PlayerLogin(p);
 
     RandoStartingEquipment(p, false);
+#ifdef injections
     class'MenuChoice_RefuseUseless'.static.SetRefusals();
     class'MenuChoice_RefuseFoodDrink'.static.SetRefusals();
     class'MenuChoice_RefuseMelee'.static.SetRefusals();
     class'MenuChoice_RefuseMisc'.static.SetRefusals();
+#endif
 }
 
 simulated function PlayerRespawn(#var(PlayerPawn) p)

--- a/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -1,7 +1,5 @@
 class DXRLoadouts extends DXRActorsBase transient;
 
-const default_item_refusals = ",#var(prefix)Cigarettes,";
-
 var int loadout;//copy locally so we don't need to make this class transient and don't need to worry about re-entering and picking up an item before DXRando loads
 
 struct loadouts
@@ -477,7 +475,11 @@ function FirstEntry()
 simulated function PlayerLogin(#var(PlayerPawn) p)
 {
     Super.PlayerLogin(p);
+
     RandoStartingEquipment(p, false);
+    class'MenuChoice_RefuseUseless'.static.SetRefusals();
+    class'MenuChoice_RefuseFoodDrink'.static.SetRefusals();
+    class'MenuChoice_RefuseMelee'.static.SetRefusals();
 }
 
 simulated function PlayerRespawn(#var(PlayerPawn) p)
@@ -699,7 +701,7 @@ static function bool IsRefused(class<Inventory> type, optional out int strIdx)
     datastorage = class'DataStorage'.static.GetObj(class'DXRando'.default.dxr);
     refusals = datastorage.GetConfigKey("item_refusals");
     if(refusals == "") {
-        refusals = default_item_refusals;
+        return false;
     }
     strIdx = InStr(refusals, "," $ type.name $ ",");
     return strIdx != -1;
@@ -734,7 +736,7 @@ static function SetRefuseItem(class<Inventory> type)
     datastorage = class'DataStorage'.static.GetObj(class'DXRando'.default.dxr);
     refusals = datastorage.GetConfigKey("item_refusals");
 
-    if (refusals == "") refusals = default_item_refusals;
+    if (refusals == "") refusals = ",";
     refusals = refusals $ type.name $ ",";
 
     datastorage.SetConfig("item_refusals", refusals, 3600*24*366);

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -1642,6 +1642,25 @@ exec function Tcl() // toggle clipping, name borrowed from Gamebryo
         Walk();
 }
 
+exec function ShowRefused()
+{
+    local string refusals, msg;
+    local int idx;
+
+    refusals = class'DataStorage'.static.GetObj(GetDXR()).GetConfigKey("item_refusals");
+
+    // basically just adds a space after every comma
+    while (Len(refusals) > 1) {
+        refusals = Right(refusals, Len(refusals) - 1);
+        idx = InStr(refusals, ",");
+        msg = msg $ Left(refusals, idx) $ ", ";
+        refusals = Right(refusals, Len(refusals) - idx);
+    }
+    msg = Left(msg, Len(msg) - 2);
+
+    ClientMessage("Refused items: " $ msg);
+}
+
 
 // ----------------------------------------------------------------------
 // InvokeUIScreen()

--- a/GUI/DeusEx/Classes/MenuChoice_ItemRefusal.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_ItemRefusal.uc
@@ -2,17 +2,24 @@ class MenuChoice_ItemRefusal extends DXRMenuUIChoiceBool;
 
 var class<Inventory> refusedItems[6];
 
-// does not unset refused items if disabled
 static function SetRefusals()
 {
     local int i;
     local class<Inventory> itemClass;
 
-    if (default.enabled == false) return;
-
     for (i = 0; i < ArrayCount(default.refusedItems); i++) {
         itemClass = default.refusedItems[i];
         if (itemClass == None) continue;
+
+        if (default.enabled)
             class'DXRLoadouts'.static.SetRefuseItem(itemClass);
+        else
+            class'DXRLoadouts'.static.UnsetRefuseItem(itemClass);
     }
+}
+
+function SaveSetting()
+{
+    Super.SaveSetting();
+    SetRefusals();
 }

--- a/GUI/DeusEx/Classes/MenuChoice_ItemRefusal.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_ItemRefusal.uc
@@ -1,0 +1,19 @@
+class MenuChoice_ItemRefusal extends DXRMenuUIChoiceBool;
+
+var class<Inventory> refusedItems[6];
+
+static function SetRefusals()
+{
+    local int i;
+    local class<Inventory> itemClass;
+
+    for (i = 0; i < ArrayCount(default.refusedItems); i++) {
+        itemClass = default.refusedItems[i];
+        if (itemClass == None) continue;
+
+        if (default.enabled)
+            class'DXRLoadouts'.static.SetRefuseItem(itemClass);
+        else
+            class'DXRLoadouts'.static.UnsetRefuseItem(itemClass);
+    }
+}

--- a/GUI/DeusEx/Classes/MenuChoice_ItemRefusal.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_ItemRefusal.uc
@@ -1,4 +1,5 @@
 class MenuChoice_ItemRefusal extends DXRMenuUIChoiceBool;
+#compileif injections
 
 var class<Inventory> refusedItems[6];
 

--- a/GUI/DeusEx/Classes/MenuChoice_ItemRefusal.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_ItemRefusal.uc
@@ -2,18 +2,17 @@ class MenuChoice_ItemRefusal extends DXRMenuUIChoiceBool;
 
 var class<Inventory> refusedItems[6];
 
+// does not unset refused items if disabled
 static function SetRefusals()
 {
     local int i;
     local class<Inventory> itemClass;
 
+    if (default.enabled == false) return;
+
     for (i = 0; i < ArrayCount(default.refusedItems); i++) {
         itemClass = default.refusedItems[i];
         if (itemClass == None) continue;
-
-        if (default.enabled)
             class'DXRLoadouts'.static.SetRefuseItem(itemClass);
-        else
-            class'DXRLoadouts'.static.UnsetRefuseItem(itemClass);
     }
 }

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseFoodDrink.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseFoodDrink.uc
@@ -1,4 +1,5 @@
 class MenuChoice_RefuseFoodDrink extends MenuChoice_ItemRefusal;
+#compileif injections
 
 defaultproperties
 {

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseFoodDrink.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseFoodDrink.uc
@@ -4,10 +4,10 @@ defaultproperties
 {
     enabled=False
     defaultvalue=False
-    HelpText="When starting a new game, should food and drinks be added to the list of Junk items that get dropped when looting a corpse?"
-    actionText="Food and Drinks"
-    enumText(0)="Not Junk"
-    enumText(1)="Junk"
+    HelpText="Should food and drinks be included in the list of Junk items that get dropped when looting a body?"
+    actionText="Drop Food & Drinks"
+    enumText(0)="Don't Drop"
+    enumText(1)="Drop"
 
     refusedItems(0)=class'SoyFood'
     refusedItems(1)=class'Candybar'

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseFoodDrink.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseFoodDrink.uc
@@ -4,10 +4,10 @@ defaultproperties
 {
     enabled=False
     defaultvalue=False
-    HelpText="Should food and drinks be dropped when looting a body?"
-    actionText="Drop Food & Drinks"
-    enumText(0)="Don't Drop"
-    enumText(1)="Drop"
+    HelpText="When starting a new game, should food and drinks be added to the list of Junk items that get dropped when looting a corpse?"
+    actionText="Food and Drinks"
+    enumText(0)="Not Junk"
+    enumText(1)="Junk"
 
     refusedItems(0)=class'SoyFood'
     refusedItems(1)=class'Candybar'
@@ -16,4 +16,3 @@ defaultproperties
     refusedItems(4)=class'LiquorBottle'
     refusedItems(5)=class'WineBottle'
 }
-

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseFoodDrink.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseFoodDrink.uc
@@ -1,0 +1,19 @@
+class MenuChoice_RefuseFoodDrink extends MenuChoice_ItemRefusal;
+
+defaultproperties
+{
+    enabled=False
+    defaultvalue=False
+    HelpText="Should food and drinks be dropped when looting a body?"
+    actionText="Drop Food & Drinks"
+    enumText(0)="Don't Drop"
+    enumText(1)="Drop"
+
+    refusedItems(0)=class'SoyFood'
+    refusedItems(1)=class'Candybar'
+    refusedItems(2)=class'Sodacan'
+    refusedItems(3)=class'Liquor40oz'
+    refusedItems(4)=class'LiquorBottle'
+    refusedItems(5)=class'WineBottle'
+}
+

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseMelee.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseMelee.uc
@@ -1,4 +1,5 @@
 class MenuChoice_RefuseMelee extends MenuChoice_ItemRefusal;
+#compileif injections
 
 defaultproperties
 {

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseMelee.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseMelee.uc
@@ -4,10 +4,10 @@ defaultproperties
 {
     enabled=False
     defaultvalue=False
-    HelpText="When starting a new game, should melee weapons be added to the list of Junk items that get dropped when looting a corpse?"
-    actionText="Melee Weapons"
-    enumText(0)="Not Junk"
-    enumText(1)="Junk"
+    HelpText="Should melee weapons be included in the list of Junk items that get dropped when looting a body?"
+    actionText="Drop Melee Weapons"
+    enumText(0)="Don't Drop"
+    enumText(1)="Drop"
 
     refusedItems(0)=class'WeaponCombatKnife'
     refusedItems(1)=class'WeaponCrowbar'

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseMelee.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseMelee.uc
@@ -1,0 +1,18 @@
+class MenuChoice_RefuseMelee extends MenuChoice_ItemRefusal;
+
+defaultproperties
+{
+    enabled=False
+    defaultvalue=False
+    HelpText="Should melee weapons be dropped when looting a body?"
+    actionText="Drop Melee Weapons"
+    enumText(0)="Don't Drop"
+    enumText(1)="Drop"
+
+    refusedItems(0)=class'WeaponCombatKnife'
+    refusedItems(1)=class'WeaponCrowbar'
+    refusedItems(2)=class'WeaponSword'
+    refusedItems(3)=class'WeaponNanoSword'
+    refusedItems(4)=class'WeaponBaton'
+}
+

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseMelee.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseMelee.uc
@@ -4,10 +4,10 @@ defaultproperties
 {
     enabled=False
     defaultvalue=False
-    HelpText="Should melee weapons be dropped when looting a body?"
-    actionText="Drop Melee Weapons"
-    enumText(0)="Don't Drop"
-    enumText(1)="Drop"
+    HelpText="When starting a new game, should melee weapons be added to the list of Junk items that get dropped when looting a corpse?"
+    actionText="Melee Weapons"
+    enumText(0)="Not Junk"
+    enumText(1)="Junk"
 
     refusedItems(0)=class'WeaponCombatKnife'
     refusedItems(1)=class'WeaponCrowbar'
@@ -15,4 +15,3 @@ defaultproperties
     refusedItems(3)=class'WeaponNanoSword'
     refusedItems(4)=class'WeaponBaton'
 }
-

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseMisc.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseMisc.uc
@@ -1,0 +1,16 @@
+class MenuChoice_RefuseMisc extends MenuChoice_ItemRefusal;
+
+defaultproperties
+{
+    enabled=False
+    defaultvalue=False
+    HelpText="Should rebreathers, tech goggles, binoculars and flares be included in the list of Junk items that get dropped when looting a body?"
+    actionText="Drop Miscellaneous"
+    enumText(0)="Don't Drop"
+    enumText(1)="Drop"
+
+    refusedItems(0)=class'Rebreather'
+    refusedItems(1)=class'TechGoggles'
+    refusedItems(2)=class'Binoculars'
+    refusedItems(3)=class'Flare'
+}

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseMisc.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseMisc.uc
@@ -1,4 +1,5 @@
 class MenuChoice_RefuseMisc extends MenuChoice_ItemRefusal;
+#compileif injections
 
 defaultproperties
 {

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseUseless.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseUseless.uc
@@ -4,10 +4,10 @@ defaultproperties
 {
     enabled=True
     defaultvalue=True
-    HelpText="When starting a new game, should cigarettes and zyme be added to the list of Junk items that get dropped when looting a corpse?"
-    actionText="Cigarettes and Zyme"
-    enumText(0)="Not Junk"
-    enumText(1)="Junk"
+    HelpText="Should cigarettes and zyme be included in the list of Junk items that get dropped when looting a body?"
+    actionText="Drop Cigarettes & Zyme" // text is too long without abreviating "and"
+    enumText(0)="Don't Drop"
+    enumText(1)="Drop"
 
     refusedItems(0)=class'Cigarettes'
     refusedItems(1)=class'VialCrack'

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseUseless.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseUseless.uc
@@ -1,0 +1,14 @@
+class MenuChoice_RefuseUseless extends MenuChoice_ItemRefusal;
+
+defaultproperties
+{
+    enabled=True
+    defaultvalue=True
+    HelpText="Should cigarettes and zyme be dropped when looting a body?"
+    actionText="Drop Cigarettes & Zyme"
+    enumText(0)="Don't Drop"
+    enumText(1)="Drop"
+
+    refusedItems(0)=class'Cigarettes'
+    refusedItems(1)=class'VialCrack'
+}

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseUseless.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseUseless.uc
@@ -4,10 +4,10 @@ defaultproperties
 {
     enabled=True
     defaultvalue=True
-    HelpText="Should cigarettes and zyme be dropped when looting a body?"
-    actionText="Drop Cigarettes & Zyme"
-    enumText(0)="Don't Drop"
-    enumText(1)="Drop"
+    HelpText="When starting a new game, should cigarettes and zyme be added to the list of Junk items that get dropped when looting a corpse?"
+    actionText="Cigarettes and Zyme"
+    enumText(0)="Not Junk"
+    enumText(1)="Junk"
 
     refusedItems(0)=class'Cigarettes'
     refusedItems(1)=class'VialCrack'

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseUseless.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseUseless.uc
@@ -1,4 +1,5 @@
 class MenuChoice_RefuseUseless extends MenuChoice_ItemRefusal;
+#compileif injections
 
 defaultproperties
 {

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptions.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptions.uc
@@ -48,17 +48,17 @@ function CreateChoices()
         CreateChoice(class'MenuChoice_Epilepsy');
         CreateChoice(class'MenuChoice_BarrelTextures');
         CreateChoice(class'MenuChoice_DecoPickupBehaviour');
+        CreateChoice(class'MenuChoice_AutoLamps');
+        CreateChoice(class'MenuChoice_RefuseUseless');
+        CreateChoice(class'MenuChoice_RefuseFoodDrink');
+        CreateChoice(class'MenuChoice_RefuseMelee');
+        CreateChoice(class'MenuChoice_RefuseMisc');
     }
 
     CreateChoice(class'MenuChoice_PasswordAutofill');
     CreateChoice(class'MenuChoice_ConfirmNoteDelete');
     CreateChoice(class'MenuChoice_FixGlitches');
     CreateChoice(class'MenuChoice_ShowTeleporters');
-    CreateChoice(class'MenuChoice_AutoLamps');
-    CreateChoice(class'MenuChoice_RefuseUseless');
-    CreateChoice(class'MenuChoice_RefuseFoodDrink');
-    CreateChoice(class'MenuChoice_RefuseMelee');
-    CreateChoice(class'MenuChoice_RefuseMisc');
 
     controlsParent.SetSize(clientWidth, choiceStartY + (choiceCount * choiceVerticalGap));
 }

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptions.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptions.uc
@@ -35,25 +35,25 @@ function CreateChoices()
 
     CreateChoice(class'MenuChoice_ShowNews');
 
-    if(#defined(vanilla)) {
-        CreateChoice(class'MenuChoice_LoadLatest');
-        CreateChoice(class'MenuChoice_SaveDuringInfolinks');
-        CreateChoice(class'MenuChoice_AutosaveCombat');
-        CreateChoice(class'MenuChoice_EnergyDisplay');
-        CreateChoice(class'MenuChoice_AutoAugs');
-        CreateChoice(class'MenuChoice_ShowKeys');
-        CreateChoice(class'MenuChoice_ThrowMelee');
-        CreateChoice(class'MenuChoice_AutoWeaponMods');
-        CreateChoice(class'MenuChoice_AutoLaser');
-        CreateChoice(class'MenuChoice_Epilepsy');
-        CreateChoice(class'MenuChoice_BarrelTextures');
-        CreateChoice(class'MenuChoice_DecoPickupBehaviour');
-        CreateChoice(class'MenuChoice_AutoLamps');
-        CreateChoice(class'MenuChoice_RefuseUseless');
-        CreateChoice(class'MenuChoice_RefuseFoodDrink');
-        CreateChoice(class'MenuChoice_RefuseMelee');
-        CreateChoice(class'MenuChoice_RefuseMisc');
-    }
+#ifdef vanilla
+    CreateChoice(class'MenuChoice_LoadLatest');
+    CreateChoice(class'MenuChoice_SaveDuringInfolinks');
+    CreateChoice(class'MenuChoice_AutosaveCombat');
+    CreateChoice(class'MenuChoice_EnergyDisplay');
+    CreateChoice(class'MenuChoice_AutoAugs');
+    CreateChoice(class'MenuChoice_ShowKeys');
+    CreateChoice(class'MenuChoice_ThrowMelee');
+    CreateChoice(class'MenuChoice_AutoWeaponMods');
+    CreateChoice(class'MenuChoice_AutoLaser');
+    CreateChoice(class'MenuChoice_Epilepsy');
+    CreateChoice(class'MenuChoice_BarrelTextures');
+    CreateChoice(class'MenuChoice_DecoPickupBehaviour');
+    CreateChoice(class'MenuChoice_AutoLamps');
+    CreateChoice(class'MenuChoice_RefuseUseless');
+    CreateChoice(class'MenuChoice_RefuseFoodDrink');
+    CreateChoice(class'MenuChoice_RefuseMelee');
+    CreateChoice(class'MenuChoice_RefuseMisc');
+#endif
 
     CreateChoice(class'MenuChoice_PasswordAutofill');
     CreateChoice(class'MenuChoice_ConfirmNoteDelete');

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptions.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptions.uc
@@ -55,6 +55,9 @@ function CreateChoices()
     CreateChoice(class'MenuChoice_FixGlitches');
     CreateChoice(class'MenuChoice_ShowTeleporters');
     CreateChoice(class'MenuChoice_AutoLamps');
+    CreateChoice(class'MenuChoice_RefuseUseless');
+    CreateChoice(class'MenuChoice_RefuseFoodDrink');
+    CreateChoice(class'MenuChoice_RefuseMelee');
 
     controlsParent.SetSize(clientWidth, choiceStartY + (choiceCount * choiceVerticalGap));
 }

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptions.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptions.uc
@@ -58,6 +58,7 @@ function CreateChoices()
     CreateChoice(class'MenuChoice_RefuseUseless');
     CreateChoice(class'MenuChoice_RefuseFoodDrink');
     CreateChoice(class'MenuChoice_RefuseMelee');
+    CreateChoice(class'MenuChoice_RefuseMisc');
 
     controlsParent.SetSize(clientWidth, choiceStartY + (choiceCount * choiceVerticalGap));
 }

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
@@ -9,22 +9,22 @@ function CreateChoices()
     CreateChoice(class'MenuChoice_ToggleMemes');
     // TODO: simulated crowd control strength
 
-    if(#defined(vanilla)) {
-        CreateChoice(class'MenuChoice_LoadLatest');
-        CreateChoice(class'MenuChoice_SaveDuringInfolinks');
-        CreateChoice(class'MenuChoice_AutosaveCombat');
-        CreateChoice(class'MenuChoice_AutoAugs');
-        CreateChoice(class'MenuChoice_ShowKeys');
-        CreateChoice(class'MenuChoice_ThrowMelee');
-        CreateChoice(class'MenuChoice_AutoWeaponMods');
-        CreateChoice(class'MenuChoice_AutoLaser');
-        CreateChoice(class'MenuChoice_DecoPickupBehaviour');
-        CreateChoice(class'MenuChoice_AutoLamps');
-        CreateChoice(class'MenuChoice_RefuseUseless');
-        CreateChoice(class'MenuChoice_RefuseFoodDrink');
-        CreateChoice(class'MenuChoice_RefuseMelee');
-        CreateChoice(class'MenuChoice_RefuseMisc');
-    }
+#ifdef vanilla
+    CreateChoice(class'MenuChoice_LoadLatest');
+    CreateChoice(class'MenuChoice_SaveDuringInfolinks');
+    CreateChoice(class'MenuChoice_AutosaveCombat');
+    CreateChoice(class'MenuChoice_AutoAugs');
+    CreateChoice(class'MenuChoice_ShowKeys');
+    CreateChoice(class'MenuChoice_ThrowMelee');
+    CreateChoice(class'MenuChoice_AutoWeaponMods');
+    CreateChoice(class'MenuChoice_AutoLaser');
+    CreateChoice(class'MenuChoice_DecoPickupBehaviour');
+    CreateChoice(class'MenuChoice_AutoLamps');
+    CreateChoice(class'MenuChoice_RefuseUseless');
+    CreateChoice(class'MenuChoice_RefuseFoodDrink');
+    CreateChoice(class'MenuChoice_RefuseMelee');
+    CreateChoice(class'MenuChoice_RefuseMisc');
+#endif
 
     CreateChoice(class'MenuChoice_PasswordAutofill');
     CreateChoice(class'MenuChoice_ConfirmNoteDelete');

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
@@ -28,6 +28,7 @@ function CreateChoices()
     CreateChoice(class'MenuChoice_RefuseUseless');
     CreateChoice(class'MenuChoice_RefuseFoodDrink');
     CreateChoice(class'MenuChoice_RefuseMelee');
+    CreateChoice(class'MenuChoice_RefuseMisc');
 }
 
 defaultproperties

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
@@ -25,6 +25,9 @@ function CreateChoices()
     CreateChoice(class'MenuChoice_ConfirmNoteDelete');
     CreateChoice(class'MenuChoice_FixGlitches');
     CreateChoice(class'MenuChoice_AutoLamps');
+    CreateChoice(class'MenuChoice_RefuseUseless');
+    CreateChoice(class'MenuChoice_RefuseFoodDrink');
+    CreateChoice(class'MenuChoice_RefuseMelee');
 }
 
 defaultproperties

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
@@ -19,16 +19,16 @@ function CreateChoices()
         CreateChoice(class'MenuChoice_AutoWeaponMods');
         CreateChoice(class'MenuChoice_AutoLaser');
         CreateChoice(class'MenuChoice_DecoPickupBehaviour');
+        CreateChoice(class'MenuChoice_AutoLamps');
+        CreateChoice(class'MenuChoice_RefuseUseless');
+        CreateChoice(class'MenuChoice_RefuseFoodDrink');
+        CreateChoice(class'MenuChoice_RefuseMelee');
+        CreateChoice(class'MenuChoice_RefuseMisc');
     }
 
     CreateChoice(class'MenuChoice_PasswordAutofill');
     CreateChoice(class'MenuChoice_ConfirmNoteDelete');
     CreateChoice(class'MenuChoice_FixGlitches');
-    CreateChoice(class'MenuChoice_AutoLamps');
-    CreateChoice(class'MenuChoice_RefuseUseless');
-    CreateChoice(class'MenuChoice_RefuseFoodDrink');
-    CreateChoice(class'MenuChoice_RefuseMelee');
-    CreateChoice(class'MenuChoice_RefuseMisc');
 }
 
 defaultproperties


### PR DESCRIPTION
In the future, three-option settings for auto consuming/dropping food/soda and liquor should probably be added.