### PR TITLE
v3.0 Alpha

### DIFF
--- a/DXRBalance/DeusEx/Classes/AnnaNavarre.uc
+++ b/DXRBalance/DeusEx/Classes/AnnaNavarre.uc
@@ -25,10 +25,14 @@ function float ShieldDamage(name damageType)
 // if her shields are down, allow her to be stunned/gassed
 function GotoDisabledState(name damageType, EHitLocation hitPos)
 {
-    if(EmpHealth > 0) {
-        MaybeDrawShield();
+    if(ShieldDamage(damageType) < 1) {
+        if(EmpHealth > 0) {
+            MaybeDrawShield();
+            Super.GotoDisabledState(damageType, hitPos);
+        }
+        else
+            Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
+    } else {
         Super.GotoDisabledState(damageType, hitPos);
     }
-    else
-        Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
 }

--- a/DXRBalance/DeusEx/Classes/AnnaNavarre.uc
+++ b/DXRBalance/DeusEx/Classes/AnnaNavarre.uc
@@ -17,15 +17,18 @@ function float ModifyDamage(int Damage, Pawn instigatedBy, Vector hitLocation,
 function float ShieldDamage(name damageType)
 {
     // move her resistances into shield so they are visible to the player
-    if ((damageType == 'Stunned') || (damageType == 'KnockedOut') || (damageType == 'Poison') || (damageType == 'PoisonEffect'))
+    if (damageType == 'Stunned' || damageType == 'KnockedOut' || damageType == 'Poison' || damageType == 'PoisonEffect')
         return 0;
     return Super.ShieldDamage(damageType);
 }
 
+// if her shields are down, allow her to be stunned/gassed
 function GotoDisabledState(name damageType, EHitLocation hitPos)
 {
-    if(EmpHealth > 0)
+    if(EmpHealth > 0) {
+        MaybeDrawShield();
         Super.GotoDisabledState(damageType, hitPos);
+    }
     else
         Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
 }

--- a/DXRBalance/DeusEx/Classes/AnnaNavarre.uc
+++ b/DXRBalance/DeusEx/Classes/AnnaNavarre.uc
@@ -21,3 +21,11 @@ function float ShieldDamage(name damageType)
         return 0;
     return Super.ShieldDamage(damageType);
 }
+
+function GotoDisabledState(name damageType, EHitLocation hitPos)
+{
+    if(EmpHealth > 0)
+        Super.GotoDisabledState(damageType, hitPos);
+    else
+        Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
+}

--- a/DXRBalance/DeusEx/Classes/AugHeartLung.uc
+++ b/DXRBalance/DeusEx/Classes/AugHeartLung.uc
@@ -3,6 +3,13 @@ class DXRAugHeartLung injects AugHeartLung;
 defaultproperties
 {
     bAutomatic=true
-    AutoLength=1.2
+    AutoLength=0
     AutoEnergyMult=1
+
+    EnergyRate=0
+    MaxLevel=3
+    LevelValues(0)=2
+    LevelValues(1)=1.75
+    LevelValues(2)=1.5
+    LevelValues(3)=1.25
 }

--- a/DXRBalance/DeusEx/Classes/AugHeartLung.uc
+++ b/DXRBalance/DeusEx/Classes/AugHeartLung.uc
@@ -1,5 +1,15 @@
 class DXRAugHeartLung injects AugHeartLung;
 
+function PostPostBeginPlay()
+{
+    Super.PostPostBeginPlay();
+    // description gets overwritten by language file, also DXRAugmentations reads from the default.Description
+    default.Description = "This synthetic heart circulates not only blood but a steady concentration of mechanochemical power cells, smart phagocytes, and liposomes containing prefab diamondoid machine parts,"
+                            $ " resulting in upgraded performance for all installed augmentations, but also increasing their energy use."
+                            $ "|n|n<UNATCO OPS FILE NOTE JR133-VIOLET> However, this will not enhance any augmentation past its maximum upgrade level. -- Jaime Reyes <END NOTE>";
+    Description = default.Description;
+}
+
 defaultproperties
 {
     bAutomatic=true

--- a/DXRBalance/DeusEx/Classes/AugmentationManager.uc
+++ b/DXRBalance/DeusEx/Classes/AugmentationManager.uc
@@ -157,31 +157,31 @@ simulated function int GetClassLevel(class<Augmentation> augClass)
 
 simulated function Float CalcEnergyUse(float deltaTime)
 {
-    local float f, energyUse, energyMult;
-    local Augmentation anAug, augBoost;
-    local bool bBoosting;
+    local float f, energyUse, boostedEnergyUse, energyMult, boostMult;
+    local Augmentation anAug;
 
     energyUse = 0;
     energyMult = 1.0;
+    boostMult = 1.0;
 
     Player.AmbientSound = None;
 
     anAug = FirstAug;
     while(anAug != None)
     {
-        if (AugPower(anAug) != None && anAug.bHasIt)
+        if (AugPower(anAug) != None && anAug.bHasIt && anAug.bIsActive)
             energyMult = anAug.LevelValues[anAug.CurrentLevel];
+        if (AugHeartLung(anAug) != None && anAug.bHasIt && anAug.bIsActive)
+            boostMult = anAug.LevelValues[anAug.CurrentLevel];
 
         if (anAug.bHasIt && anAug.bIsActive)
         {
-            if (AugHeartLung(anAug) != None) {
-                augBoost = AnAug;
-            }
             f = ((anAug.GetEnergyRate()/60) * deltaTime);
             if(f > 0 && anAug.bBoosted) {
-                bBoosting = true;
+                boostedEnergyUse += f;
+            } else {
+                energyUse += f;
             }
-            energyUse += f;
 
             if ((anAug.bAutomatic == false && anAug.bAlwaysActive == false) || f > 0.0) {
                 Player.AmbientSound = anAug.LoopSound;
@@ -190,14 +190,8 @@ simulated function Float CalcEnergyUse(float deltaTime)
         anAug = anAug.next;
     }
 
-    if(bBoosting) {
-        f = (augBoost.GetEnergyRate()/60) * deltaTime;// check if it wasn't using energy yet
-        augBoost.TickUse();
-        if(f == 0) { // add in its energy usage if this is the first tick
-            f = (augBoost.GetEnergyRate()/60) * deltaTime;
-            energyUse += f;
-        }
-    }
+    // check for synthetic heart
+    energyUse += boostedEnergyUse * boostMult;
 
     // check for the power augmentation
     energyUse *= energyMult;

--- a/DXRBalance/DeusEx/Classes/BalanceAugDrone.uc
+++ b/DXRBalance/DeusEx/Classes/BalanceAugDrone.uc
@@ -1,5 +1,19 @@
 class BalanceAugDrone injects AugDrone;
-// original values went from 10 to 50, but we also adjust the damage values in BalanceSpyDrone.uc
+
+function PostPostBeginPlay()
+{
+    Super.PostPostBeginPlay();
+    // description gets overwritten by language file, also DXRAugmentations reads from the default.Description
+    default.Description = "Advanced nanofactories can assemble a spy drone upon demand which can then be remotely controlled by the agent until released or destroyed, at which a point a new drone will be assembled."
+                            $ " Detonating the drone costs 10 energy. Further upgrades equip the spy drones with better armor and a one-shot EMP attack."
+                            $ "|n|nTECH ONE: The drone can take little damage and has a very light EMP attack."
+                            $ "|n|nTECH TWO: The drone can take minor damage and has a light EMP attack."
+                            $ "|n|nTECH THREE: The drone can take moderate damage and has a medium EMP attack."
+                            $ "|n|nTECH FOUR: The drone can take heavy damage and has a strong EMP attack.";
+    Description = default.Description;
+}
+
+// original values went from 10 to 50, but we also adjust the multipliers in BalancePlayer.uc
 defaultproperties
 {
     reconstructTime=1

--- a/DXRBalance/DeusEx/Classes/BalanceAugDrone.uc
+++ b/DXRBalance/DeusEx/Classes/BalanceAugDrone.uc
@@ -6,10 +6,10 @@ function PostPostBeginPlay()
     // description gets overwritten by language file, also DXRAugmentations reads from the default.Description
     default.Description = "Advanced nanofactories can assemble a spy drone upon demand which can then be remotely controlled by the agent until released or destroyed, at which a point a new drone will be assembled."
                             $ " Detonating the drone costs 10 energy. Further upgrades equip the spy drones with better armor and a one-shot EMP attack."
-                            $ "|n|nTECH ONE: The drone can take little damage and has a very light EMP attack."
-                            $ "|n|nTECH TWO: The drone can take minor damage and has a light EMP attack."
-                            $ "|n|nTECH THREE: The drone can take moderate damage and has a medium EMP attack."
-                            $ "|n|nTECH FOUR: The drone can take heavy damage and has a strong EMP attack.";
+                            $ "|n|nTECH ONE: The drone is slow and has a very light EMP attack."
+                            $ "|n|nTECH TWO: The drone is fast and has a light EMP attack."
+                            $ "|n|nTECH THREE: The drone is very fast and has a medium EMP attack."
+                            $ "|n|nTECH FOUR: The drone is extremely fast and has a strong EMP attack.";
     Description = default.Description;
 }
 

--- a/DXRBalance/DeusEx/Classes/BalanceAugDrone.uc
+++ b/DXRBalance/DeusEx/Classes/BalanceAugDrone.uc
@@ -3,9 +3,9 @@ class BalanceAugDrone injects AugDrone;
 defaultproperties
 {
     reconstructTime=1
-    EnergyRate=100
-    LevelValues(0)=50
-    LevelValues(1)=75
-    LevelValues(2)=100
-    LevelValues(3)=150
+    EnergyRate=20
+    LevelValues(0)=30
+    LevelValues(1)=50
+    LevelValues(2)=70
+    LevelValues(3)=100
 }

--- a/DXRBalance/DeusEx/Classes/BalancePlayer.uc
+++ b/DXRBalance/DeusEx/Classes/BalancePlayer.uc
@@ -504,9 +504,9 @@ function CreateDrone()
         //aDrone.MaxSpeed = 3 * spyDroneLevelValue;
         aDrone.MaxSpeed = 5 * spyDroneLevelValue;
         //aDrone.Damage = 5 * spyDroneLevelValue;
-        aDrone.Damage = 3 * spyDroneLevelValue;
+        aDrone.Damage = 2 * spyDroneLevelValue;
         //aDrone.blastRadius = 8 * spyDroneLevelValue;
-        aDrone.blastRadius = 5 * spyDroneLevelValue;
+        aDrone.blastRadius = 4 * spyDroneLevelValue;
         // window construction now happens in Tick()
     }
 }

--- a/DXRBalance/DeusEx/Classes/BalancePlayer.uc
+++ b/DXRBalance/DeusEx/Classes/BalancePlayer.uc
@@ -489,7 +489,52 @@ exec function DualmapF10() { ActivateAugmentation(7); }
 exec function DualmapF11() { ActivateAugmentation(8); }
 exec function DualmapF12() { ActivateAugmentation(9); }
 
+function CreateDrone()
+{
+    local Vector loc;
+
+    loc = (2.0 + class'SpyDrone'.Default.CollisionRadius + CollisionRadius) * Vector(ViewRotation);
+    loc.Z = BaseEyeHeight;
+    loc += Location;
+    aDrone = Spawn(class'SpyDrone', Self,, loc, ViewRotation);
+    if (aDrone != None)
+    {
+        //aDrone.Speed = 3 * spyDroneLevelValue;
+        aDrone.Speed = 5 * spyDroneLevelValue;
+        //aDrone.MaxSpeed = 3 * spyDroneLevelValue;
+        aDrone.MaxSpeed = 5 * spyDroneLevelValue;
+        //aDrone.Damage = 5 * spyDroneLevelValue;
+        aDrone.Damage = 3 * spyDroneLevelValue;
+        //aDrone.blastRadius = 8 * spyDroneLevelValue;
+        aDrone.blastRadius = 5 * spyDroneLevelValue;
+        // window construction now happens in Tick()
+    }
+}
+
 simulated function MoveDrone( float DeltaTime, Vector loc )
 {
+    if(aDrone == None) {
+        // just in case the drone got killed
+        DroneExplode();
+        return;
+    }
     aDrone.MoveDrone(DeltaTime, loc);// DXRando: this doesn't belong in the player...
+}
+
+function DroneExplode()
+{
+    local AugDrone anAug;
+
+    if (aDrone == None) {
+        anAug = AugDrone(AugmentationSystem.FindAugmentation(class'AugDrone'));
+        if (anAug != None) anAug.Deactivate();
+        return;
+    }
+
+    if(Energy >= 10) {
+        Energy -= 10;
+        Super.DroneExplode();
+    } else {
+        ClientMessage("You need 10 bio-electric energy to detonate the spy drone.");
+    }
 }

--- a/DXRBalance/DeusEx/Classes/BalanceSpyDrone.uc
+++ b/DXRBalance/DeusEx/Classes/BalanceSpyDrone.uc
@@ -34,3 +34,13 @@ function TakeDamage(int Damage, Pawn instigatedBy, Vector HitLocation, Vector Mo
         LifeSpan=class'AugDrone'.Default.reconstructTime-0.1;
     }
 }
+
+function Destroyed()
+{
+    if ( DeusExPlayer(Owner) != None ) {
+        DeusExPlayer(Owner).aDrone = None;
+        DeusExPlayer(Owner).DroneExplode();
+    }
+
+    Super.Destroyed();
+}

--- a/DXRBalance/DeusEx/Classes/GuntherHermann.uc
+++ b/DXRBalance/DeusEx/Classes/GuntherHermann.uc
@@ -1,0 +1,12 @@
+class DXRGuntherHermann injects GuntherHermann;
+
+// if his shields are down, allow him to be stunned/gassed
+function GotoDisabledState(name damageType, EHitLocation hitPos)
+{
+    if(EmpHealth > 0) {
+        MaybeDrawShield();
+        Super.GotoDisabledState(damageType, hitPos);
+    }
+    else
+        Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
+}

--- a/DXRBalance/DeusEx/Classes/GuntherHermann.uc
+++ b/DXRBalance/DeusEx/Classes/GuntherHermann.uc
@@ -3,10 +3,14 @@ class DXRGuntherHermann injects GuntherHermann;
 // if his shields are down, allow him to be stunned/gassed
 function GotoDisabledState(name damageType, EHitLocation hitPos)
 {
-    if(EmpHealth > 0) {
-        MaybeDrawShield();
+    if(ShieldDamage(damageType) < 1) {
+        if(EmpHealth > 0) {
+            MaybeDrawShield();
+            Super.GotoDisabledState(damageType, hitPos);
+        }
+        else
+            Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
+    } else {
         Super.GotoDisabledState(damageType, hitPos);
     }
-    else
-        Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
 }

--- a/DXRBalance/DeusEx/Classes/MJ12Commando.uc
+++ b/DXRBalance/DeusEx/Classes/MJ12Commando.uc
@@ -4,6 +4,8 @@ function float ModifyDamage(int Damage, Pawn instigatedBy, Vector hitLocation,
                             Vector offset, Name damageType)
 {
     if(damageType == 'Sabot') Damage *= 2;
+    if(damageType == 'TearGas' || damageType == 'HalonGas') return 0;
+
     return Super.ModifyDamage(Damage, instigatedBy, hitLocation, offset, damageType);
 }
 
@@ -12,15 +14,20 @@ function PlayPanicRunning()
     PlayRunning();
 }
 
-// if his shields are down, allow him to be stunned/gassed
+// if his shields are down, allow him to be stunned
+// commandos don't have the rubbing eyes animation
 function GotoDisabledState(name damageType, EHitLocation hitPos)
 {
-    if(EmpHealth > 0) {
-        MaybeDrawShield();
+    if(damageType != 'TearGas' && damageType != 'HalonGas' && ShieldDamage(damageType) < 1) {
+        if(EmpHealth > 0) {
+            MaybeDrawShield();
+            Super.GotoDisabledState(damageType, hitPos);
+        }
+        else
+            Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
+    } else {
         Super.GotoDisabledState(damageType, hitPos);
     }
-    else
-        Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
 }
 
 defaultproperties

--- a/DXRBalance/DeusEx/Classes/MJ12Commando.uc
+++ b/DXRBalance/DeusEx/Classes/MJ12Commando.uc
@@ -12,6 +12,17 @@ function PlayPanicRunning()
     PlayRunning();
 }
 
+// if his shields are down, allow him to be stunned/gassed
+function GotoDisabledState(name damageType, EHitLocation hitPos)
+{
+    if(EmpHealth > 0) {
+        MaybeDrawShield();
+        Super.GotoDisabledState(damageType, hitPos);
+    }
+    else
+        Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
+}
+
 defaultproperties
 {
     BurnPeriod=5.0

--- a/DXRBalance/DeusEx/Classes/PaulDenton.uc
+++ b/DXRBalance/DeusEx/Classes/PaulDenton.uc
@@ -1,0 +1,12 @@
+class DXRPaulDenton injects PaulDenton;
+
+// if his shields are down, allow him to be stunned/gassed
+function GotoDisabledState(name damageType, EHitLocation hitPos)
+{
+    if(EmpHealth > 0) {
+        MaybeDrawShield();
+        Super.GotoDisabledState(damageType, hitPos);
+    }
+    else
+        Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
+}

--- a/DXRBalance/DeusEx/Classes/PaulDenton.uc
+++ b/DXRBalance/DeusEx/Classes/PaulDenton.uc
@@ -3,10 +3,14 @@ class DXRPaulDenton injects PaulDenton;
 // if his shields are down, allow him to be stunned/gassed
 function GotoDisabledState(name damageType, EHitLocation hitPos)
 {
-    if(EmpHealth > 0) {
-        MaybeDrawShield();
+    if(ShieldDamage(damageType) < 1) {
+        if(EmpHealth > 0) {
+            MaybeDrawShield();
+            Super.GotoDisabledState(damageType, hitPos);
+        }
+        else
+            Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
+    } else {
         Super.GotoDisabledState(damageType, hitPos);
     }
-    else
-        Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
 }

--- a/DXRBalance/DeusEx/Classes/WaltonSimons.uc
+++ b/DXRBalance/DeusEx/Classes/WaltonSimons.uc
@@ -1,0 +1,12 @@
+class DXRWaltonSimons injects WaltonSimons;
+
+// if his shields are down, allow him to be stunned/gassed
+function GotoDisabledState(name damageType, EHitLocation hitPos)
+{
+    if(EmpHealth > 0) {
+        MaybeDrawShield();
+        Super.GotoDisabledState(damageType, hitPos);
+    }
+    else
+        Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
+}

--- a/DXRBalance/DeusEx/Classes/WaltonSimons.uc
+++ b/DXRBalance/DeusEx/Classes/WaltonSimons.uc
@@ -3,10 +3,14 @@ class DXRWaltonSimons injects WaltonSimons;
 // if his shields are down, allow him to be stunned/gassed
 function GotoDisabledState(name damageType, EHitLocation hitPos)
 {
-    if(EmpHealth > 0) {
-        MaybeDrawShield();
+    if(ShieldDamage(damageType) < 1) {
+        if(EmpHealth > 0) {
+            MaybeDrawShield();
+            Super.GotoDisabledState(damageType, hitPos);
+        }
+        else
+            Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
+    } else {
         Super.GotoDisabledState(damageType, hitPos);
     }
-    else
-        Super(HumanMilitary).GotoDisabledState(damageType, hitPos);
 }

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -894,6 +894,8 @@ static function int GetRotationOffset(class<Actor> c)
         return 16384;
     if(ClassIsChildOf(c, class'ProjectileGenerator'))
         return 16384;
+    if(ClassIsChildOf(c, class'#var(prefix)Button1'))
+        return 16384;
     //ComputerPersonal is fine without this, so just leave it commented out
     //if(ClassIsChildOf(c, class'#var(prefix)ComputerPersonal'))
     //    return 32768;

--- a/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -4,13 +4,13 @@ simulated static function CurrentVersion(optional out int major, optional out in
 {
     major=2;
     minor=7;
-    patch=2;
-    build=3;//build can't be higher than 99
+    patch=3;
+    build=0;//build can't be higher than 99
 }
 
 simulated static function bool VersionIsStable()
 {
-    return true;
+    return false;
 }
 
 simulated static function string VersionString(optional bool full)
@@ -18,7 +18,7 @@ simulated static function string VersionString(optional bool full)
     local int major,minor,patch,build;
     local string status;
 
-    status = "";
+    status = "Alpha";
 
     if(status!="") {
         status = " " $ status;

--- a/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -2,9 +2,9 @@ class DXRVersion extends Info;
 
 simulated static function CurrentVersion(optional out int major, optional out int minor, optional out int patch, optional out int build)
 {
-    major=2;
-    minor=7;
-    patch=3;
+    major=3;
+    minor=0;
+    patch=0;
     build=0;//build can't be higher than 99
 }
 

--- a/DXRFixes/DeusEx/Classes/Animal.uc
+++ b/DXRFixes/DeusEx/Classes/Animal.uc
@@ -1,6 +1,8 @@
 class DXRAnimal merges Animal;
 // TODO: we can change this to injects but it breaks savegame compatibility
 
+var bool bHasBeenPet;
+
 function float ModifyDamage(int Damage, Pawn instigatedBy, Vector hitLocation,
                             Vector offset, Name damageType)
 {
@@ -10,4 +12,54 @@ function float ModifyDamage(int Damage, Pawn instigatedBy, Vector hitLocation,
 function PlayDying(name damageType, vector hitLoc)
 {
     Super(FixScriptedPawn).PlayDying(damageType, hitLoc);
+}
+
+//Animal petting
+function Timer()
+{
+    local DXRCameraModes camera;
+
+    foreach AllActors(class'DXRCameraModes',camera)
+        break;
+
+    if (camera!=None) {
+        camera.DisableTempCamera();
+
+        if (!bHasBeenPet){
+            bHasBeenPet=True;
+            class'DXREvents'.static.MarkBingo(camera.dxr,"PetAnimal_"$Class.Name);
+        }
+    }
+}
+
+function PetAnimal(#var(PlayerPawn) petter)
+{
+    local DXRCameraModes camera;
+    local float animTime;
+
+    if (petter==None) return;
+    if (GetAllianceType('player')==ALLIANCE_Hostile) return;
+
+    foreach AllActors(class'DXRCameraModes',camera)
+        break;
+
+    camera.EnableTempThirdPerson();
+
+    //This should probably have some logic around crouching
+    if (petter.Location.Z - Location.Z < 16){
+        petter.PlayAnim('PushButton',0.75,0.5);
+        animTime=2.25;
+    }else{
+        petter.PlayAnim('Pickup',0.5,0.1);
+        animTime=1.5;
+    }
+    SetTimer(animTime,False);
+
+}
+
+function Frob(Actor Frobber, Inventory frobWith)
+{
+    if (#var(PlayerPawn)(Frobber)!=None){
+        PetAnimal(#var(PlayerPawn)(Frobber));
+    }
 }

--- a/DXRFixes/DeusEx/Classes/Animal.uc
+++ b/DXRFixes/DeusEx/Classes/Animal.uc
@@ -41,7 +41,7 @@ function PetAnimal(#var(PlayerPawn) petter)
     local bool highPet;
 
     if (petter==None) return;
-    if (GetAllianceType('player')==ALLIANCE_Hostile) return;
+    //if (GetAllianceType('player')==ALLIANCE_Hostile) return;
 
     foreach AllActors(class'DXRCameraModes',camera)
         break;

--- a/DXRFixes/DeusEx/Classes/Animal.uc
+++ b/DXRFixes/DeusEx/Classes/Animal.uc
@@ -2,6 +2,7 @@ class DXRAnimal merges Animal;
 // TODO: we can change this to injects but it breaks savegame compatibility
 
 var bool bHasBeenPet;
+var bool bPetInProgress;
 
 function float ModifyDamage(int Damage, Pawn instigatedBy, Vector hitLocation,
                             Vector offset, Name damageType)
@@ -14,10 +15,11 @@ function PlayDying(name damageType, vector hitLoc)
     Super(FixScriptedPawn).PlayDying(damageType, hitLoc);
 }
 
-//Animal petting
-function Timer()
+function EndPetting(optional bool bInterrupted)
 {
     local DXRCameraModes camera;
+
+    if (!bPetInProgress) return;
 
     foreach AllActors(class'DXRCameraModes',camera)
         break;
@@ -25,13 +27,26 @@ function Timer()
     if (camera!=None) {
         camera.DisableTempCamera();
 
-        if (!bHasBeenPet){
+        if (!bHasBeenPet && !bInterrupted){
             bHasBeenPet=True;
             class'DXREvents'.static.MarkBingo(camera.dxr,"PetAnimal_"$Class.Name);
         }
         camera.player().bBlockAnimations=False;
         camera.player().AnimEnd(); //Kicks the appropriate normal animations off again
     }
+    bPetInProgress=False;
+}
+
+//Animal petting
+function Timer()
+{
+    EndPetting();
+}
+
+function Destroyed()
+{
+    EndPetting(True); //If they die before you finish petting them, don't mark the bingo
+    Super.Destroyed();
 }
 
 function PetAnimal(#var(PlayerPawn) petter)
@@ -44,6 +59,7 @@ function PetAnimal(#var(PlayerPawn) petter)
     if (petter.InHand!=None) return; //Must have free hands to pet!
     if (petter.Region.Zone.bWaterZone) return; //No underwater petting (but you can pet things that are IN the water)
     if (Fly(self)!=None) return; //No, you can't pet the flies
+    if (bPetInProgress) return; //No pet interruptions
     //if (GetAllianceType('player')==ALLIANCE_Hostile) return;
 
     foreach AllActors(class'DXRCameraModes',camera)
@@ -71,6 +87,7 @@ function PetAnimal(#var(PlayerPawn) petter)
         animTime=1.25;
     }
     SetTimer(animTime,False);
+    bPetInProgress=True;
 
 }
 

--- a/DXRFixes/DeusEx/Classes/Animal.uc
+++ b/DXRFixes/DeusEx/Classes/Animal.uc
@@ -29,13 +29,16 @@ function Timer()
             bHasBeenPet=True;
             class'DXREvents'.static.MarkBingo(camera.dxr,"PetAnimal_"$Class.Name);
         }
+        camera.player().bPetting=False;
+        camera.player().AnimEnd();
     }
 }
 
 function PetAnimal(#var(PlayerPawn) petter)
 {
     local DXRCameraModes camera;
-    local float animTime;
+    local float animTime,tweenTime;
+    local bool highPet;
 
     if (petter==None) return;
     if (GetAllianceType('player')==ALLIANCE_Hostile) return;
@@ -45,13 +48,24 @@ function PetAnimal(#var(PlayerPawn) petter)
 
     camera.EnableTempThirdPerson();
 
-    //This should probably have some logic around crouching
-    if (petter.Location.Z - Location.Z < 16){
-        petter.PlayAnim('PushButton',0.75,0.5);
-        animTime=2.25;
+    highPet=False;
+    if ((petter.bIsCrouching || petter.bForceDuck)){
+        if (Location.Z - petter.Location.Z > 16){
+            highPet=True;
+        }
+    } else {
+        if (petter.Location.Z - Location.Z < 16){
+            highPet=True;
+        }
+    }
+
+    petter.bPetting=True;
+    if (highPet){
+        petter.PlayAnim('PushButton',0.75,0.1);
+        animTime=1.75;
     }else{
         petter.PlayAnim('Pickup',0.5,0.1);
-        animTime=1.5;
+        animTime=1.25;
     }
     SetTimer(animTime,False);
 

--- a/DXRFixes/DeusEx/Classes/Animal.uc
+++ b/DXRFixes/DeusEx/Classes/Animal.uc
@@ -41,6 +41,9 @@ function PetAnimal(#var(PlayerPawn) petter)
     local bool highPet;
 
     if (petter==None) return;
+    if (petter.InHand!=None) return; //Must have free hands to pet!
+    if (petter.Region.Zone.bWaterZone) return; //No underwater petting (but you can pet things that are IN the water)
+    if (Fly(self)!=None) return; //No, you can't pet the flies
     //if (GetAllianceType('player')==ALLIANCE_Hostile) return;
 
     foreach AllActors(class'DXRCameraModes',camera)

--- a/DXRFixes/DeusEx/Classes/Animal.uc
+++ b/DXRFixes/DeusEx/Classes/Animal.uc
@@ -29,8 +29,8 @@ function Timer()
             bHasBeenPet=True;
             class'DXREvents'.static.MarkBingo(camera.dxr,"PetAnimal_"$Class.Name);
         }
-        camera.player().bPetting=False;
-        camera.player().AnimEnd();
+        camera.player().bBlockAnimations=False;
+        camera.player().AnimEnd(); //Kicks the appropriate normal animations off again
     }
 }
 
@@ -59,7 +59,7 @@ function PetAnimal(#var(PlayerPawn) petter)
         }
     }
 
-    petter.bPetting=True;
+    petter.bBlockAnimations=True;
     if (highPet){
         petter.PlayAnim('PushButton',0.75,0.1);
         animTime=1.75;

--- a/DXRFixes/DeusEx/Classes/BeamTrigger.uc
+++ b/DXRFixes/DeusEx/Classes/BeamTrigger.uc
@@ -11,6 +11,50 @@ function bool IsRelevant( actor Other )
     return Super.IsRelevant(Other);
 }
 
+function TakeDamage(int Damage, Pawn EventInstigator, vector HitLocation, vector Momentum, name DamageType)
+{
+    local MetalFragment frag;
+
+    if (DamageType == 'EMP')
+    {
+        confusionTimer = 0;
+        if (!bConfused)
+        {
+            bConfused = True;
+            PlaySound(sound'EMPZap', SLOT_None,,, 1280);
+        }
+    }
+    else if ((DamageType == 'Exploded') || (DamageType == 'Shot') || (DamageType == 'Sabot'))
+    {
+        if (Damage >= minDamageThreshold) {
+            HitPoints -= Damage;
+        } else {
+            //Damage doesn't meet minimum damage threshold
+            //Logic from DeusExDecoration - sabot does 50% damage, explosions 25%
+            if (DamageType == 'Exploded'){
+                HitPoints -= Damage * 0.25;
+            } else if  (DamageType == 'Sabot'){
+                HitPoints -= Damage * 0.5;
+            }
+        }
+
+    }
+
+    if (HitPoints <= 0)
+    {
+        frag = Spawn(class'MetalFragment', Owner);
+        if (frag != None)
+        {
+            frag.Instigator = EventInstigator;
+            frag.CalcVelocity(Momentum,0);
+            frag.DrawScale = 0.5*FRand();
+            frag.Skin = GetMeshTexture();
+        }
+
+        Destroy();
+    }
+}
+
 defaultproperties
 {
     bProjTarget=true

--- a/DXRFixes/DeusEx/Classes/Carcass.uc
+++ b/DXRFixes/DeusEx/Classes/Carcass.uc
@@ -126,13 +126,12 @@ function Destroyed()
 }
 
 //Toss the item, but not very hard
-function TossItem(Inventory inv, DeusExPlayer Frobber){
-    local float xVel,yVel;
+function TossItem(Inventory inv){
     local vector velocity;
 
     DeleteInventory(inv);
     class'DXRActorsBase'.static.ThrowItem(inv, 0.5);
-    inv.SetLocation( Location + vect(0,0,20));
+    inv.SetLocation(Location + vect(0,0,20));
 
     velocity.X = ((FRand() - 0.5) * 2);
     velocity.Y = ((FRand() - 0.5) * 2);
@@ -258,7 +257,28 @@ function Frob(Actor Frobber, Inventory frobWith)
 function bool TryLootItem(DeusExPlayer player, Inventory item)
 {
     local DeusExPickup invItem;
-    local int itemCount;
+    local int itemCount, newAmmoAmmout, ammoAddedAmount;
+    local Weapon weap;
+    local Ammo playerAmmo;
+
+    if (class'DXRLoadouts'.static.IsRefused(item.class)) {
+        weap = Weapon(item);
+        if (weap != None && weap.AmmoName != class'AmmoNone') {
+            playerAmmo = Ammo(player.FindInventoryType(weap.AmmoName));
+            if (playerAmmo == None) {
+                playerAmmo = player.Spawn(weap.AmmoName);
+                playerAmmo.GiveTo(player);
+            }
+            newAmmoAmmout = Min(playerAmmo.MaxAmmo, playerAmmo.AmmoAmount + weap.PickupAmmoCount);
+            ammoAddedAmount = newAmmoAmmout - playerAmmo.AmmoAmount;
+            playerAmmo.AmmoAmount = newAmmoAmmout;
+            weap.PickupAmmoCount -= ammoAddedAmount;
+        }
+
+        TossItem(item);
+
+        return true;
+    }
 
     if (item.IsA('NanoKey'))
     {
@@ -313,7 +333,7 @@ function bool TryLootItem(DeusExPlayer player, Inventory item)
             {
                 player.ClientMessage(Sprintf(msgCannotPickup, invItem.itemName));
                 //Also toss the item out of the carcass
-                TossItem(item,player);
+                TossItem(item);
             }
         }
         else
@@ -427,7 +447,7 @@ function bool TryLootWeapon(DeusExPlayer player, DeusExWeapon item)
         {
             player.ClientMessage(Sprintf(player.InventoryFull, item.itemName));
             //Also toss the item out of the carcass
-            TossItem(item,player);
+            TossItem(item);
             return true;
         }
 
@@ -439,7 +459,7 @@ function bool TryLootWeapon(DeusExPlayer player, DeusExWeapon item)
             player.ClientMessage(Sprintf(player.InventoryFull, item.itemName));
 
             //Also toss the item out of the carcass
-            TossItem(item,player);
+            TossItem(item);
             return true;
         }
 
@@ -527,7 +547,7 @@ function bool TryLootRegularItem(DeusExPlayer player, Inventory item)
             player.ClientMessage(Item.PickupMessage @ Item.itemArticle @ Item.itemName, 'Pickup');
             PlaySound(Item.PickupSound);
         } else {
-            TossItem(item,player);
+            TossItem(item);
         }
         return true;
     }

--- a/DXRFixes/DeusEx/Classes/Carcass.uc
+++ b/DXRFixes/DeusEx/Classes/Carcass.uc
@@ -267,6 +267,7 @@ function bool TryLootItem(DeusExPlayer player, Inventory item)
             playerAmmo = Ammo(player.FindInventoryType(weap.AmmoName));
             if (playerAmmo == None) {
                 playerAmmo = player.Spawn(weap.AmmoName);
+                playerAmmo.AmmoAmount = 0;
                 playerAmmo.GiveTo(player);
             }
             newAmmoAmmout = Min(playerAmmo.MaxAmmo, playerAmmo.AmmoAmount + weap.PickupAmmoCount);

--- a/DXRFixes/DeusEx/Classes/LaserTrigger.uc
+++ b/DXRFixes/DeusEx/Classes/LaserTrigger.uc
@@ -46,6 +46,50 @@ function Tick(float deltaTime)
     }
 }
 
+function TakeDamage(int Damage, Pawn EventInstigator, vector HitLocation, vector Momentum, name DamageType)
+{
+    local MetalFragment frag;
+
+    if (DamageType == 'EMP')
+    {
+        confusionTimer = 0;
+        if (!bConfused)
+        {
+            bConfused = True;
+            PlaySound(sound'EMPZap', SLOT_None,,, 1280);
+        }
+    }
+    else if ((DamageType == 'Exploded') || (DamageType == 'Shot') || (DamageType == 'Sabot'))
+    {
+        if (Damage >= minDamageThreshold) {
+            HitPoints -= Damage;
+        } else {
+            //Damage doesn't meet minimum damage threshold
+            //Logic from DeusExDecoration - sabot does 50% damage, explosions 25%
+            if (DamageType == 'Exploded'){
+                HitPoints -= Damage * 0.25;
+            } else if  (DamageType == 'Sabot'){
+                HitPoints -= Damage * 0.5;
+            }
+        }
+
+    }
+
+    if (HitPoints <= 0)
+    {
+        frag = Spawn(class'MetalFragment', Owner);
+        if (frag != None)
+        {
+            frag.Instigator = EventInstigator;
+            frag.CalcVelocity(Momentum,0);
+            frag.DrawScale = 0.5*FRand();
+            frag.Skin = GetMeshTexture();
+        }
+
+        Destroy();
+    }
+}
+
 defaultproperties
 {
     bProjTarget=true

--- a/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
+++ b/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
@@ -142,6 +142,18 @@ function Carcass SpawnCarcass()
     return Super.SpawnCarcass();
 }
 
+// only draw a new shield if we haven't spawned one recently
+function MaybeDrawShield()
+{
+    local EllipseEffect shield;
+
+    foreach BasedActors(class'EllipseEffect', shield) {
+        if(shield.LifeSpan > 0.6) return;
+    }
+
+    DrawShield();
+}
+
 function TakeDamageBase(int Damage, Pawn instigatedBy, Vector hitlocation, Vector momentum, name damageType,
                         bool bPlayAnim)
 {

--- a/DXRFixes/DeusEx/Classes/Skill.uc
+++ b/DXRFixes/DeusEx/Classes/Skill.uc
@@ -1,0 +1,43 @@
+class DXRSkill merges Skill;
+// merges instead of injects, because: Error, DeusEx.Skill's superclass must be Engine.Actor, not DeusEx.SkillInjBase
+
+// IncLevel is mostly vanilla, but with a message when upgrading
+function bool IncLevel(optional DeusExPlayer usePlayer)
+{
+    local DeusExPlayer localPlayer;
+
+    // First make sure we're not maxed out
+    if (CurrentLevel < 3)
+    {
+        // If "usePlayer" is passed in, then we want to use this
+        // as the basis for making our calculations, temporarily
+        // overriding whatever this skill's player is set to.
+
+        if (usePlayer != None)
+            localPlayer = usePlayer;
+        else
+            localPlayer = Player;
+
+        // Now, if a player is defined, then check to see if there enough
+        // skill points available.  If no player is defined, just do it.
+        if (localPlayer != None)
+        {
+            if ((localPlayer.SkillPointsAvail >= Cost[CurrentLevel]))
+            {
+                // decrement the cost and increment the current skill level
+                localPlayer.SkillPointsAvail -= GetCost();
+                CurrentLevel++;
+                localPlayer.ClientMessage(SkillName $ " upgraded to " $ skillLevelStrings[CurrentLevel]);
+                return True;
+            }
+        }
+        else
+        {
+            CurrentLevel++;
+            log(SkillName $ " upgraded to " $ skillLevelStrings[CurrentLevel]);
+            return True;
+        }
+    }
+
+    return False;
+}

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
@@ -158,6 +158,9 @@ function AnyEntryMapFixes()
     // if you can talk to gunther then obviously he's been rescued
     DeleteConversationFlag(GetConversation('GuntherRescued'), 'GuntherFreed', true);
 
+    // you can't take a corpse alive and conscious
+    GetConversation('DL_Top').AddFlagRef('TerroristCommander_Dead', false);
+
     //Cut out the dialog for Paul giving you equipment
     if(dxr.flags.IsReducedRando()) return; // but not in reduced rando
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
@@ -339,5 +339,6 @@ function AnyEntryMapFixes()
         if (dxr.flagbase.getBool('SmugglerDoorDone')) {
             dxr.flagbase.setBool('MetSmuggler', true,, -1);
         }
+        break;
     }
 }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
@@ -23,6 +23,9 @@ function PreFirstEntryMapFixes()
     local OnceOnlyTrigger oot;
     local bool RevisionMaps;
     local bool VanillaMaps;
+    local #var(prefix)CrateUnbreakableSmall crateSmall;
+    local #var(prefix)CrateUnbreakableMed crateMedium;
+    local Vector loc;
 
 #ifdef injections
     local #var(prefix)Newspaper np;
@@ -78,6 +81,18 @@ function PreFirstEntryMapFixes()
         break;
     case "02_NYC_WAREHOUSE":
         if (VanillaMaps){
+            foreach RadiusActors(class'#var(prefix)CrateUnbreakableSmall', crateSmall, 8.0, vectm(-1658.93, 664.61, -358.68)) {
+                crateSmall.bIsSecretGoal = true;
+                loc = crateSmall.Location - vectm(0, 123.0, 0);
+                crateSmall.SetLocation(loc);
+                break;
+            }
+            foreach RadiusActors(class'#var(prefix)CrateUnbreakableMed', crateMedium, 20.0, vectm(-1606.68, 640.60, -435.55)) {
+                crateMedium.bIsSecretGoal = true;
+                loc = crateMedium.Location - vectm(0, 123.0, 0);
+                crateMedium.SetLocation(loc);
+            }
+
             npClass.static.SpawnInfoDevice(self,class'#var(prefix)NewspaperOpen',vectm(1700.929810,-519.988037,57.729870),rotm(0,0,0,0),'02_Newspaper06'); //Joe Greene article, table in room next to break room (near bathrooms)
             npClass.static.SpawnInfoDevice(self,class'#var(prefix)NewspaperOpen',vectm(-1727.644775,2479.614990,1745.724976),rotm(0,0,0,0),'02_Newspaper06'); //Next to apartment(?) door on rooftops, near elevator
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
@@ -324,7 +324,18 @@ function PostFirstEntryMapFixes()
 
 function AnyEntryMapFixes()
 {
-    if (dxr.localURL == "02_NYC_SMUG") {
+    Local Jock j;
+
+    switch (dxr.localURL) {
+    case "02_NYC_BAR":
+        if (dxr.flagbase.getBool('GeneratorBlown')) {
+            foreach AllActors(class'Jock', j) {
+                j.LeaveWorld();
+                break;
+            }
+        }
+        break;
+    case "02_NYC_SMUG":
         if (dxr.flagbase.getBool('SmugglerDoorDone')) {
             dxr.flagbase.setBool('MetSmuggler', true,, -1);
         }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
@@ -81,6 +81,7 @@ function PreFirstEntryMapFixes()
         break;
     case "02_NYC_WAREHOUSE":
         if (VanillaMaps){
+            // crates for climbing out of the sewer water
             foreach RadiusActors(class'#var(prefix)CrateUnbreakableSmall', crateSmall, 8.0, vectm(-1658.93, 664.61, -358.68)) {
                 crateSmall.bIsSecretGoal = true;
                 loc = crateSmall.Location - vectm(0, 123.0, 0);

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -353,6 +353,8 @@ function PreFirstEntryMapFixes()
             }
         }
 
+        SetAllLampsState(true, false, true); // alex isn't in his office
+
         //Spawn some placeholders for new item locations
         Spawn(class'PlaceholderItem',,, vectm(363.284149, 344.847, 50.32)); //Womens bathroom counter
         Spawn(class'PlaceholderItem',,, vectm(211.227, 348.46, 50.32)); //Mens bathroom counter
@@ -369,7 +371,7 @@ function PreFirstEntryMapFixes()
         Spawn(class'PlaceholderContainer',,, vectm(-1187,-1154,-31)); //Behind Jail Desk
         Spawn(class'PlaceholderContainer',,, vectm(2384,1669,-95)); //MJ12 Door
         Spawn(class'PlaceholderContainer',,, vectm(-383.6,1376,273)); //JC's Office
-        
+
         break;
     }
 }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -15,6 +15,7 @@ function PostFirstEntryMapFixes()
 {
     local Actor a;
     local bool RevisionMaps;
+    local #var(prefix)NanoKey key;
 
     RevisionMaps = class'DXRMapVariants'.static.IsRevisionMaps(player());
 
@@ -36,6 +37,14 @@ function PostFirstEntryMapFixes()
             AddActor(class'#var(prefix)CrateUnbreakableMed', vect(-9461.959961, 3320.718750, 75));
         }
         SetAllLampsState(true, true, false); // this map has one desk lamp, in an office no one is in
+        break;
+
+    case "03_NYC_AIRFIELD":
+        foreach AllActors(class'#var(prefix)NanoKey', key) {
+            if(key.KeyID == 'securitytower' && key.Owner == None) {
+                key.Destroy();
+            }
+        }
         break;
     }
 }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -32,7 +32,6 @@ function PreFirstEntryMapFixes()
 {
     local Actor a;
     local #var(prefix)ScriptedPawn p;
-    local Button1 b;
     local ElevatorMover e;
     local #var(DeusExPrefix)Mover m;
     local #var(prefix)AllianceTrigger at;
@@ -51,7 +50,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)TriadRedArrow bouncer;
     local #var(prefix)MapExit exit;
     local #var(prefix)BlackHelicopter jock;
-    local #var(prefix)Button1 button;
+    local #var(injectsprefix)Button1 button;
     local #var(prefix)BeamTrigger bt;
     local #var(prefix)LaserTrigger lt;
     local DXRButtonHoverHint buttonHint;
@@ -99,20 +98,20 @@ function PreFirstEntryMapFixes()
             }
 
             foreach AllActors(class'#var(prefix)MapExit',exit,'change_floors'){break;}
-            foreach AllActors(class'#var(prefix)Button1',button){
+            foreach AllActors(class'#var(injectsprefix)Button1',button){
                 if (button.Event=='change_floors'){
                     break;
                 }
             }
-
-            foreach AllActors(class'Button1', b) {
-                if (b.tag == 'Weapons_Lock_broken' || b.tag == 'Weapons_lock' || b.event == 'missile_door') {
-                    b.SetRotation(rotm(14400,16500,0,GetRotationOffset(class'Button1'))); //A similar rotation to original that only rotates in two axes instead of all three
-                }
-            }
-
             buttonHint = DXRButtonHoverHint(class'DXRButtonHoverHint'.static.Create(self, "", button.Location, button.CollisionRadius+5, button.CollisionHeight+5, exit));
             buttonHint.SetBaseActor(button);
+
+
+            foreach AllActors(class'#var(injectsprefix)Button1', button) {
+                if (button.tag == 'Weapons_Lock_broken' || button.tag == 'Weapons_lock' || button.event == 'missile_door') {
+                    button.SetRotation(rotm(14400,16500,0,GetRotationOffset(class'#var(injectsprefix)Button1'))); //A similar rotation to original that only rotates in two axes instead of all three
+                }
+            }
 
             class'PlaceholderEnemy'.static.Create(self,vectm(769,-520,144));
             class'PlaceholderEnemy'.static.Create(self,vectm(1620,-87,144));
@@ -190,7 +189,7 @@ function PreFirstEntryMapFixes()
         if (VanillaMaps){
             //Elevator to Versalife
             foreach AllActors(class'#var(prefix)MapExit',exit,'change_floors01'){break;}
-            foreach AllActors(class'#var(prefix)Button1',button){
+            foreach AllActors(class'#var(injectsprefix)Button1',button){
                 if (button.Event=='change_floors01'){
                     break;
                 }
@@ -200,7 +199,7 @@ function PreFirstEntryMapFixes()
 
             //Elevator to Helibase
             foreach AllActors(class'#var(prefix)MapExit',exit,'change_floors'){break;}
-            foreach AllActors(class'#var(prefix)Button1',button){
+            foreach AllActors(class'#var(injectsprefix)Button1',button){
                 if (button.Event=='change_floors'){
                     break;
                 }
@@ -228,11 +227,11 @@ function PreFirstEntryMapFixes()
             dts.bIsSecretGoal = true;// just in case you don't have DXRMissions enabled
         }
         if (VanillaMaps){
-            foreach AllActors(class'Button1',b)
+            foreach AllActors(class'#var(injectsprefix)Button1',button)
             {
-                if (b.Event=='JockShaftTop')
+                if (button.Event=='JockShaftTop')
                 {
-                    b.Event='JocksElevatorTop';
+                    button.Event='JocksElevatorTop';
                 }
             }
 
@@ -324,7 +323,7 @@ function PreFirstEntryMapFixes()
 
         //Elevator to Versalife
         foreach AllActors(class'#var(prefix)MapExit',exit,'change_floors01'){break;}
-        foreach AllActors(class'#var(prefix)Button1',button){
+        foreach AllActors(class'#var(injectsprefix)Button1',button){
             if (button.Event=='change_floors01'){
                 break;
             }
@@ -334,7 +333,7 @@ function PreFirstEntryMapFixes()
 
         //Elevator to Level 2
         foreach AllActors(class'#var(prefix)MapExit',exit,'change_floors'){break;}
-        foreach AllActors(class'#var(prefix)Button1',button){
+        foreach AllActors(class'#var(injectsprefix)Button1',button){
             if (button.Event=='change_floors'){
                 break;
             }
@@ -503,7 +502,7 @@ function PreFirstEntryMapFixes()
 
         //Elevator to Market
         foreach AllActors(class'#var(prefix)MapExit',exit,'change_floors01'){break;}
-        foreach AllActors(class'#var(prefix)Button1',button){
+        foreach AllActors(class'#var(injectsprefix)Button1',button){
             if (button.Event=='change_floors01'){
                 break;
             }
@@ -513,7 +512,7 @@ function PreFirstEntryMapFixes()
 
         //Elevator to MJ12 Lab
         foreach AllActors(class'#var(prefix)MapExit',exit,'change_floors'){break;}
-        foreach AllActors(class'#var(prefix)Button1',button){
+        foreach AllActors(class'#var(injectsprefix)Button1',button){
             if (button.Event=='change_floors'){
                 break;
             }
@@ -546,7 +545,7 @@ function PreFirstEntryMapFixes()
 
         //Elevator to MJ12 Lab
         foreach AllActors(class'#var(prefix)MapExit',exit,'change_floors'){break;}
-        foreach AllActors(class'#var(prefix)Button1',button){
+        foreach AllActors(class'#var(injectsprefix)Button1',button){
             if (button.Event=='change_floors'){
                 break;
             }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -109,7 +109,7 @@ function PreFirstEntryMapFixes()
 
             foreach AllActors(class'#var(injectsprefix)Button1', button) {
                 if (button.tag == 'Weapons_Lock_broken' || button.tag == 'Weapons_lock' || button.event == 'missile_door') {
-                    button.SetRotation(rotm(14400,16500,0,GetRotationOffset(class'#var(injectsprefix)Button1'))); //A similar rotation to original that only rotates in two axes instead of all three
+                    button.SetRotation(rotm(14400,16500,0,GetRotationOffset(button.class))); //A similar rotation to original that only rotates in two axes instead of all three
                 }
             }
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -107,7 +107,7 @@ function PreFirstEntryMapFixes()
 
             foreach AllActors(class'Button1', b) {
                 if (b.tag == 'Weapons_Lock_broken' || b.tag == 'Weapons_lock' || b.event == 'missile_door') {
-                    b.SetRotation(rot(14312, 18536, 51312)); // my guess is that the vanilla rotations were each done by eye
+                    b.SetRotation(rotm(14400,16500,0,GetRotationOffset(class'Button1'))); //A similar rotation to original that only rotates in two axes instead of all three
                 }
             }
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM09.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM09.uc
@@ -212,6 +212,8 @@ function PreFirstEntryMapFixes()
             foreach AllActors(class'#var(prefix)BlackHelicopter',jock,'BlackHelicopter'){break;}
             hoverHint = class'DXRTeleporterHoverHint'.static.Create(self, "", jock.Location, jock.CollisionRadius+5, jock.CollisionHeight+5, exit);
             hoverHint.SetBaseActor(jock);
+
+            AddSwitch( vect(4973.640137, 6476.444336, 1423.943848), rot(0,32768,0), 'Crane');
         }
 
         //They put the key ID in the tag for some reason

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
@@ -53,6 +53,17 @@ function CheckConfig()
     Super.CheckConfig();
 }
 
+function FixJockExplosion()
+{
+#ifdef injections
+    local BlackHelicopter chopper;
+
+    foreach AllActors(class'BlackHelicopter',chopper,'heli_sabotaged'){
+        chopper.bDying=True;
+    }
+#endif
+}
+
 function PreFirstEntryMapFixes_Bunker()
 {
     local DeusExMover d;
@@ -143,6 +154,8 @@ function PreFirstEntryMapFixes_Bunker()
 
     //Button to open blast doors from inside
     AddSwitch( vect(2015.894653,1390.463867,-839.793091), rot(0, -16328, 0), 'blast_door');
+
+    FixJockExplosion();
 
     Spawn(class'#var(prefix)LiquorBottle',,, vectm(1005.13,2961.26,-480)); //Liquor in a locker, so every mission has alcohol
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -18,6 +18,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)MapExit exit;
     local #var(prefix)BlackHelicopter jock;
     local bool VanillaMaps;
+    local FlagTrigger ft;
 
     VanillaMaps = class'DXRMapVariants'.static.IsVanillaMaps(player());
 
@@ -83,6 +84,31 @@ function PreFirstEntryMapFixes()
             }
 
             SetAllLampsState(false, false, false); // surely Nicolette didn't leave all the lights on when she moved out
+
+            foreach AllActors(class'FlagTrigger', ft) {
+                if (ft.FlagName == 'ChateauInCellar') {
+                    ft.Destroy();
+                    break;
+                }
+            }
+
+            ft = Spawn(class'FlagTrigger',,, vectm(1364.082031, 2048.021240, -311.900421));
+            ft.SetCollisionSize(250.0, 40.0);
+            ft.bWhileStandingOnly = true;
+            ft.bTriggerOnceOnly = false;
+            ft.FlagName = 'ChateauInCellar';
+
+            ft = Spawn(class'FlagTrigger',,, vectm(979.147034, 2428.054932, -392.494201));
+            ft.SetCollisionSize(300.0, 40.0);
+            ft.bWhileStandingOnly = true;
+            ft.bTriggerOnceOnly = false;
+            ft.FlagName = 'ChateauInCellar';
+
+            ft = Spawn(class'FlagTrigger',,, vectm(1798.484375, 2425.229736, -392.494201));
+            ft.SetCollisionSize(300.0, 40.0);
+            ft.bWhileStandingOnly = true;
+            ft.bTriggerOnceOnly = false;
+            ft.FlagName = 'ChateauInCellar';
         }
         break;
     case "10_PARIS_METRO":
@@ -232,6 +258,7 @@ function AnyEntryMapFixes()
         break;
     case "10_PARIS_CHATEAU":
         FixConversationAddNote(GetConversation('NicoletteInStudy'),"I used to use that computer whenever I was at home");
+        FixConversationFlag(GetConversation('NicoletteInCellar'), 'ChateauInCeller', true, 'ChateauInCellar', true);
         break;
     case "10_PARIS_METRO":
         //Tong gives you a map of the streets when you enter via the subway

--- a/DXRModules/DeusEx/Classes/DXRAugmentations.uc
+++ b/DXRModules/DeusEx/Classes/DXRAugmentations.uc
@@ -337,7 +337,8 @@ simulated function RandoAug(Augmentation a)
 
     aug_value_wet_dry = float(dxr.flags.settings.aug_value_rando) / 100.0;
     if(( aug_value_wet_dry > 0
-        && ( #var(prefix)AugVision(a) != None || #var(prefix)AugMuscle(a) != None) || #var(prefix)AugHeartLung(a) != None )
+        && ( #var(prefix)AugVision(a) != None || #var(prefix)AugMuscle(a) != None)
+        || (#var(prefix)AugHeartLung(a) != None && !#defined(injections)) )
     ) {
         // don't randomize vision aug strength and instead randomize its energy usage
         // so it can be used for speedrun strategies with specific spots to check from
@@ -403,7 +404,7 @@ simulated function string DescriptionLevel(Actor act, int i, out string word)
         word = "Strength";
         return int(a.LevelValues[i] * 100.0) $ "%";
     }
-    else if( a.Class == class'#var(prefix)AugPower') {
+    else if( a.Class == class'#var(prefix)AugPower' || (a.Class == class'#var(prefix)AugHeartLung' && #defined(injections))) {
         word = "Energy";
         return int(a.LevelValues[i] * 100.0) $ "%";
     }
@@ -430,6 +431,10 @@ simulated function string DescriptionLevel(Actor act, int i, out string word)
         if(a.LevelValues[i] < 0)
             a.LevelValues[i] = 0;
         return int(a.LevelValues[i] / 16.0) $" ft";
+    }
+    else if( a.Class == class'#var(prefix)AugHeartLung') {
+        word = "Energy Usage";
+        return Max(int(a.LevelValues[i] * 100.0), 0) $ "%";
     }
 
 #ifdef gmdx

--- a/DXRModules/DeusEx/Classes/DXRCameraModes.uc
+++ b/DXRModules/DeusEx/Classes/DXRCameraModes.uc
@@ -83,6 +83,7 @@ function SetFirstPersonCamera()
         player().bCrosshairVisible=True;
     }
     player().ViewTarget=None;
+    player().Style= STY_Normal;
     if (reCam!=None){
         reCam.Destroy();
         reCam=None;
@@ -110,6 +111,7 @@ function SetFixedCamera()
 #ifdef vanilla
     player().bBehindView=False;
     player().bCrosshairVisible=False;
+    player().Style= STY_Normal;
     if (reCam==None || reCam.bDeleteMe){
         SpawnRECam();
     }

--- a/DXRModules/DeusEx/Classes/DXRDatacubes.uc
+++ b/DXRModules/DeusEx/Classes/DXRDatacubes.uc
@@ -621,6 +621,7 @@ function _RandoInfoDev(#var(injectsprefix)InformationDevices id, bool containers
     local Actor temp[1024];
     local int num, slot, numHasPass, bads, tries;
     local int hasPass[64];
+    local Vector newloc;
 
     InfoDevsHasPass(id, hasPass, numHasPass);
 
@@ -665,7 +666,10 @@ function _RandoInfoDev(#var(injectsprefix)InformationDevices id, bool containers
         l("swapping infodevice "$ActorToString(id)$" with "$temp[slot] $" ("$temp[slot].Location$")");
 
         if(PlaceholderItem(temp[slot]) != None) {
+            newloc = temp[slot].Location;
+            newloc.Z -= temp[slot].CollisionHeight - id.CollisionHeight;
             temp[slot].SetCollisionSize(id.CollisionRadius, id.CollisionHeight);
+            temp[slot].SetLocation(newloc);
         }
         // Swap argument A is more lenient with collision than argument B
         if(Swap(temp[slot], id)) break;

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -289,6 +289,7 @@ function SetWatchFlags() {
     local #var(prefix)Fan1 fan1;
     local #var(prefix)Button1 button;
     local #var(prefix)VialCrack zyme;
+    local #var(prefix)ControlPanel conPanel;
     local Dispatcher disp;
     local int i;
 
@@ -1254,15 +1255,12 @@ function SetWatchFlags() {
 
         bt = class'BingoTrigger'.static.Create(self,'EnterUC',vectm(1135,2360,-2138),40,40);
 
-        bt = class'BingoTrigger'.static.Create(self,'VandenbergComputerElec',vectm(0,0,0));
-        bt.bUntrigger=True;
-        bt.Tag='level1_emitter';
-        bt.bDestroyOthers=False;
-
-        bt = class'BingoTrigger'.static.Create(self,'VandenbergComputerElec',vectm(0,0,0));
-        bt.bUntrigger=True;
-        bt.Tag='level3_emitter';
-        bt.bDestroyOthers=False;
+        foreach AllActors(class'#var(prefix)ControlPanel',conPanel){
+            bt = class'BingoTrigger'.static.Create(self,'VandenbergComputerElec',conPanel.Location);
+            bt.Tag=conPanel.name;
+            bt.bDestroyOthers=False;
+            conPanel.event=conPanel.name;
+        }
 
         break;
     case "14_OCEANLAB_SILO":

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -2164,6 +2164,9 @@ static function int GetBingoFailedEvents(DXRando dxr, string eventname, out stri
         case "NSFSignalSent":
             failed[num_failed++] = "M04PlayerLikesUNATCO_Played";
             return num_failed;
+        case "GeneratorBlown":
+            failed[num_failed++] = "JockSecondStory";
+            return num_failed;
     }
 
     return num_failed;

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -2035,6 +2035,21 @@ function string RemapBingoEvent(string eventname)
         case "DonDone":
         case "LennyDone":
             return "GiveZyme";
+        case "PetAnimal_Karkian":
+        case "PetAnimal_KarkianBaby":
+            return "PetKarkians";
+        case "PetAnimal_Doberman":
+        case "PetAnimal_Mutt":
+            return "PetDogs";
+        case "PetAnimal_Fish":
+        case "PetAnimal_Fish2":
+            return "PetFish";
+        case "PetAnimal_Pigeon":
+        case "PetAnimal_Seagull":
+            return "PetBirds";
+        case "PetAnimal_Rat":
+        case "PetAnimal_NastyRat":
+            return "PetRats";
         default:
             return eventname;
     }
@@ -3095,6 +3110,20 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             return "Knock out Louis Pan, the kid running a protection racket for the Luminous Path in the Wan Chai Market.  Crime (sometimes) doesn't pay.";
         case "MaggieLived":
             return "Leave Hong Kong for New York with Maggie Chow still alive and conscious.";
+        case "PetKarkians":
+            return "Hear me out - Karkians are basically just big puppies...  Give enough of them the head rubs they deserve!  Make sure your hands are empty, or you won't be able to pet anything!";
+        case "PetDogs":
+            return "That's right, you can pet the dog!  Give enough dogs some petting time.  Make sure your hands are empty, or you won't be able to pet anything!";
+        case "PetFish":
+            return "Trust me, fish like getting pet.  Max Chen has some fish in his office who would really appreciate it.  Make sure your hands are empty, or you won't be able to pet anything!";
+        case "PetBirds":
+            return "Ok, maybe you shouldn't pet the birds, but can you help yourself?  Give enough birds a pet!  Make sure your hands are empty, or you won't be able to pet anything!";
+        case "PetAnimal_Cat":
+            return "Ohhhh, that cat really wants to get pet!  Give enough cats a pet!  Make sure your hands are empty, or you won't be able to pet anything!";
+        case "PetAnimal_Greasel":
+            return "They might look a bit greasy and very mean, but they sure love head pats!  Give those greasels some pets!  Make sure your hands are empty, or you won't be able to pet anything!";
+        case "PetRats":
+            return "Get down there and pet enough rats!  Make sure your hands are empty, or you won't be able to pet anything!";
         default:
             return "Unable to find help text for event '"$event$"'|nReport this to the developers!";
     }
@@ -3478,6 +3507,15 @@ defaultproperties
     // bingo_options()=(event="MarketKid_BindNameUnconscious",desc="Crime doesn't pay",max=1,missions=64)
     bingo_options(328)=(event="MaggieLived",desc="Let Maggie Live",max=1,missions=64)
     bingo_options(329)=(event="SoldRenaultZyme",desc="Sell Zyme to Renault",max=5,missions=1024)
+#ifdef vanilla
+    bingo_options(330)=(event="PetKarkians",desc="Karkians are just big leather dogs (%s)",max=3,missions=49248)
+    bingo_options(331)=(event="PetDogs",desc="You can pet the dog (%s)",max=5,missions=21604)
+    bingo_options(332)=(event="PetFish",desc="They feel kind of slimy (%s)",max=5,missions=64)
+    bingo_options(333)=(event="PetBirds",desc="Feel the hollow bones (%s)",max=3,missions=19806)
+    bingo_options(334)=(event="PetAnimal_Cat",desc="Here kitty, kitty, kitty! (%s)",max=3,missions=7256)
+    bingo_options(335)=(event="PetAnimal_Greasel",desc="Green, Greasy, and very pettable (%s)",max=5,missions=50272)
+    bingo_options(336)=(event="PetRats",desc="Pat dat rat (%s)",max=25,missions=53118)
+#endif
 
 
 
@@ -3537,5 +3575,12 @@ defaultproperties
     mutually_exclusive(51)=(e1="AimeeLeMerchantLived",e2="lemerchant_Dead")
     mutually_exclusive(52)=(e1="AimeeLeMerchantLived",e2="aimee_Dead")
     mutually_exclusive(52)=(e1="MaggieLived",e2="MaggieCanFly")
-    mutually_exclusive(53)=(e1="MeetRenault_Played",e2="SoldRenaultZyme")
+    mutually_exclusive(53)=(e1="GoneFishing",e2="PetFish")
+    mutually_exclusive(54)=(e1="BirdWatching",e2="PetBirds")
+    mutually_exclusive(55)=(e1="Cat_peeptime",e2="PetAnimal_Cat")
+    mutually_exclusive(56)=(e1="Greasel_ClassDead",e2="PetAnimal_Greasel")
+    mutually_exclusive(57)=(e1="Rat_ClassDead",e2="PetRats")
+    mutually_exclusive(58)=(e1="Karkian_ClassDead",e2="PetKarkians")
+    mutually_exclusive(59)=(e1="PerformBurder",e2="PetBirds")
+    mutually_exclusive(60)=(e1="PetRats",e2="PetBirds")
 }

--- a/DXRModules/DeusEx/Classes/DXRFashion.uc
+++ b/DXRModules/DeusEx/Classes/DXRFashion.uc
@@ -255,9 +255,10 @@ simulated function AddInfluencer(class<ScriptedPawn> male, class<ScriptedPawn> f
 simulated function AddInfluencerName(class<ScriptedPawn> male, name female)
 {
     local class<ScriptedPawn> femaleClass;
+
     // don't want to require LDDP for compilation, so this handles it at runtime
-    if( isFemale )
-        femaleClass = GetInfluencerClass(female);
+    femaleClass = GetInfluencerClass(female);
+
     AddInfluencer(male, femaleClass);
 }
 

--- a/DXRModules/DeusEx/Classes/DXRHints.uc
+++ b/DXRModules/DeusEx/Classes/DXRHints.uc
@@ -41,6 +41,7 @@ simulated function InitHints()
     AddHint("Attaching a LAM or Gas Grenade to a wall can be very strong!", "Also try to lure enemies into them.");
     AddHint("You don't trigger your own grenades.", "Setup traps without fear.");
     AddHint("Use sabot shotgun rounds to kill the little spider bots.");
+    AddHint("Sabot rounds can damage tough objects no matter the damage threshold.","Check the highlight text!");
     AddHint("Grab a plasma rifle, blast everything in sight,", "then go get your items back.");
     if(dxr.flags.settings.energy != 100) {
         AddHint("Your max energy is "$dxr.flags.settings.energy$" points.", "Your energy meter shows percent relative to this value.");
@@ -108,7 +109,7 @@ simulated function InitHints()
             AddHint("The PS20 has been upgraded to the PS40", "and does significantly more damage.");
             AddHint("Flare darts now set enemies on fire for 3 seconds.");
             AddHint("Thowing knives deal more damage,", "and their speed and range increase with your low-tech skill.");
-            AddHint("Read the pop-up text on doors to see how many", "hits from your equiped weapon it takes to break it.");
+            AddHint("Read the pop-up text on doors to see how many", "hits from your equipped weapon it takes to break it.");
             AddHint("Vision Enhancement Aug and Tech Goggles can now see through walls", "even at level 1, and they stack.");
             AddHint("Vision Enhancement Aug can see goal items through walls at level 2.", "Use it to see what's inside locked boxes.");
         } else {

--- a/DXRModules/DeusEx/Classes/DXRKeys.uc
+++ b/DXRModules/DeusEx/Classes/DXRKeys.uc
@@ -957,6 +957,7 @@ function _RandoKey(#var(prefix)NanoKey k, bool containers)
     local Containers c;
     local int num, slot, tries;
     local bool vanilla_good;
+    local Vector newloc;
 
 #ifndef injections
     k.ItemName = k.default.ItemName $ " (" $ k.Description $ ")";
@@ -1014,7 +1015,10 @@ function _RandoKey(#var(prefix)NanoKey k, bool containers)
         info("key "$k.KeyID$" got num: "$num$", slot: "$slot$", actor: "$temp[slot] $" ("$temp[slot].Location$")");
 
         if(PlaceholderItem(temp[slot]) != None) {
+            newloc = temp[slot].Location;
+            newloc.Z -= temp[slot].CollisionHeight - k.CollisionHeight;
             temp[slot].SetCollisionSize(k.CollisionRadius, k.CollisionHeight);
+            temp[slot].SetLocation(newloc);
         }
         // Swap argument A is more lenient with collision than argument B
         if( Swap(temp[slot], k) ) break;

--- a/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -1,7 +1,5 @@
 class DXRLoadouts extends DXRActorsBase transient;
 
-const default_item_refusals = ",#var(prefix)Cigarettes,";
-
 var int loadout;//copy locally so we don't need to make this class transient and don't need to worry about re-entering and picking up an item before DXRando loads
 
 struct loadouts
@@ -477,7 +475,14 @@ function FirstEntry()
 simulated function PlayerLogin(#var(PlayerPawn) p)
 {
     Super.PlayerLogin(p);
+
     RandoStartingEquipment(p, false);
+#ifdef injections
+    class'MenuChoice_RefuseUseless'.static.SetRefusals();
+    class'MenuChoice_RefuseFoodDrink'.static.SetRefusals();
+    class'MenuChoice_RefuseMelee'.static.SetRefusals();
+    class'MenuChoice_RefuseMisc'.static.SetRefusals();
+#endif
 }
 
 simulated function PlayerRespawn(#var(PlayerPawn) p)
@@ -699,7 +704,7 @@ static function bool IsRefused(class<Inventory> type, optional out int strIdx)
     datastorage = class'DataStorage'.static.GetObj(class'DXRando'.default.dxr);
     refusals = datastorage.GetConfigKey("item_refusals");
     if(refusals == "") {
-        refusals = default_item_refusals;
+        return false;
     }
     strIdx = InStr(refusals, "," $ type.name $ ",");
     return strIdx != -1;
@@ -734,7 +739,7 @@ static function SetRefuseItem(class<Inventory> type)
     datastorage = class'DataStorage'.static.GetObj(class'DXRando'.default.dxr);
     refusals = datastorage.GetConfigKey("item_refusals");
 
-    if (refusals == "") refusals = default_item_refusals;
+    if (refusals == "") refusals = ",";
     refusals = refusals $ type.name $ ",";
 
     datastorage.SetConfig("item_refusals", refusals, 3600*24*366);

--- a/DXRModules/DeusEx/Classes/DXRNames.uc
+++ b/DXRModules/DeusEx/Classes/DXRNames.uc
@@ -122,7 +122,7 @@ static function string RandomNamePart(DXRando dxr, int min, int max)
         if ( i == 0 ) n = Caps(n);
     }
 
-    if(WordInStr(Caps(n), "FAG", 3, true) != -1 || WordInStr(Caps(n), "RAPE", 4, true) != -1) {
+    if(WordInStr(Caps(n), "FAG", 3, true) != -1 || WordInStr(Caps(n), "RAPE", 4, true) != -1 || WordInStr(Caps(n), "JEW", 3, true) != -1) {
         return RandomNamePart(dxr, min, max);
     }
     return n;

--- a/DXRModules/DeusEx/Classes/DXRReduceItems.uc
+++ b/DXRModules/DeusEx/Classes/DXRReduceItems.uc
@@ -210,6 +210,7 @@ function _ReduceWeaponAmmo(Weapon w, float mult)
     if( w.AmmoName == None || w.PickupAmmoCount <= 0 ) return;
     // don't reduce weapon PickupAmmoCount owned by Robots? does this matter?
     if(#var(prefix)Robot(w.Owner) != None) return;
+    if( w.bIsSecretGoal ) return;
 
     mult *= _GetItemMult(_item_reductions, w.AmmoName);
     mult = rngrangeseeded(mult, min_rate_adjust, max_rate_adjust, w.AmmoName);
@@ -224,6 +225,7 @@ function _ReduceAmmo(Ammo a, float mult)
 {
     // don't reduce ammo owned by pawns
     if( a.AmmoAmount <= 0 || CarriedItem(a) ) return;
+    if( a.bIsSecretGoal ) return;
 
     mult *= _GetItemMult(_item_reductions, a.class);
     mult = rngrangeseeded(mult, min_rate_adjust, max_rate_adjust, a.class.name);

--- a/DXRModules/DeusEx/Classes/DXRStats.uc
+++ b/DXRModules/DeusEx/Classes/DXRStats.uc
@@ -249,7 +249,7 @@ function string GetCompleteMissionMenuTimeString(int mission)
     return fmtTimeToString(time);
 }
 
-function String GetTotalTimeString()
+function int GetTotalSuccessTime()
 {
     local int i, totaltime;
 
@@ -257,10 +257,10 @@ function String GetTotalTimeString()
         totaltime += GetMissionTime(i);
     }
 
-    return fmtTimeToString(totaltime);
+    return totaltime;
 }
 
-function String GetTotalCompleteTimeString()
+function int GetTotalCompleteTime()
 {
     local int i, totaltime;
 
@@ -268,7 +268,7 @@ function String GetTotalCompleteTimeString()
         totaltime += GetCompleteMissionTime(i);
     }
 
-    return fmtTimeToString(totaltime);
+    return totaltime;
 }
 
 static function int GetTotalTime(DXRando dxr)
@@ -295,7 +295,7 @@ function String GetTotalMenuTimeString()
     return fmtTimeToString(time);
 }
 
-function String GetTotalCompleteMenuTimeString()
+function int GetTotalCompleteMenuTime()
 {
     local int i, totaltime;
 
@@ -303,7 +303,7 @@ function String GetTotalCompleteMenuTimeString()
         totaltime += GetCompleteMissionMenuTime(i);
     }
 
-    return fmtTimeToString(totaltime);
+    return totaltime;
 }
 
 static function int GetTotalMenuTime(DXRando dxr)
@@ -446,34 +446,65 @@ function String FormatCreditsTimeStrings(String missionNum, String missionName, 
 function AddMissionTimeTable(CreditsWindow cw)
 {
     local CreditsTimerWindow ctw;
-    local int i, totalTime, totalRealTime;
+    local int i, dyingTime, successTime, successMenuTime, menuTime, completeTime;
+    local int dyingTimeWithoutMenusTotal, timeWithoutMenusTotal;
+    local int dyingTimeMenusTotal, timeMenusTotal;
+    local string s;
 
     ctw = CreditsTimerWindow(cw.winScroll.NewChild(Class'CreditsTimerWindow'));
 
-    ctw.AddMissionTime("1","Liberty Island",GetMissionTimeString(1),GetCompleteMissionTimeWithMenusString(1));
-    ctw.AddMissionTime("2","NYC Generator",GetMissionTimeString(2),GetCompleteMissionTimeWithMenusString(2));
-    ctw.AddMissionTime("3","Airfield",GetMissionTimeString(3),GetCompleteMissionTimeWithMenusString(3));
-    ctw.AddMissionTime("4","NSF HQ",GetMissionTimeString(4),GetCompleteMissionTimeWithMenusString(4));
-    ctw.AddMissionTime("5","UNATCO MJ12 Base",GetMissionTimeString(5),GetCompleteMissionTimeWithMenusString(5));
-    ctw.AddMissionTime("6","Hong Kong",GetMissionTimeString(6),GetCompleteMissionTimeWithMenusString(6));
-    ctw.AddMissionTime("8","Return to NYC",GetMissionTimeString(8),GetCompleteMissionTimeWithMenusString(8));
-    ctw.AddMissionTime("9","Superfreighter",GetMissionTimeString(9),GetCompleteMissionTimeWithMenusString(9));
-    ctw.AddMissionTime("10","Paris Streets",GetMissionTimeString(10),GetCompleteMissionTimeWithMenusString(10));
-    ctw.AddMissionTime("11","Cathedral",GetMissionTimeString(11),GetCompleteMissionTimeWithMenusString(11));
-    ctw.AddMissionTime("12","Vandenberg",GetMissionTimeString(12),GetCompleteMissionTimeWithMenusString(12));
-    ctw.AddMissionTime("14","Ocean Lab",GetMissionTimeString(14),GetCompleteMissionTimeWithMenusString(14));
-    ctw.AddMissionTime("15","Area 51",GetMissionTimeString(15),GetCompleteMissionTimeWithMenusString(15));
-    ctw.AddMissionTime("----","--------------","-------------","-------------");
-    ctw.AddMissionTime(" ","Total Without Menus",GetTotalTimeString(),GetTotalCompleteTimeString());
-    ctw.AddMissionTime(" ","Total Menu Time",GetTotalMenuTimeString(),GetTotalCompleteMenuTimeString());
+    for(i=1; i<=15; i++) {
+        if(i==7 || i==13) continue;
+        switch(i) {
+            case 1: s="Liberty Island"; break;
+            case 2: s="NYC Generator"; break;
+            case 3: s="Airfield"; break;
+            case 4: s="NSF HQ"; break;
+            case 5: s="UNATCO MJ12 Base"; break;
+            case 6: s="Hong Kong"; break;
+            case 8: s="Return to NYC"; break;
+            case 9: s="Superfreighter"; break;
+            case 10: s="Paris Streets"; break;
+            case 11: s="Cathedral"; break;
+            case 12: s="Vandenberg"; break;
+            case 14: s="Ocean Lab"; break;
+            case 15: s="Area 51"; break;
 
-    totalTime = GetTotalTime(dxr)+GetTotalMenuTime(dxr);
-    totalRealTime = 0;
-    for (i=1;i<=15;i++) {
-        totalRealTime += GetCompleteMissionTime(i);
-        totalRealTime += GetCompleteMissionMenuTime(i);
+            default:
+                err("AddMissionTimeTable mission " $ i);
+                s="?";
+                break;
+        }
+
+        successTime = GetMissionTime(i);
+        successMenuTime = GetMissionMenuTime(i);
+        completeTime = GetCompleteMissionTime(i);
+        menuTime = GetCompleteMissionMenuTime(i);
+
+        dyingTimeWithoutMenusTotal += completeTime - successTime;
+        timeWithoutMenusTotal += completeTime;
+        dyingTimeMenusTotal += menuTime - successMenuTime;
+        timeMenusTotal += menuTime;
+
+        completeTime += menuTime;
+        dyingTime = completeTime - successTime - successMenuTime;
+
+        ctw.AddMissionTime(string(i), s, fmtTimeToString(dyingTime), fmtTimeToString(completeTime));
     }
-    ctw.AddMissionTime(" ","Total With Menus",fmtTimeToString(totalTime),fmtTimeToString(totalRealTime));
+
+    ctw.AddMissionTime("----","--------------------------","-------------","-------------");
+    ctw.AddMissionTime(" ","Total Without Menus",
+        fmtTimeToString(dyingTimeWithoutMenusTotal),
+        fmtTimeToString(timeWithoutMenusTotal)
+    );
+    ctw.AddMissionTime(" ","Total Menu Time",
+        fmtTimeToString(dyingTimeMenusTotal),
+        fmtTimeToString(timeMenusTotal)
+    );
+    ctw.AddMissionTime(" ","Total Time With Menus",
+        fmtTimeToString(dyingTimeWithoutMenusTotal + dyingTimeMenusTotal),
+        fmtTimeToString(timeWithoutMenusTotal + timeMenusTotal)
+    );
 }
 
 function QueryLeaderboard()

--- a/DXRVanilla/DeusEx/Classes/BlackHelicopter.uc
+++ b/DXRVanilla/DeusEx/Classes/BlackHelicopter.uc
@@ -53,7 +53,7 @@ function Scream()
 
     //Increase the radius from the default 4096 just so you can hear it from a distance
     PlaySound(Sound'ChildDeath', SLOT_Pain,100,,9000, RandomPitch());
-    AISendEvent('LoudNoise', EAITYPE_Audio);
+    //AISendEvent('LoudNoise', EAITYPE_Audio);
 }
 
 function Destroyed()

--- a/DXRVanilla/DeusEx/Classes/BlackHelicopter.uc
+++ b/DXRVanilla/DeusEx/Classes/BlackHelicopter.uc
@@ -7,6 +7,67 @@ singular function SupportActor(Actor standingActor)
 		standingActor.TakeDamage(10000, None, standingActor.Location, vect(0,0,0), 'Helicopter'); //Just change the damage type
 }
 
+//From DeusExCarcass
+function ChunkUp()
+{
+    local int i;
+    local float size;
+    local Vector loc;
+    local FleshFragment chunk;
+
+    // gib the carcass
+    //size = (CollisionRadius + CollisionHeight) / 2; //We don't want helicopter sized gibs
+    size = (class'Jock'.Default.CollisionRadius + class'Jock'.Default.CollisionHeight) / 2; //Jock-sized Gibs!
+    if (size > 10.0)
+    {
+        for (i=0; i<size/4.0; i++)
+        {
+            loc.X = (1-2*FRand()) * CollisionRadius;
+            loc.Y = (1-2*FRand()) * CollisionRadius;
+            loc.Z = (1-2*FRand()) * CollisionHeight;
+            loc += Location;
+            chunk = spawn(class'FleshFragment', None,, loc);
+            if (chunk != None)
+            {
+                chunk.DrawScale = size / 25;
+                chunk.SetCollisionSize(chunk.CollisionRadius / chunk.DrawScale, chunk.CollisionHeight / chunk.DrawScale);
+                chunk.bFixedRotationDir = True;
+                chunk.RotationRate = RotRand(False);
+            }
+        }
+    }
+}
+
+function float RandomPitch()
+{
+    return (1.1 - 0.2*FRand());
+}
+
+function Scream()
+{
+    local DXRando dxr;
+
+    foreach AllActors(class'DXRando',dxr){break;}
+    if (dxr==None) return;
+    if(!class'MenuChoice_ToggleMemes'.static.IsEnabled(dxr.flags)) return;
+
+    //Increase the radius from the default 4096 just so you can hear it from a distance
+    PlaySound(Sound'ChildDeath', SLOT_Pain,100,,9000, RandomPitch());
+    AISendEvent('LoudNoise', EAITYPE_Audio);
+}
+
+function Destroyed()
+{
+    //Daddy screamed real good before he died!
+    Scream();
+
+    //Also generate gibs
+    ChunkUp();
+
+    //Destroy as normal
+    Super.Destroyed();
+}
+
 /////////////////////////////////////////////////////////////
 ///////////////States copied from base class/////////////////
 //////Including these allows old save games to load//////////

--- a/DXRVanilla/DeusEx/Classes/BlackHelicopter.uc
+++ b/DXRVanilla/DeusEx/Classes/BlackHelicopter.uc
@@ -1,5 +1,7 @@
 class DXRBlackHelicopter injects BlackHelicopter;
 
+var bool bDying;
+
 singular function SupportActor(Actor standingActor)
 {
 	// kill whatever lands on the blades
@@ -58,11 +60,13 @@ function Scream()
 
 function Destroyed()
 {
-    //Daddy screamed real good before he died!
-    Scream();
+    if (bDying){
+        //Daddy screamed real good before he died!
+        Scream();
 
-    //Also generate gibs
-    ChunkUp();
+        //Also generate gibs
+        ChunkUp();
+    }
 
     //Destroy as normal
     Super.Destroyed();
@@ -85,5 +89,6 @@ auto state Flying
 
 defaultproperties
 {
+    bDying=False
     CollisionRadius=360
 }

--- a/DXRVanilla/DeusEx/Classes/LuciusDeBeers.uc
+++ b/DXRVanilla/DeusEx/Classes/LuciusDeBeers.uc
@@ -65,6 +65,12 @@ function SetDead()
 
 function Scream()
 {
+    local DXRando dxr;
+
+    foreach AllActors(class'DXRando',dxr){break;}
+    if (dxr==None) return;
+    if(!class'MenuChoice_ToggleMemes'.static.IsEnabled(dxr.flags)) return;
+
     PlaySound(Sound'ChildDeath', SLOT_Pain,100,,, RandomPitch());
     AISendEvent('LoudNoise', EAITYPE_Audio);
 }

--- a/DXRVanilla/DeusEx/Classes/LuciusDeBeers.uc
+++ b/DXRVanilla/DeusEx/Classes/LuciusDeBeers.uc
@@ -72,7 +72,7 @@ function Scream()
     if(!class'MenuChoice_ToggleMemes'.static.IsEnabled(dxr.flags)) return;
 
     PlaySound(Sound'ChildDeath', SLOT_Pain,100,,, RandomPitch());
-    AISendEvent('LoudNoise', EAITYPE_Audio);
+    //AISendEvent('LoudNoise', EAITYPE_Audio);
 }
 
 function Destroyed()

--- a/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
+++ b/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
@@ -191,7 +191,7 @@ function EnableButtons()
                 btnEquip.DisableWindow();
                 btnUse.DisableWindow();
             } else {
-                if (WeaponMod(inv) != None || AugmentationUpgradeCannister(inv) != None) {
+                if (WeaponMod(inv) != None || AugmentationUpgradeCannister(inv) != None || DeusExWeapon(inv) != None) {
                     btnUse.DisableWindow();
                 } else {
                     if ((inv == player.inHand ) || (inv == player.inHandPending))
@@ -247,7 +247,6 @@ function UnsetRefuseItem()
 function SetRefuseItem()
 {
     local Inventory item;
-    local Pickup droppedItem;
     local Vector x, y, z;
     local Vector dropVect;
 
@@ -259,20 +258,17 @@ function SetRefuseItem()
     if (Pickup(item) == None) {
         DropSelectedItem();
     } else {
-        droppedItem = Pickup(player.Spawn(item.class));
-        droppedItem.numCopies = Pickup(item).numCopies;
-        item.Destroy();
-
+        // we don't want to drop just 1 copy, so do our own drop code
         GetAxes(player.Rotation, x, y, z);
-        dropVect = player.Location + (player.CollisionRadius + 2.0 * droppedItem.CollisionRadius) * x;
+        dropVect = player.Location + (player.CollisionRadius + 2.0 * item.CollisionRadius) * x;
         dropVect.z += player.BaseEyeHeight; // TODO: change drop height based on where the player is looking
 
-        if (player.FastTrace(dropVect)) {
-            droppedItem.DropFrom(dropVect);
-            droppedItem.bFixedRotationDir = true;
-            droppedItem.RotationRate.Pitch = (32768 - Rand(65536)) * 4.0;
-            droppedItem.RotationRate.Yaw = (32768 - Rand(65536)) * 4.0;
-        }
+        if(!player.FastTrace(dropVect)) dropVect = player.Location;
+
+        item.DropFrom(dropVect);
+        item.bFixedRotationDir = true;
+        item.RotationRate.Pitch = (32768 - Rand(65536)) * 4.0;
+        item.RotationRate.Yaw = (32768 - Rand(65536)) * 4.0;
     }
 
     player.ClientMessage(item.ItemName $ " set as trash.");

--- a/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
+++ b/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
@@ -1,5 +1,10 @@
 class PersonaScreenInventory injects PersonaScreenInventory;
 
+const RefuseLabel = "|&Trash";
+const AcceptLabel = "Not |&Trash";
+
+var PersonaActionButtonWindow btnRefusal;
+
 function SelectInventory(PersonaItemButton buttonPressed)
 {
     Super.SelectInventory(buttonPressed);
@@ -128,4 +133,147 @@ event DescendantRemoved(Window descendant)
         }
     }
     Super.DescendantRemoved(descendant);
+}
+
+function CreateButtons()
+{
+    local PersonaButtonBarWindow winActionButtons;
+
+    winActionButtons = PersonaButtonBarWindow(winClient.NewChild(Class'PersonaButtonBarWindow'));
+    winActionButtons.SetPos(9, 339);
+    winActionButtons.SetWidth(267);
+
+    btnRefusal = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
+    btnRefusal.SetButtonText(RefuseLabel);
+
+    btnDrop = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
+    btnDrop.SetButtonText(DropButtonLabel);
+
+    btnUse = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
+    btnUse.SetButtonText(UseButtonLabel);
+
+    btnEquip = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
+    btnEquip.SetButtonText(EquipButtonLabel);
+}
+
+function EnableButtons()
+{
+    local Inventory inv;
+
+    if ((btnRefusal == None) || (btnDrop == None) || (btnEquip == None) || (btnUse == None))
+        return;
+
+    btnRefusal.SetButtonText(RefuseLabel);
+
+    if (selectedItem == None) {
+        btnDrop.DisableWindow();
+        btnRefusal.DisableWindow();
+        btnEquip.DisableWindow();
+        btnUse.DisableWindow();
+    } else {
+        btnEquip.EnableWindow();
+        btnUse.EnableWindow();
+        btnDrop.EnableWindow();
+        btnRefusal.EnableWindow();
+
+        inv = Inventory(selectedItem.GetClientObject());
+
+        if (inv != None) {
+            if (class'DXRLoadouts'.static.IsRefused(inv.class)) {
+                btnRefusal.SetButtonText(AcceptLabel);
+            } else {
+                btnRefusal.SetButtonText(RefuseLabel);
+            }
+
+            if (NanoKeyRing(inv) != None) {
+                btnDrop.DisableWindow();
+                btnRefusal.DisableWindow();
+                btnEquip.DisableWindow();
+                btnUse.DisableWindow();
+            } else {
+                if (WeaponMod(inv) != None || AugmentationUpgradeCannister(inv) != None) {
+                    btnUse.DisableWindow();
+                } else {
+                    if ((inv == player.inHand ) || (inv == player.inHandPending))
+                        btnEquip.SetButtonText(UnequipButtonLabel);
+                    else
+                        btnEquip.SetButtonText(EquipButtonLabel);
+                }
+            }
+        } else {
+            btnDrop.DisableWindow();
+            btnRefusal.DisableWindow();
+            btnEquip.DisableWindow();
+            btnUse.DisableWindow();
+        }
+    }
+}
+
+function bool ButtonActivated(Window buttonPressed)
+{
+    local bool ret;
+
+    if (buttonPressed == btnRefusal) {
+        if(btnRefusal.buttonText == RefuseLabel) {
+            SetRefuseItem();
+        } else {
+            UnsetRefuseItem();
+        }
+        return true;
+    }
+
+    ret = Super.ButtonActivated(buttonPressed);
+    if (PersonaAmmoDetailButton(buttonPressed) != None) {
+        btnDrop.DisableWindow();
+        btnRefusal.DisableWindow();
+        btnEquip.DisableWindow();
+        btnUse.DisableWindow();
+    }
+    return ret;
+}
+
+function UnsetRefuseItem()
+{
+    local Inventory item;
+
+    item = Inventory(selectedItem.GetClientObject());
+    if(item == None) return;
+
+    class'DXRLoadouts'.static.UnsetRefuseItem(item.class);
+    btnRefusal.SetButtonText(RefuseLabel);
+    player.ClientMessage(item.ItemName $ " set as not trash.");
+}
+
+function SetRefuseItem()
+{
+    local Inventory item;
+    local Pickup droppedItem;
+    local Vector x, y, z;
+    local Vector dropVect;
+
+    item = Inventory(selectedItem.GetClientObject());
+    if(item == None) return;
+
+    class'DXRLoadouts'.static.SetRefuseItem(item.class);
+
+    if (Pickup(item) == None) {
+        DropSelectedItem();
+    } else {
+        droppedItem = Pickup(player.Spawn(item.class));
+        droppedItem.numCopies = Pickup(item).numCopies;
+        item.Destroy();
+
+        GetAxes(player.Rotation, x, y, z);
+        dropVect = player.Location + (player.CollisionRadius + 2.0 * droppedItem.CollisionRadius) * x;
+        dropVect.z += player.BaseEyeHeight; // TODO: change drop height based on where the player is looking
+
+        if (player.FastTrace(dropVect)) {
+            droppedItem.DropFrom(dropVect);
+            droppedItem.bFixedRotationDir = true;
+            droppedItem.RotationRate.Pitch = (32768 - Rand(65536)) * 4.0;
+            droppedItem.RotationRate.Yaw = (32768 - Rand(65536)) * 4.0;
+        }
+    }
+
+    player.ClientMessage(item.ItemName $ " set as trash.");
 }

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -567,6 +567,12 @@ exec function ParseRightClick()
         }
     }
 
+    //PET THE ANIMAL
+    if (Animal(FrobTarget)!=None){
+        handled=True;
+        FrobTarget.Frob(self, None);
+    }
+
     if (!handled){
         Super.ParseRightClick();
     }

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -1642,6 +1642,11 @@ function InvokeUIScreen(Class<DeusExBaseWindow> windowClass)
     }
 }
 
+function PreTravel()
+{
+    DeusExRootWindow(rootWindow).ClearWindowStack();
+    Super.PreTravel();
+}
 
 
 defaultproperties

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -8,6 +8,7 @@ var transient string nextMap;
 var laserEmitter aimLaser;
 var bool bDoomMode;
 var bool bAutorun;
+var bool bPetting;
 
 var Rotator ShakeRotator;
 
@@ -1169,11 +1170,15 @@ function PlayTakeHitSound(int Damage, name damageType, int Mult)
 }
 function TweenToRunning(float tweentime)
 {
+    if(bPetting){return;}
+
     Super.TweenToRunning(tweentime);
 }
 function PlayWalking()
 {
     local float newhumanAnimRate;
+
+    if(bPetting){return;}
 
     newhumanAnimRate = humanAnimRate;
 
@@ -1208,6 +1213,9 @@ function PlayFiring()
 function TweenToWaiting(float tweentime)
 {
     //	ClientMessage("TweenToWaiting()");
+
+    if(bPetting){return;}
+
     if (IsInState('PlayerSwimming') || (Physics == PHYS_Swimming))
     {
         if (IsFiring())
@@ -1257,6 +1265,8 @@ function PlayWeaponSwitch(Weapon newWeapon)
 function PlayCrawling()
 {
     //	ClientMessage("PlayCrawling()");
+    if(bPetting){return;}
+
     if (IsFiring())
         LoopAnim('CrouchShoot');
     else if(HasAnim('CrouchWalk'))
@@ -1269,6 +1279,8 @@ function PlayRising()
 function PlayDuck()
 {
     //	ClientMessage("PlayDuck()");
+    if(bPetting){return;}
+
     if ((AnimSequence != 'Crouch') && (AnimSequence != 'CrouchWalk'))
     {
         if (IsFiring())
@@ -1294,6 +1306,9 @@ function PlaySwimming()
 function PlayWaiting()
 {
 //	ClientMessage("PlayWaiting()");
+
+    if(bPetting){return;}
+
     if (IsInState('PlayerSwimming') || (Physics == PHYS_Swimming))
     {
         if (IsFiring())
@@ -1313,6 +1328,8 @@ function PlayWaiting()
 }
 function PlayRunning()
 {
+    if(bPetting){return;}
+
     Super.PlayRunning();
 }
 function PlayTurning()

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -1642,6 +1642,25 @@ exec function Tcl() // toggle clipping, name borrowed from Gamebryo
         Walk();
 }
 
+exec function ShowRefused()
+{
+    local string refusals, msg;
+    local int idx;
+
+    refusals = class'DataStorage'.static.GetObj(GetDXR()).GetConfigKey("item_refusals");
+
+    // basically just adds a space after every comma
+    while (Len(refusals) > 1) {
+        refusals = Right(refusals, Len(refusals) - 1);
+        idx = InStr(refusals, ",");
+        msg = msg $ Left(refusals, idx) $ ", ";
+        refusals = Right(refusals, Len(refusals) - idx);
+    }
+    msg = Left(msg, Len(msg) - 2);
+
+    ClientMessage("Refused items: " $ msg);
+}
+
 
 // ----------------------------------------------------------------------
 // InvokeUIScreen()

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -1667,7 +1667,16 @@ function InvokeUIScreen(Class<DeusExBaseWindow> windowClass)
 
 function PreTravel()
 {
-    DeusExRootWindow(rootWindow).ClearWindowStack();
+    local DeusExRootWindow root;
+
+    root = DeusExRootWindow(rootWindow);
+
+    //Don't clear the stack if the top of the stack is the Credits.
+    //We're pretraveling as part of the DestroyWindow call chain
+    if (root!=None && CreditsWindow(root.GetTopWindow())==None){
+        root.ClearWindowStack();
+    }
+
     Super.PreTravel();
 }
 

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -8,7 +8,7 @@ var transient string nextMap;
 var laserEmitter aimLaser;
 var bool bDoomMode;
 var bool bAutorun;
-var bool bPetting;
+var bool bBlockAnimations;
 
 var Rotator ShakeRotator;
 
@@ -1170,7 +1170,7 @@ function PlayTakeHitSound(int Damage, name damageType, int Mult)
 }
 function TweenToRunning(float tweentime)
 {
-    if(bPetting){return;}
+    if(bBlockAnimations){return;}
 
     Super.TweenToRunning(tweentime);
 }
@@ -1178,7 +1178,7 @@ function PlayWalking()
 {
     local float newhumanAnimRate;
 
-    if(bPetting){return;}
+    if(bBlockAnimations){return;}
 
     newhumanAnimRate = humanAnimRate;
 
@@ -1214,7 +1214,7 @@ function TweenToWaiting(float tweentime)
 {
     //	ClientMessage("TweenToWaiting()");
 
-    if(bPetting){return;}
+    if(bBlockAnimations){return;}
 
     if (IsInState('PlayerSwimming') || (Physics == PHYS_Swimming))
     {
@@ -1265,7 +1265,7 @@ function PlayWeaponSwitch(Weapon newWeapon)
 function PlayCrawling()
 {
     //	ClientMessage("PlayCrawling()");
-    if(bPetting){return;}
+    if(bBlockAnimations){return;}
 
     if (IsFiring())
         LoopAnim('CrouchShoot');
@@ -1279,7 +1279,7 @@ function PlayRising()
 function PlayDuck()
 {
     //	ClientMessage("PlayDuck()");
-    if(bPetting){return;}
+    if(bBlockAnimations){return;}
 
     if ((AnimSequence != 'Crouch') && (AnimSequence != 'CrouchWalk'))
     {
@@ -1307,7 +1307,7 @@ function PlayWaiting()
 {
 //	ClientMessage("PlayWaiting()");
 
-    if(bPetting){return;}
+    if(bBlockAnimations){return;}
 
     if (IsInState('PlayerSwimming') || (Physics == PHYS_Swimming))
     {
@@ -1328,7 +1328,7 @@ function PlayWaiting()
 }
 function PlayRunning()
 {
-    if(bPetting){return;}
+    if(bBlockAnimations){return;}
 
     Super.PlayRunning();
 }

--- a/DXRVanilla/DeusEx/Classes/Weapon.uc
+++ b/DXRVanilla/DeusEx/Classes/Weapon.uc
@@ -78,6 +78,8 @@ simulated function Tick(float deltaTime)
             r = (class'DXRWeapons'.static.GetDefaultShottime(self) / ShotTime);
             r = FClamp(r, 0.4, 1.7);
             e = 1.0;// these animations don't scale as much with skill
+            // PS20/40 should get thrown away more quickly
+            if(WeaponHideAGun(self) != None) r *= 1.2;
         }
         else if(AnimSequence == 'Idle1' || AnimSequence == 'Idle2' || AnimSequence == 'Idle3')
         {

--- a/DXRando/DeusEx/Classes/DXRLamp.uc
+++ b/DXRando/DeusEx/Classes/DXRLamp.uc
@@ -17,7 +17,7 @@ function SetState(bool turnOn)
         bOn = True;
         LightType = LT_Steady;
         bUnlit = True;
-        ScaleGlow = 3.0;
+        ScaleGlow = 2.5;
     } else if (bOn) {
         bOn = False;
         LightType = LT_None;

--- a/DXRando/DeusEx/Classes/DXRLamp2.uc
+++ b/DXRando/DeusEx/Classes/DXRLamp2.uc
@@ -34,7 +34,7 @@ function SetState(bool turnOn)
         bOn = true;
         lt.LightType = LT_Steady;
         bUnlit = True;
-        ScaleGlow = 3.0;
+        ScaleGlow = 2.5;
     } else {
         bOn = false;
         lt.LightType = LT_None;
@@ -59,8 +59,8 @@ defaultproperties
     FamiliarName="Stand Lamp"
     UnfamiliarName="Stand Lamp"
     LightHue=44
-    LightSaturation=160
+    LightSaturation=128
     LightBrightness=255
     // increasing the radius to ~21-25 causes weird flickering on a couch in the Free Clinic, probably elsewhere
-    LightRadius=15
+    LightRadius=12
 }

--- a/GUI/DeusEx/Classes/CreditsTimerWindow.uc
+++ b/GUI/DeusEx/Classes/CreditsTimerWindow.uc
@@ -4,7 +4,7 @@ struct MissionTimeInfo
 {
     var string MissionNum;
     var string MissionName;
-    var string SuccessTime;
+    var string DyingTime;
     var string CompleteTime;
 };
 
@@ -15,7 +15,7 @@ event InitWindow()
     SetSize(default.width, default.height);
 }
 
-function AddMissionTime(string missionNum, string missionName, string successTime, string completeTime)
+function AddMissionTime(string missionNum, string missionName, string dyingTime, string completeTime)
 {
     local int i;
     i=0;
@@ -23,7 +23,7 @@ function AddMissionTime(string missionNum, string missionName, string successTim
 
     mission_times[i].MissionNum = missionNum;
     mission_times[i].MissionName = missionName;
-    mission_times[i].SuccessTime = successTime;
+    mission_times[i].DyingTime = dyingTime;
     mission_times[i].CompleteTime = completeTime;
 }
 
@@ -41,15 +41,15 @@ event DrawWindow(GC gc)
     gc.SetFont(Font'DeusExUI.FontConversationLargeBold');
     yPos = 0;
     gc.DrawText(0,yPos,100,50,"Mission");
-    gc.DrawText(235,yPos,150,50,"In-Game Time");
-    gc.DrawText(350,yPos,100,50,"Real Time");
+    gc.DrawText(235,yPos,150,50,"Retries Time");
+    gc.DrawText(350,yPos,100,50,"Time");
 
     gc.SetFont(Font'DeusExUI.FontConversationLarge');
     while(mission_times[i].MissionName!=""){
         yPos = (i+1) * 25;
         gc.DrawText(0,yPos,100,50,mission_times[i].MissionNum);
         gc.DrawText(25,yPos,200,50,mission_times[i].MissionName);
-        gc.DrawText(250,yPos,100,50,mission_times[i].SuccessTime);
+        gc.DrawText(250,yPos,100,50,mission_times[i].DyingTime);
         gc.DrawText(350,yPos,100,50,mission_times[i].CompleteTime);
         i++;
     }

--- a/GUI/DeusEx/Classes/DXRNewsWindow.uc
+++ b/GUI/DeusEx/Classes/DXRNewsWindow.uc
@@ -27,6 +27,21 @@ function ProcessAction(String actionKey)
     }
 }
 
+
+event bool VirtualKeyPressed(EInputKey key, bool bRepeat)
+{
+    if ( IsKeyDown( IK_Alt ) || IsKeyDown( IK_Shift ) )
+        return False;
+
+    switch( key )
+    {
+        case IK_Escape:
+            player.PlaySound(Sound'DeusExSounds.Generic.Buzz1');
+            return True;
+            break;
+    }
+}
+
 function Set(DXRTelemetry tel, string newtitle)
 {
     callbackModule = tel;
@@ -36,7 +51,7 @@ function Set(DXRTelemetry tel, string newtitle)
 
 defaultproperties
 {
-    actionButtons(0)=(Align=HALIGN_Right,Action=AB_Other,Text="|&Cancel",Key="CANCEL")
+    actionButtons(0)=(Align=HALIGN_Right,Action=AB_Other,Text="Keep Using Old Version",Key="CANCEL")
     actionButtons(1)=(Align=HALIGN_Right,Action=AB_Other,Text="|&Open In Browser",Key="OPEN")
     Title="News"
     ClientWidth=400

--- a/GUI/DeusEx/Classes/FrobDisplayWindow.uc
+++ b/GUI/DeusEx/Classes/FrobDisplayWindow.uc
@@ -284,7 +284,15 @@ function bool KeyAcquired(Mover m)
 
 function int CalcDecoDamage(int iDamage, name damageType, #var(DeusExPrefix)Decoration deco)
 {
-    if (iDamage < deco.minDamageThreshold) return 0;
+    if (iDamage < deco.minDamageThreshold) {
+        if (damageType=='Sabot'){
+            return iDamage * 0.5;
+        } else if (damageType=='Exploded'){
+            return iDamage * 0.25;
+        } else {
+            return 0;
+        }
+    }
 
     if ((DamageType == 'TearGas') || (DamageType == 'PoisonGas') || (DamageType == 'Radiation'))
         return 0;

--- a/GUI/DeusEx/Classes/FrobDisplayWindow.uc
+++ b/GUI/DeusEx/Classes/FrobDisplayWindow.uc
@@ -660,13 +660,20 @@ function string LaserStrInfo(Actor a, out int numLines)
 #ifdef vanilla
     w = DXRWeapon(player.inHand);
     if( w != None ) {
-        if (w.WeaponDamageType() != 'Exploded' && w.WeaponDamageType() != 'Shot'){
-            damage = 0; //only exploded and shot damage actually hurt lasers
+        if (w.WeaponDamageType() != 'Exploded' && w.WeaponDamageType() != 'Shot' && w.WeaponDamageType() != 'Sabot'){
+            damage = 0; //only exploded, shot, and sabot damage actually hurt lasers
         } else {
             damage = w.GetDamage();
-            if (damage<minDmg){
-                damage = 0;
+            if (damage < minDmg) {
+                if (w.WeaponDamageType()=='Sabot'){
+                    damage = damage * 0.5;
+                } else if (w.WeaponDamageType()=='Exploded'){
+                    damage = damage * 0.25;
+                } else {
+                    damage = 0;
+                }
             }
+
             damage = damage * float(w.GetNumHits());
         }
 

--- a/GUI/DeusEx/Classes/HUDEnergyDisplay.uc
+++ b/GUI/DeusEx/Classes/HUDEnergyDisplay.uc
@@ -43,7 +43,10 @@ event Tick(float deltaSeconds)
 {
     local float energyUse;
 
-    energyUse = GetTotalEnergyUse();
+    if(player != None && player.AugmentationSystem != None) {
+        energyUse = player.AugmentationSystem.CalcEnergyUse(1);
+    }
+
     text.SetText(
         class'DXRInfo'.static.FloatToString(energyUse,3) $ " / Sec|n"
         $ class'DXRInfo'.static.FloatToString(GetEnergyTimeRemaining(energyUse),1)$" sec left"
@@ -55,40 +58,6 @@ event Tick(float deltaSeconds)
 function float GetEnergyTimeRemaining(float energyUse)
 {
     return player.Energy / energyUse;
-}
-
-function float GetTotalEnergyUse()
-{
-	local float energyUse, energyMult;
-	local Augmentation anAug;
-    local Augmentation PowerAug;
-
-	energyUse = 0;
-	energyMult = 1.0;
-
-    if(player == None || player.AugmentationSystem == None)
-        return 0;
-
-	anAug = player.AugmentationSystem.FirstAug;
-	while(anAug != None)
-	{
-        if (anAug.IsA('AugPower'))
-            PowerAug = anAug;
-	    if (anAug.bHasIt && anAug.bIsActive)
-		{
-			energyUse += ((anAug.GetEnergyRate()/60));
-		    if (anAug.IsA('AugPower'))
-            {
-			    energyMult = anAug.LevelValues[anAug.CurrentLevel];
-            }
-		}
-		anAug = anAug.next;
-    }
-
-    if (PowerAug.bIsActive)
-        energyMult = PowerAug.LevelValues[PowerAug.CurrentLevel];
-
-    return energyUse * energyMult;
 }
 
 // ----------------------------------------------------------------------

--- a/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
+++ b/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
@@ -6,7 +6,7 @@ var DXRStats        stats;
 var config int version;
 var config Font  textfont;
 
-var config Color colorBackground, colorText, colorBehind, colorBehindLosingTime, colorBehindGainingTime, colorAhead, colorAheadLosingTime, colorAheadGainingTime, colorBest, colorBestBehind, colorBestAhead;
+var config Color colorBackground, colorNotesBackground, colorText, colorBehind, colorBehindLosingTime, colorBehindGainingTime, colorAhead, colorAheadLosingTime, colorAheadGainingTime, colorBest, colorBestBehind, colorBestAhead;
 
 var config bool enabled, showPrevprev, showPrev, showCurrentMission, showNext, showSeg, showCur, showPB, showSpeed, showAllSplits;
 var config bool showAverage, useAverageGoal;
@@ -49,18 +49,30 @@ event InitWindow()
     if(class'DXRVersion'.static.VersionOlderThan(version, 2,6,1,1)) {
         x_pos = 0;
         y_pos = 0;
-        colorText.R = 200;
-        colorText.G = 200;
-        colorText.B = 200;
-        colorText.A = 255;
     }
     if(textFont == None) {
         textFont = Font'DeusExUI.FontMenuHeaders_DS';
+    }
+    if( version < class'DXRVersion'.static.VersionToInt(2, 7, 3, 1) ) {
+        colorText=RGB(200,200,200);
+        colorBehind=RGB(204,90,80);
+        colorBehindLosingTime=RGB(255,60,40);
+        colorBehindGainingTime=RGB(234,140,131);
     }
     if( version < class'DXRVersion'.static.VersionNumber() ) {
         version = class'DXRVersion'.static.VersionNumber();
         SaveConfig();
     }
+}
+
+function Color RGB(int r, int g, int b)
+{
+    local Color c;
+    c.A=255;
+    c.R=r;
+    c.G=g;
+    c.B=b;
+    return c;
 }
 
 function string ReplaceVariables(string s)
@@ -574,12 +586,19 @@ function int TotalTime()
 function DrawBackground(GC gc)
 {
     local float width, height;
+
+    backgroundDrawStyle = default.backgroundDrawStyle;// StyleChanged overwrites this, but we can read from default to get the config value
     gc.SetStyle(backgroundDrawStyle);
     gc.SetTileColor(colorBackground);
     width = windowWidth + 8;
-    if(notesWidth > 0) width += 24 + notesWidth;
+    if(notesWidth > 0) width += 12;
     height = FMax(windowHeight, notesHeight + 4);
-    gc.DrawPattern(x_pos, ty_pos, width, height, 0, 0, Texture'Solid');
+    gc.DrawPattern(x_pos, ty_pos, width, height, 0, 0, Texture'DeusExUI.UserInterface.WindowShadow_Center');
+
+    if(notesWidth > 0) {
+        gc.SetTileColor(colorNotesBackground);
+        gc.DrawPattern(x_pos + width, ty_pos, notesWidth + 12, height, 0, 0, Texture'DeusExUI.UserInterface.WindowShadow_Center');
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -599,13 +618,15 @@ defaultproperties
     showAllSplits=false
     showAverage=true
 
+    backgroundDrawStyle=DSTY_Translucent
     textfont=Font'DeusExUI.FontMenuHeaders_DS';
     colorBackground=(R=0,G=0,B=0,A=100)
+    colorNotesBackground=(R=0,G=0,B=0,A=100)
     colorText=(R=200,G=200,B=200,A=255)
 
-    colorBehind=(R=204,G=60,B=40,A=255)
-    colorBehindLosingTime=(R=204,G=18,B=0,A=255)
-    colorBehindGainingTime=(R=204,G=92,B=82,A=255)
+    colorBehind=(R=204,G=90,B=80,A=255)
+    colorBehindLosingTime=(R=255,G=60,B=40,A=255)
+    colorBehindGainingTime=(R=234,G=140,B=131,A=255)
 
     colorAhead=(R=40,G=204,B=80,A=255)
     colorAheadLosingTime=(R=82,G=204,B=115,A=255)

--- a/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
+++ b/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
@@ -539,7 +539,8 @@ function int BalancedSplit(int m)
     local int i, balanced_split_time;
     local int total_goal;
     local int typical_split_time, typical_total_time;
-    local float ratio_of_game;
+    local int timesave, total_timesave;
+    local float ratio;
 
     total_goal = PB_total;
     if(goal_time != 0) total_goal = goal_time;
@@ -560,16 +561,25 @@ function int BalancedSplit(int m)
         return Golds[m];
     }
     if(m == 15) { // last split, avoid rounding issues
-        return total_goal - balanced_splits_totals[m-1];
+        balanced_split_time = total_goal - balanced_splits_totals[m-1];
+        //log("Mission: " $ m $ ", balanced: " $ fmtTimeSeg(balanced_split_time) $ ", gold: " $ fmtTimeSeg(Golds[m]) $ ", PB: " $ fmtTimeSeg(PB[m]) $ ", Avg: " $ fmtTimeSeg(Avgs[m]));
+        return balanced_split_time;
     }
     if(typical_total_time == 0) {
         if(Avgs[m] > 0) return Avgs[m];
         return PB[m];
     }
 
-    ratio_of_game = float(typical_split_time) / float(typical_total_time);
-
-    balanced_split_time = ratio_of_game * float(total_goal);
+    if(sum_of_bests > 0) {
+        timesave = typical_split_time - Golds[m];
+        total_timesave = typical_total_time - sum_of_bests;
+        ratio = float(typical_total_time - total_goal) / float(total_timesave);// ratio is the desired timesave divided by the maximum timesave
+        balanced_split_time = typical_split_time - timesave * ratio;
+    } else {
+        ratio = float(typical_split_time) / float(typical_total_time);
+        balanced_split_time = ratio * float(total_goal);
+    }
+    //log("Mission: " $ m $ ", balanced: " $ fmtTimeSeg(balanced_split_time) $ ", gold: " $ fmtTimeSeg(Golds[m]) $ ", PB: " $ fmtTimeSeg(PB[m]) $ ", Avg: " $ fmtTimeSeg(Avgs[m]));
     return balanced_split_time;
 }
 

--- a/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
+++ b/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
@@ -55,9 +55,9 @@ event InitWindow()
     }
     if( version < class'DXRVersion'.static.VersionToInt(2, 7, 3, 1) ) {
         colorText=RGB(200,200,200);
-        colorBehind=RGB(204,90,80);
+        colorBehind=RGB(220,90,80);
         colorBehindLosingTime=RGB(255,60,40);
-        colorBehindGainingTime=RGB(234,140,131);
+        colorBehindGainingTime=RGB(250,140,131);
     }
     if( version < class'DXRVersion'.static.VersionNumber() ) {
         version = class'DXRVersion'.static.VersionNumber();
@@ -634,9 +634,9 @@ defaultproperties
     colorNotesBackground=(R=0,G=0,B=0,A=100)
     colorText=(R=200,G=200,B=200,A=255)
 
-    colorBehind=(R=204,G=90,B=80,A=255)
+    colorBehind=(R=220,G=90,B=80,A=255)
     colorBehindLosingTime=(R=255,G=60,B=40,A=255)
-    colorBehindGainingTime=(R=234,G=140,B=131,A=255)
+    colorBehindGainingTime=(R=250,G=140,B=131,A=255)
 
     colorAhead=(R=40,G=204,B=80,A=255)
     colorAheadLosingTime=(R=82,G=204,B=115,A=255)

--- a/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
+++ b/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
@@ -1,6 +1,3 @@
-//=============================================================================
-// HUDEnergyDisplay
-//=============================================================================
 class HUDSpeedrunSplits expands HUDBaseWindow config(DXRSplits);
 
 var DeusExPlayer    player;

--- a/GUI/DeusEx/Classes/MenuChoice_ItemRefusal.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_ItemRefusal.uc
@@ -1,0 +1,26 @@
+class MenuChoice_ItemRefusal extends DXRMenuUIChoiceBool;
+#compileif injections
+
+var class<Inventory> refusedItems[6];
+
+static function SetRefusals()
+{
+    local int i;
+    local class<Inventory> itemClass;
+
+    for (i = 0; i < ArrayCount(default.refusedItems); i++) {
+        itemClass = default.refusedItems[i];
+        if (itemClass == None) continue;
+
+        if (default.enabled)
+            class'DXRLoadouts'.static.SetRefuseItem(itemClass);
+        else
+            class'DXRLoadouts'.static.UnsetRefuseItem(itemClass);
+    }
+}
+
+function SaveSetting()
+{
+    Super.SaveSetting();
+    SetRefusals();
+}

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseFoodDrink.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseFoodDrink.uc
@@ -1,0 +1,19 @@
+class MenuChoice_RefuseFoodDrink extends MenuChoice_ItemRefusal;
+#compileif injections
+
+defaultproperties
+{
+    enabled=False
+    defaultvalue=False
+    HelpText="Should food and drinks be included in the list of Junk items that get dropped when looting a body?"
+    actionText="Drop Food & Drinks"
+    enumText(0)="Don't Drop"
+    enumText(1)="Drop"
+
+    refusedItems(0)=class'SoyFood'
+    refusedItems(1)=class'Candybar'
+    refusedItems(2)=class'Sodacan'
+    refusedItems(3)=class'Liquor40oz'
+    refusedItems(4)=class'LiquorBottle'
+    refusedItems(5)=class'WineBottle'
+}

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseMelee.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseMelee.uc
@@ -1,0 +1,18 @@
+class MenuChoice_RefuseMelee extends MenuChoice_ItemRefusal;
+#compileif injections
+
+defaultproperties
+{
+    enabled=False
+    defaultvalue=False
+    HelpText="Should melee weapons be included in the list of Junk items that get dropped when looting a body?"
+    actionText="Drop Melee Weapons"
+    enumText(0)="Don't Drop"
+    enumText(1)="Drop"
+
+    refusedItems(0)=class'WeaponCombatKnife'
+    refusedItems(1)=class'WeaponCrowbar'
+    refusedItems(2)=class'WeaponSword'
+    refusedItems(3)=class'WeaponNanoSword'
+    refusedItems(4)=class'WeaponBaton'
+}

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseMisc.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseMisc.uc
@@ -1,0 +1,17 @@
+class MenuChoice_RefuseMisc extends MenuChoice_ItemRefusal;
+#compileif injections
+
+defaultproperties
+{
+    enabled=False
+    defaultvalue=False
+    HelpText="Should rebreathers, tech goggles, binoculars and flares be included in the list of Junk items that get dropped when looting a body?"
+    actionText="Drop Miscellaneous"
+    enumText(0)="Don't Drop"
+    enumText(1)="Drop"
+
+    refusedItems(0)=class'Rebreather'
+    refusedItems(1)=class'TechGoggles'
+    refusedItems(2)=class'Binoculars'
+    refusedItems(3)=class'Flare'
+}

--- a/GUI/DeusEx/Classes/MenuChoice_RefuseUseless.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_RefuseUseless.uc
@@ -1,0 +1,15 @@
+class MenuChoice_RefuseUseless extends MenuChoice_ItemRefusal;
+#compileif injections
+
+defaultproperties
+{
+    enabled=True
+    defaultvalue=True
+    HelpText="Should cigarettes and zyme be included in the list of Junk items that get dropped when looting a body?"
+    actionText="Drop Cigarettes & Zyme" // text is too long without abreviating "and"
+    enumText(0)="Don't Drop"
+    enumText(1)="Drop"
+
+    refusedItems(0)=class'Cigarettes'
+    refusedItems(1)=class'VialCrack'
+}

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptions.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptions.uc
@@ -35,26 +35,30 @@ function CreateChoices()
 
     CreateChoice(class'MenuChoice_ShowNews');
 
-    if(#defined(vanilla)) {
-        CreateChoice(class'MenuChoice_LoadLatest');
-        CreateChoice(class'MenuChoice_SaveDuringInfolinks');
-        CreateChoice(class'MenuChoice_AutosaveCombat');
-        CreateChoice(class'MenuChoice_EnergyDisplay');
-        CreateChoice(class'MenuChoice_AutoAugs');
-        CreateChoice(class'MenuChoice_ShowKeys');
-        CreateChoice(class'MenuChoice_ThrowMelee');
-        CreateChoice(class'MenuChoice_AutoWeaponMods');
-        CreateChoice(class'MenuChoice_AutoLaser');
-        CreateChoice(class'MenuChoice_Epilepsy');
-        CreateChoice(class'MenuChoice_BarrelTextures');
-        CreateChoice(class'MenuChoice_DecoPickupBehaviour');
-    }
+#ifdef vanilla
+    CreateChoice(class'MenuChoice_LoadLatest');
+    CreateChoice(class'MenuChoice_SaveDuringInfolinks');
+    CreateChoice(class'MenuChoice_AutosaveCombat');
+    CreateChoice(class'MenuChoice_EnergyDisplay');
+    CreateChoice(class'MenuChoice_AutoAugs');
+    CreateChoice(class'MenuChoice_ShowKeys');
+    CreateChoice(class'MenuChoice_ThrowMelee');
+    CreateChoice(class'MenuChoice_AutoWeaponMods');
+    CreateChoice(class'MenuChoice_AutoLaser');
+    CreateChoice(class'MenuChoice_Epilepsy');
+    CreateChoice(class'MenuChoice_BarrelTextures');
+    CreateChoice(class'MenuChoice_DecoPickupBehaviour');
+    CreateChoice(class'MenuChoice_AutoLamps');
+    CreateChoice(class'MenuChoice_RefuseUseless');
+    CreateChoice(class'MenuChoice_RefuseFoodDrink');
+    CreateChoice(class'MenuChoice_RefuseMelee');
+    CreateChoice(class'MenuChoice_RefuseMisc');
+#endif
 
     CreateChoice(class'MenuChoice_PasswordAutofill');
     CreateChoice(class'MenuChoice_ConfirmNoteDelete');
     CreateChoice(class'MenuChoice_FixGlitches');
     CreateChoice(class'MenuChoice_ShowTeleporters');
-    CreateChoice(class'MenuChoice_AutoLamps');
 
     controlsParent.SetSize(clientWidth, choiceStartY + (choiceCount * choiceVerticalGap));
 }

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
@@ -9,22 +9,26 @@ function CreateChoices()
     CreateChoice(class'MenuChoice_ToggleMemes');
     // TODO: simulated crowd control strength
 
-    if(#defined(vanilla)) {
-        CreateChoice(class'MenuChoice_LoadLatest');
-        CreateChoice(class'MenuChoice_SaveDuringInfolinks');
-        CreateChoice(class'MenuChoice_AutosaveCombat');
-        CreateChoice(class'MenuChoice_AutoAugs');
-        CreateChoice(class'MenuChoice_ShowKeys');
-        CreateChoice(class'MenuChoice_ThrowMelee');
-        CreateChoice(class'MenuChoice_AutoWeaponMods');
-        CreateChoice(class'MenuChoice_AutoLaser');
-        CreateChoice(class'MenuChoice_DecoPickupBehaviour');
-    }
+#ifdef vanilla
+    CreateChoice(class'MenuChoice_LoadLatest');
+    CreateChoice(class'MenuChoice_SaveDuringInfolinks');
+    CreateChoice(class'MenuChoice_AutosaveCombat');
+    CreateChoice(class'MenuChoice_AutoAugs');
+    CreateChoice(class'MenuChoice_ShowKeys');
+    CreateChoice(class'MenuChoice_ThrowMelee');
+    CreateChoice(class'MenuChoice_AutoWeaponMods');
+    CreateChoice(class'MenuChoice_AutoLaser');
+    CreateChoice(class'MenuChoice_DecoPickupBehaviour');
+    CreateChoice(class'MenuChoice_AutoLamps');
+    CreateChoice(class'MenuChoice_RefuseUseless');
+    CreateChoice(class'MenuChoice_RefuseFoodDrink');
+    CreateChoice(class'MenuChoice_RefuseMelee');
+    CreateChoice(class'MenuChoice_RefuseMisc');
+#endif
 
     CreateChoice(class'MenuChoice_PasswordAutofill');
     CreateChoice(class'MenuChoice_ConfirmNoteDelete');
     CreateChoice(class'MenuChoice_FixGlitches');
-    CreateChoice(class'MenuChoice_AutoLamps');
 }
 
 defaultproperties

--- a/GUI/DeusEx/Classes/NewGamePlusCreditsWindow.uc
+++ b/GUI/DeusEx/Classes/NewGamePlusCreditsWindow.uc
@@ -180,9 +180,9 @@ defaultproperties
 {
      currentScrollSpeed=100.0000
      scrollSpeed=100.0000
-     minScrollSpeed=-500
-     maxScrollSpeed=500
-     speedAdjustment=10
+     minScrollSpeed=-600
+     maxScrollSpeed=600
+     speedAdjustment=15
      maxTileWidth=700
      maxTextWidth=700
 }

--- a/Pawns/DeusEx/Classes/MedicalBot.uc
+++ b/Pawns/DeusEx/Classes/MedicalBot.uc
@@ -35,21 +35,48 @@ function updateName()
     unfamiliarName = familiarName;
 }
 
-function int HealPlayer(DeusExPlayer player)
+function int HealPlayer(DeusExPlayer PlayerToHeal)
 {
-    local int healAmount;
+    local int healedPoints, uses;
+    local string msg;
 
 #ifdef injections
-    healAmount = _HealPlayer(player);
-#else
-    healAmount = Super.HealPlayer(player);
-#endif
+    // vanilla HealPlayer but with a different client message
+    if (Human(PlayerToHeal) != None) {
+        healedPoints = Human(PlayerToHeal)._HealPlayer(healAmount);
+        numUses++;
 
+        lastHealTime = Level.TimeSeconds;
+        uses = GetRemainingUses();
+
+        if (healedPoints == 1)
+            msg = "Healed 1 point";
+        else
+            msg = "Healed " $ healedPoints $ " points";
+        if (healedPoints < healAmount)
+            msg = msg $ " (max " $ healAmount $ ")";
+
+        if (uses == 0) {
+            msg = msg $ ". No heals left.";
+        } else {
+            msg = msg $ ". " $ healRefreshTime $ "s until recharged. ";
+            if (uses == 1)
+                msg = msg $ "1 heal left.";
+            else
+                msg = msg $ uses $ " heals left.";
+        }
+
+        PlayerToHeal.ClientMessage(msg);
+    }
+#else
+    healedPoints = Super.HealPlayer(player);
     numUses++;
+    // don't show multiple client messages
+#endif
 
     updateName();
 
-    return healAmount;
+    return healedPoints;
 }
 
 simulated function int GetMaxUses()

--- a/Pawns/DeusEx/Classes/MedicalBot.uc
+++ b/Pawns/DeusEx/Classes/MedicalBot.uc
@@ -69,7 +69,7 @@ function int HealPlayer(DeusExPlayer PlayerToHeal)
         PlayerToHeal.ClientMessage(msg);
     }
 #else
-    healedPoints = Super.HealPlayer(player);
+    healedPoints = Super.HealPlayer(PlayerToHeal);
     numUses++;
     // don't show multiple client messages
 #endif

--- a/Pawns/DeusEx/Classes/NastyRat.uc
+++ b/Pawns/DeusEx/Classes/NastyRat.uc
@@ -125,19 +125,22 @@ function float RandomPitch()
 
 #ifdef revision
 function float ModifyDamage(int Damage, Pawn instigatedBy, Vector hitLocation, Vector offset, Name damageType, optional bool bTestOnly){
-#else
-function float ModifyDamage(int Damage, Pawn instigatedBy, Vector hitLocation, Vector offset, Name damageType){
-#endif
     if (instigatedBy==self && damageType=='Exploded'){
         Damage = Damage * 0.1;
         instigatedBy = None; //Prevents the 10x damage mult for point-blank hits
     }
-#ifdef revision
     return Super.ModifyDamage(Damage,instigatedBy,hitlocation,offset,damageType,bTestOnly);
-#else
-    return Super.ModifyDamage(Damage,instigatedBy,hitlocation,offset,damageType);
-#endif
 }
+#elseifn gmdx
+// Animal.ModifyDamage breaks GMDX v10 here
+function float ModifyDamage(int Damage, Pawn instigatedBy, Vector hitLocation, Vector offset, Name damageType){
+    if (instigatedBy==self && damageType=='Exploded'){
+        Damage = Damage * 0.1;
+        instigatedBy = None; //Prevents the 10x damage mult for point-blank hits
+    }
+    return Super.ModifyDamage(Damage,instigatedBy,hitlocation,offset,damageType);
+}
+#endif
 
 defaultproperties
 {

--- a/Pawns/DeusEx/Classes/RepairBot.uc
+++ b/Pawns/DeusEx/Classes/RepairBot.uc
@@ -36,19 +36,40 @@ function updateName()
 
 function int ChargePlayer(DeusExPlayer PlayerToCharge)
 {
-    local int chargeAmount;
+    local int chargedPoints, uses;
+    local string msg;
 
 #ifdef injections
-    chargeAmount = _ChargePlayer(PlayerToCharge);
+    chargedPoints = _ChargePlayer(PlayerToCharge);
 #else
-    chargeAmount = Super.ChargePlayer(PlayerToCharge);
+    chargedPoints = Super.ChargePlayer(PlayerToCharge);
 #endif
 
     numUses++;
 
+    uses = GetRemainingUses();
+    if (chargedPoints == 1)
+        msg = "Charged 1 point";
+    else
+        msg = "Charged " $ chargedPoints $ " points";
+    if (chargedPoints < chargeAmount)
+        msg = msg $ " (max " $ chargeAmount $ ")";
+
+    if (uses == 0) {
+        msg = msg $ ". No charges left.";
+    } else {
+        msg = msg $ ". " $ chargeRefreshTime $ "s until recharged. ";
+        if (uses == 1)
+            msg = msg $ "1 charge left.";
+        else
+            msg = msg $ uses $ " charges left.";
+    }
+
+    PlayerToCharge.ClientMessage(msg);
+
     updateName();
 
-    return chargeAmount;
+    return chargedPoints;
 }
 
 simulated function int GetMaxUses()


### PR DESCRIPTION
# Major Changes

- Loot Refusal (#768) 
- rework snyth heart aug (#657)
- spy drone rework (#657)
- reduce ammo now respects bIsSecretGoal, mostly for jail
- petting animals, and bingo goals for them
- close windows in PreTravel to prevent crashes with autorun and realtime menus

# Minor Changes

- Jock drops gibs when he explodes. Louis Pan screams are now controlled by the Memes toggle
- Jock leaves the bar before flying to the NSF warehouse (#776) 
- More info in messages after using bots (#771) 
- messages for skill upgrades
- dockyard roof backtrack button for the crane
- Restore 2 Nicollete lines in the Chateau cellar (#775) 
- Fix crates that allow you to jump out of the Warehouse sewer water (#773 
- Update rotation on HK Helibase flight deck buttons to use rotm
- fix Anna pepper spray when EMP'd and other issues with shielded enemies
- PS20/40 get thrown away more quickly
- Ensure FemJC can actually get the default jacket
- fix GMDX v10 missing Animal.ModifyDamage (#767)
- buffed update notifications
- speedrun splits display tweaks
- fix timer names in credits (#782)
- fix balanced splits being faster than gold (#787)
- Add 'TerroristCommander_Dead' == false requirement to 'DL_Top' (#783) 
- tone down lamps a bit to retain mood of the game
- fix floating nanokeys and datacubes 
- Bingo Goal for disabling electrical control panels in Vandenberg Computer room no longer gets completed by merging Helios
- Highlighting decorations will now show the proper number of shots from sabot and explosive weapons
- Beam and Laser Triggers now take damage from sabot and explosives even when under the min damage threshold, to match DeusExDecoration behaviour.  Highlight info reflects this as well.
- clean up airfield tower keys (#758)
