### PR TITLE
Improvements and fixes for adding goals and DXRStartMap

### DIFF
--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -815,30 +815,29 @@ static function ConEventSpeech GetSpeechEvent(ConEvent start, string speech) {
     return None;
 }
 
-static function string GetGoalTextStatic(name goalName, Conversation con, optional int which)
+static function ConEventAddGoal GetGoalConEventStatic(name goalName, Conversation con, optional int which)
 {
     local ConEvent ce;
     local ConEventAddGoal ceag;
 
-    if (con == None || goalName == '' || which < 0) return "";
+    if (con == None || goalName == '' || which < 0) return None;
 
     for (ce = con.eventList; ce != None; ce = ce.nextEvent) {
         ceag = ConEventAddGoal(ce);
         if (ceag != None && ceag.goalName == goalName) {
             if (which == 0) // keep looping until we find the version of the goal we want
-                return ceag.goalText;
+                return ceag;
             which--;
         }
     }
 
-    return "";
+    return None;
 }
 
-function string GetGoalText(name goalName, name conversationName, optional int which)
+function ConEventAddGoal GetGoalConEvent(name goalName, name convname, optional int which)
 {
-    return GetGoalTextStatic(goalName, GetConversation(conversationName), which);
+    return GetGoalConEventStatic(goalName, GetConversation(convname), which);
 }
-
 
 static function string GetActorName(Actor a)
 {
@@ -1664,16 +1663,18 @@ static function bool ChangeInitialAlliance(ScriptedPawn pawn, Name allianceName,
     return true;
 }
 
-function DeusExGoal AddGoalFromConv(#var(PlayerPawn) player, name goaltag, name convname, bool primary, optional int which)
+function DeusExGoal AddGoalFromConv(#var(PlayerPawn) player, name goaltag, name convname, optional int which)
 {
     local DeusExGoal goal;
+    local ConEventAddGoal ceag;
 
     goal = player.FindGoal(goaltag);
 
     if (goal == None) {
-        goal = player.AddGoal(goaltag, primary);
-        if(goal == None) return None;
-        goal.SetText(GetGoalText(goaltag, convname, which));
+        ceag = GetGoalConEvent(goaltag, convname, which);
+        if (ceag == None) return None;
+        goal = player.AddGoal(goaltag, ceag.bPrimaryGoal);
+        goal.SetText(ceag.goalText);
     }
 
     return goal;

--- a/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
@@ -134,19 +134,16 @@ function MissionTimer()
 
 function AddMissionGoals()
 {
-    local DeusExGoal newGoal;
+    local #var(PlayerPawn) p;
+
     if(dxr.localURL != "01_NYC_UNATCOISLAND") return;
 
     //The MeetPaul conversation would normally give you several goals.
     //Give them manually instead of via that conversation.
-    newGoal=player().AddGoal('DefeatNSFCommandCenter',True);
-    newGoal.SetText("The NSF seem to be directing the attack from somewhere on the island.  Find the commander.");
-
-    newGoal=player().AddGoal('RescueAgent',False);
-    newGoal.SetText("One of UNATCO's top agents is being held inside the Statue.  Break him out, and he'll back you up against the NSF.");
-
-    newGoal=player().AddGoal('MeetFilben',False);
-    newGoal.SetText("Meet UNATCO informant Harley Filben at the North Docks.  He has a key to the Statue doors.");
+    p = player();
+    AddGoalFromConv(p, 'DefeatNSFCommandCenter', 'MeetPaul', true);
+    AddGoalFromConv(p, 'RescueAgent', 'MeetPaul', false);
+    AddGoalFromConv(p, 'MeetFilben', 'MeetPaul', false);
 }
 
 function AfterMoveGoalToLocation(Goal g, GoalLocation Loc)

--- a/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
@@ -135,13 +135,16 @@ function MissionTimer()
 function AddMissionGoals()
 {
     local #var(PlayerPawn) p;
+    local DeusExGoal newGoal;
 
     if(dxr.localURL != "01_NYC_UNATCOISLAND") return;
 
     //The MeetPaul conversation would normally give you several goals.
     //Give them manually instead of via that conversation.
+    //Leo is not necessarily in the statue, so that goal text cannot be retrieved directly from the conversation.
     p = player();
-    AddGoalFromConv(p, 'DefeatNSFCommandCenter', 'MeetPaul');
+    newGoal=p.AddGoal('DefeatNSFCommandCenter',True);
+    newGoal.SetText("The NSF seem to be directing the attack from somewhere on the island.  Find the commander.");
     AddGoalFromConv(p, 'RescueAgent', 'MeetPaul');
     AddGoalFromConv(p, 'MeetFilben', 'MeetPaul');
 }

--- a/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
@@ -141,9 +141,9 @@ function AddMissionGoals()
     //The MeetPaul conversation would normally give you several goals.
     //Give them manually instead of via that conversation.
     p = player();
-    AddGoalFromConv(p, 'DefeatNSFCommandCenter', 'MeetPaul', true);
-    AddGoalFromConv(p, 'RescueAgent', 'MeetPaul', false);
-    AddGoalFromConv(p, 'MeetFilben', 'MeetPaul', false);
+    AddGoalFromConv(p, 'DefeatNSFCommandCenter', 'MeetPaul');
+    AddGoalFromConv(p, 'RescueAgent', 'MeetPaul');
+    AddGoalFromConv(p, 'MeetFilben', 'MeetPaul');
 }
 
 function AfterMoveGoalToLocation(Goal g, GoalLocation Loc)

--- a/DXRMissions/DeusEx/Classes/DXRMissionsM05.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsM05.uc
@@ -244,15 +244,12 @@ function AddMissionGoals()
             dlt.Destroy();
         }
     }
-    newGoal=player().AddGoal('FindPaul', true);
-    if(dxr.flagbase.GetBool('PaulDenton_Dead'))
-        newGoal.SetText("Get the datavault from your brother's body.  Tracer Tong will need it to defeat the killswitch.");
-    else
-        newGoal.SetText("Find your brother and access information in his datavault that Tracer Tong will need to defeat the killswitch.");
 
-    newGoal=player().AddGoal('FindEquipment', false);
-    l("added goal "$newGoal);
-    newGoal.SetText("Find the equipment taken from you when you were captured by UNATCO.");
+    if(dxr.flagbase.GetBool('PaulDenton_Dead'))
+        AddGoalFromConv(player(), 'FindPaul', 'DL_Choice', true, 1);
+    else
+        AddGoalFromConv(player(), 'FindPaul', 'DL_Choice', true);
+    AddGoalFromConv(player(), 'FindEquipment', 'DL_Choice', false);
 
     GivePlayerImage(player(), class'Image05_NYC_MJ12Lab');
 }

--- a/DXRMissions/DeusEx/Classes/DXRMissionsM05.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsM05.uc
@@ -246,10 +246,10 @@ function AddMissionGoals()
     }
 
     if(dxr.flagbase.GetBool('PaulDenton_Dead'))
-        AddGoalFromConv(player(), 'FindPaul', 'DL_Choice', true, 1);
+        AddGoalFromConv(player(), 'FindPaul', 'DL_Choice', 1);
     else
-        AddGoalFromConv(player(), 'FindPaul', 'DL_Choice', true);
-    AddGoalFromConv(player(), 'FindEquipment', 'DL_Choice', false);
+        AddGoalFromConv(player(), 'FindPaul', 'DL_Choice');
+    AddGoalFromConv(player(), 'FindEquipment', 'DL_Choice');
 
     GivePlayerImage(player(), class'Image05_NYC_MJ12Lab');
 }

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -467,16 +467,6 @@ static function AddNote(#var(PlayerPawn) player, bool bEmptyNotes, string text)
     }
 }
 
-function AddGoalFromConv(#var(PlayerPawn) player, name goaltag, name convname)
-{
-    local DeusExGoal newGoal;
-    newGoal = player.FindGoal(goaltag);
-    if(newGoal != None) return;
-    newGoal = player.AddGoal(goaltag, true);
-    if(newGoal == None) return;
-    newGoal.SetText(GetGoalTextGC(goaltag, convname));
-}
-
 function MarkConvPlayed(name flagname, bool bFemale)
 {
     dxr.flagbase.SetBool(flagname,true,,-1);
@@ -597,8 +587,8 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
             MarkConvPlayed('MeetHelios_Played', bFemale);              // You will go to Sector 4 and deactivate the uplink locks, yes.
             flagbase.SetBool('MS_TongAppeared',true,,-1);              // We can get you into Sector 3 -- but no further.
             GivePlayerImage(player, class'Image15_Area51_Sector3');
-            AddGoalFromConv(player, 'DestroyArea51', 'M15MeetTong');
-            AddGoalFromConv(player, 'DeactivateLocks', 'MeetHelios');
+            AddGoalFromConv(player, 'DestroyArea51', 'M15MeetTong', true);
+            AddGoalFromConv(player, 'DeactivateLocks', 'MeetHelios', true);
             // fallthrough
         case 152:
             MarkConvPlayed('DL_Final_Page02_Played', bFemale);         // Barely a scratch.
@@ -607,7 +597,7 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
             MarkConvPlayed('M15MeetEverett_Played', bFemale);          // Not far.  You will reach Page. I just wanted to let you know that Alex hacked the Sector 2 security grid
             flagbase.SetBool('MS_EverettAppeared',true,,-1);
             AddNote(player, bEmptyNotes, "Crew-complex security code: 8946.");
-            AddGoalFromConv(player, 'KillPage', 'M15MeetEverett');
+            AddGoalFromConv(player, 'KillPage', 'M15MeetEverett', true);
             // fallthrough
         case 151:
             MarkConvPlayed('DL_tong1_Played', bFemale);                // Here's a satellite image of the damage from the missile.

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -469,9 +469,10 @@ static function AddNote(#var(PlayerPawn) player, bool bEmptyNotes, string text)
 
 function MarkConvPlayed(name flagname, bool bFemale)
 {
+    flagname = StringToName(flagname$"_Played");
     dxr.flagbase.SetBool(flagname,true,,-1);
     if(bFemale) {
-        flagname = StringToName("FemJC"$string(flagname));
+        flagname = StringToName("FemJC"$flagname);
         dxr.flagbase.SetBool(flagname,true,,-1);
     }
 }
@@ -485,19 +486,19 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
 
     switch(start_flag/10) {
         case 4:
-            MarkConvPlayed('DL_SeeManderley_Played', bFemale);
+            MarkConvPlayed('DL_SeeManderley', bFemale);
             break;
         case 5:
             if(start_flag > 50) {
                 AddNote(player, bEmptyNotes, "Facility exit: 1125.");
                 AddNote(player, bEmptyNotes, "Until the grid is fully restored, the detention block door code has been reset to 4089 while _all_ detention cells have been reset to 4679.");
-                MarkConvPlayed('DL_NoPaul_Played', bFemale);
+                MarkConvPlayed('DL_NoPaul', bFemale);
                 flagbase.SetBool('MS_InventoryRemoved',true,,6);
             }
         case 7:
             flagbase.SetBool('Have_ROM',true,,-1);
-            MarkConvPlayed('MeetTracerTong_Played', bFemale);// do we need FemJC versions for these?
-            MarkConvPlayed('TriadCeremony_Played', bFemale);
+            MarkConvPlayed('MeetTracerTong', bFemale);// do we need FemJC versions for these?
+            MarkConvPlayed('TriadCeremony', bFemale);
             break;
         case 8:
             flagbase.SetBool('KnowsSmugglerPassword',true,,-1);
@@ -505,7 +506,7 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
             break;
         case 9:
             flagbase.SetBool('M08WarnedSmuggler',true,,-1);
-            MarkConvPlayed('DL_BadNews_Played', bFemale);
+            MarkConvPlayed('DL_BadNews', bFemale);
             flagbase.SetBool('HelpSailor',true,,-1);
             flagbase.SetBool('SandraWentToCalifornia',true,,-1);//Make sure Sandra spawns at the gas station
             break;
@@ -532,13 +533,13 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
     switch(start_flag) {
         case 21:
             flagbase.SetBool('EscapeSuccessful',true,,-1);
-            MarkConvPlayed('DL_SubwayComplete_Played', bFemale);
+            MarkConvPlayed('DL_SubwayComplete', bFemale);
             flagbase.SetBool('SubTerroristsDead',true,,-1);
-            MarkConvPlayed('MS_DL_Played', bFemale);
+            MarkConvPlayed('MS_DL', bFemale);
             break;
 
         case 45:
-            MarkConvPlayed('PaulInjured_Played', bFemale);
+            MarkConvPlayed('PaulInjured', bFemale);
             flagbase.SetBool('KnowsSmugglerPassword',true,,-1); // Paul ordinarily tells you the password if you don't know it
             flagbase.SetBool('GatesOpen',true,,5);
             break;
@@ -546,14 +547,14 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
         case 75:
         case 71:// anything greater than 70 should get these, even though this isn't an actual value currently
             AddNote(player, bEmptyNotes, "Access code to the Versalife nanotech research wing on Level 2: 55655.  There is a back entrance at the north end of the Canal Road Tunnel, which is just east of the temple.");
-            MarkConvPlayed('M07Briefing_Played', bFemale);// also spawns big spider in MJ12Lab
+            MarkConvPlayed('M07Briefing', bFemale);// also spawns big spider in MJ12Lab
         case 70://fallthrough
         case 68:
             AddNote(player, bEmptyNotes, "VersaLife elevator code: 6512.");
         case 67://fallthrough
             AddNote(player, bEmptyNotes, "Versalife employee ID: 06288.  Use this to access the VersaLife elevator north of the market.");
-            MarkConvPlayed('MeetTracerTong_Played', bFemale);
-            MarkConvPlayed('MeetTracerTong2_Played', bFemale);
+            MarkConvPlayed('MeetTracerTong', bFemale);
+            MarkConvPlayed('MeetTracerTong2', bFemale);
             flagbase.SetBool('KillswitchFixed',true,,-1);
         case 66://fallthrough
             AddNote(player, bEmptyNotes, "Luminous Path door-code: 1997.");
@@ -561,7 +562,7 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
             flagbase.SetBool('QuickConvinced',true,,-1);
         case 65://fallthrough
             flagbase.SetBool('Have_Evidence',true,,-1); // found the DTS, evidence against Maggie Chow
-            MarkConvPlayed('DL_Tong_00_Played', bFemale); // disable "Now take the sword to Max Chen" infolink you would have heard already
+            MarkConvPlayed('DL_Tong_00', bFemale); // disable "Now take the sword to Max Chen" infolink you would have heard already
             flagbase.SetBool('PaidForLuckyMoney',true,,-1);
             break;
         case 81:
@@ -573,45 +574,45 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
             break;
 
         case 129:
-            MarkConvPlayed('GaryHostageBriefing_Played', bFemale);
+            MarkConvPlayed('GaryHostageBriefing', bFemale);
             flagbase.SetBool('Heliosborn',true,,-1); //Make sure Daedalus and Icarus have merged
             break;
         case 145:
             flagbase.SetBool('schematic_downloaded',true,,-1); //Make sure the oceanlab UC schematics are downloaded
             break;
         case 153:
-            MarkConvPlayed('DL_Helios_Door1_Played', bFemale);         // Not yet.  No... I will not allow you to enter Sector 4 until you have received my instructions.
-            MarkConvPlayed('DL_Helios_Intro_Played', bFemale);         // I will now explain why you have been allowed to reach Sector 3.
-            MarkConvPlayed('DL_Final_Page03_Played', bFemale);         // Don't get your hopes up; my compound is quite secure.
+            MarkConvPlayed('DL_Helios_Door1', bFemale);         // Not yet.  No... I will not allow you to enter Sector 4 until you have received my instructions.
+            MarkConvPlayed('DL_Helios_Intro', bFemale);         // I will now explain why you have been allowed to reach Sector 3.
+            MarkConvPlayed('DL_Final_Page03', bFemale);         // Don't get your hopes up; my compound is quite secure.
             flagbase.SetBool('MS_PaulOrGaryAppeared',true,,-1);        // It let me through... I can't believe it.
-            MarkConvPlayed('MeetHelios_Played', bFemale);              // You will go to Sector 4 and deactivate the uplink locks, yes.
+            MarkConvPlayed('MeetHelios', bFemale);              // You will go to Sector 4 and deactivate the uplink locks, yes.
             flagbase.SetBool('MS_TongAppeared',true,,-1);              // We can get you into Sector 3 -- but no further.
             GivePlayerImage(player, class'Image15_Area51_Sector3');
             AddGoalFromConv(player, 'DestroyArea51', 'M15MeetTong', true);
             AddGoalFromConv(player, 'DeactivateLocks', 'MeetHelios', true);
             // fallthrough
         case 152:
-            MarkConvPlayed('DL_Final_Page02_Played', bFemale);         // Barely a scratch.
-            MarkConvPlayed('DL_elevator_Played', bFemale);             // Bet you didn't know your mom and dad tried to protest when we put you in training.
-            MarkConvPlayed('DL_conveyor_room_Played', bFemale);        // Page is further down.  Find the elevator.
-            MarkConvPlayed('M15MeetEverett_Played', bFemale);          // Not far.  You will reach Page. I just wanted to let you know that Alex hacked the Sector 2 security grid
+            MarkConvPlayed('DL_Final_Page02', bFemale);         // Barely a scratch.
+            MarkConvPlayed('DL_elevator', bFemale);             // Bet you didn't know your mom and dad tried to protest when we put you in training.
+            MarkConvPlayed('DL_conveyor_room', bFemale);        // Page is further down.  Find the elevator.
+            MarkConvPlayed('M15MeetEverett', bFemale);          // Not far.  You will reach Page. I just wanted to let you know that Alex hacked the Sector 2 security grid
             flagbase.SetBool('MS_EverettAppeared',true,,-1);
             AddNote(player, bEmptyNotes, "Crew-complex security code: 8946.");
             AddGoalFromConv(player, 'KillPage', 'M15MeetEverett', true);
             // fallthrough
         case 151:
-            MarkConvPlayed('DL_tong1_Played', bFemale);                // Here's a satellite image of the damage from the missile.
-            MarkConvPlayed('DL_tong_reached_bunker_Played', bFemale);  // Good work.  You've reached the bunker.
-            MarkConvPlayed('DL_JockDeathTongComment_Played', bFemale); // I don't believe it!  JC!  We lost Jock!
-            MarkConvPlayed('DL_JockDeath_Played', bFemale);            // JC!  Got a problem.  Someone planted a bo-----
-            MarkConvPlayed('DL_Bunker_Start_Played', bFemale);         // Just spotted a sniper in the tower.
-            MarkConvPlayed('DL_Bunker_PowerRoom_Played', bFemale);     // You're nearing the power room.
-            MarkConvPlayed('DL_Bunker_Power_Played', bFemale);         // The elevator power is online.
-            MarkConvPlayed('DL_Bunker_Hangar_Played', bFemale);        // I saw some soldiers running away from the hangar.
-            // MarkConvPlayed('DL_Bunker_Fan_Played', bFemale);        // Jump!  You can make it!
-            MarkConvPlayed('DL_Bunker_Elevator_Played', bFemale);      // The power to the elevator is down.
-            MarkConvPlayed('DL_Bunker_blastdoor_Played', bFemale);     // The schematics show an elevator to the west, but utility power is down.
-            MarkConvPlayed('DL_blastdoor_shut_Played', bFemale);       // These blast doors are the reason I don't have to worry about nukes -- or you.
+            MarkConvPlayed('DL_tong1', bFemale);                // Here's a satellite image of the damage from the missile.
+            MarkConvPlayed('DL_tong_reached_bunker', bFemale);  // Good work.  You've reached the bunker.
+            MarkConvPlayed('DL_JockDeathTongComment', bFemale); // I don't believe it!  JC!  We lost Jock!
+            MarkConvPlayed('DL_JockDeath', bFemale);            // JC!  Got a problem.  Someone planted a bo-----
+            MarkConvPlayed('DL_Bunker_Start', bFemale);         // Just spotted a sniper in the tower.
+            MarkConvPlayed('DL_Bunker_PowerRoom', bFemale);     // You're nearing the power room.
+            MarkConvPlayed('DL_Bunker_Power', bFemale);         // The elevator power is online.
+            MarkConvPlayed('DL_Bunker_Hangar', bFemale);        // I saw some soldiers running away from the hangar.
+            // MarkConvPlayed('DL_Bunker_Fan', bFemale);        // Jump!  You can make it!
+            MarkConvPlayed('DL_Bunker_Elevator', bFemale);      // The power to the elevator is down.
+            MarkConvPlayed('DL_Bunker_blastdoor', bFemale);     // The schematics show an elevator to the west, but utility power is down.
+            MarkConvPlayed('DL_blastdoor_shut', bFemale);       // These blast doors are the reason I don't have to worry about nukes -- or you.
             GivePlayerImage(player, class'Image15_Area51Bunker');
             break;
     }

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -623,11 +623,11 @@ function PostFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase,
 {
     switch(start_flag) {
         case 153:
-            AddGoalFromConv(player, 'DestroyArea51', 'M15MeetTong', true);
-            AddGoalFromConv(player, 'DeactivateLocks', 'MeetHelios', true);
+            AddGoalFromConv(player, 'DestroyArea51', 'M15MeetTong');
+            AddGoalFromConv(player, 'DeactivateLocks', 'MeetHelios');
             //fallthrough
         case 152:
-            AddGoalFromConv(player, 'KillPage', 'M15MeetEverett', true);
+            AddGoalFromConv(player, 'KillPage', 'M15MeetEverett');
             break;
     }
 }

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -292,10 +292,10 @@ static function string _GetStartMap(int start_map_val, optional out string frien
             bShowInMenu=1;
             friendlyName = "NSF Defection (UNATCO HQ)";
             return "04_NYC_UNATCOHQ";
-        case 41:
+        case 42:
             friendlyName = "NSF Defection (Streets)";
             return "04_NYC_Street";
-        case 42:
+        case 43:
             friendlyName = "NSF Defection (Hotel)";
             return "04_NYC_Hotel";
         case 45:

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -15,7 +15,7 @@ function PlayerLogin(#var(PlayerPawn) p)
     //Add extra skill points to make available once you enter the game
     AddStartingSkillPoints(dxr,p);
 
-    StartMapSpecificFlags(p, p.flagbase, dxr.flags.settings.starting_map);
+    PreFirstEntryStartMapFixes(p, p.flagbase, dxr.flags.settings.starting_map);
 }
 
 function PlayerAnyEntry(#var(PlayerPawn) p)
@@ -38,6 +38,10 @@ function PreFirstEntry()
 
     p = player();
     DeusExRootWindow(p.rootWindow).hud.startDisplay.AddMessage("Mission " $ dxr.dxInfo.missionNumber);
+
+    if(IsStartMap()) {
+        PreFirstEntryStartMapFixes(p, p.flagbase, dxr.flags.settings.starting_map);
+    }
 
     switch(dxr.localURL) {
     case "02_NYC_BATTERYPARK":
@@ -86,7 +90,7 @@ function PreFirstEntry()
 function PostFirstEntry()
 {
     if(IsStartMap()) {
-        StartMapSpecificFlags(player(), dxr.flagbase, dxr.flags.settings.starting_map);
+        PostFirstEntryStartMapFixes(player(), dxr.flagbase, dxr.flags.settings.starting_map);
     }
 }
 
@@ -477,7 +481,7 @@ function MarkConvPlayed(string flagname, bool bFemale)
     }
 }
 
-function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int start_flag)
+function PreFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, int start_flag)
 {
     local bool bEmptyNotes, bFemale;
 
@@ -588,8 +592,6 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
             MarkConvPlayed("MeetHelios", bFemale);              // You will go to Sector 4 and deactivate the uplink locks, yes.
             flagbase.SetBool('MS_TongAppeared',true,,-1);              // We can get you into Sector 3 -- but no further.
             GivePlayerImage(player, class'Image15_Area51_Sector3');
-            AddGoalFromConv(player, 'DestroyArea51', 'M15MeetTong', true);
-            AddGoalFromConv(player, 'DeactivateLocks', 'MeetHelios', true);
             // fallthrough
         case 152:
             MarkConvPlayed("DL_Final_Page02", bFemale);         // Barely a scratch.
@@ -598,7 +600,6 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
             MarkConvPlayed("M15MeetEverett", bFemale);          // Not far.  You will reach Page. I just wanted to let you know that Alex hacked the Sector 2 security grid
             flagbase.SetBool('MS_EverettAppeared',true,,-1);
             AddNote(player, bEmptyNotes, "Crew-complex security code: 8946.");
-            AddGoalFromConv(player, 'KillPage', 'M15MeetEverett', true);
             // fallthrough
         case 151:
             MarkConvPlayed("DL_tong1", bFemale);                // Here's a satellite image of the damage from the missile.
@@ -614,6 +615,19 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
             MarkConvPlayed("DL_Bunker_blastdoor", bFemale);     // The schematics show an elevator to the west, but utility power is down.
             MarkConvPlayed("DL_blastdoor_shut", bFemale);       // These blast doors are the reason I don't have to worry about nukes -- or you.
             GivePlayerImage(player, class'Image15_Area51Bunker');
+            break;
+    }
+}
+
+function PostFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, int start_flag)
+{
+    switch(start_flag) {
+        case 153:
+            AddGoalFromConv(player, 'DestroyArea51', 'M15MeetTong', true);
+            AddGoalFromConv(player, 'DeactivateLocks', 'MeetHelios', true);
+            //fallthrough
+        case 152:
+            AddGoalFromConv(player, 'KillPage', 'M15MeetEverett', true);
             break;
     }
 }
@@ -759,7 +773,7 @@ static function bool BingoGoalImpossible(string bingo_event, int start_map, int 
             // This goal is impossible with a 50+ start because he is then always alive
             return start_map>=50 || end_mission < 6;
         case "MetSmuggler":
-            return start_map>=80; //Mission 8 and later starts you should already know Smuggler (see StartMapSpecificFlags)
+            return start_map>=80; //Mission 8 and later starts you should already know Smuggler (see PreFirstEntryStartMapFixes)
         case "KnowsGuntherKillphrase":
             if (end_mission < 12){
                 return True;

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -39,10 +39,6 @@ function PreFirstEntry()
     p = player();
     DeusExRootWindow(p.rootWindow).hud.startDisplay.AddMessage("Mission " $ dxr.dxInfo.missionNumber);
 
-    if(IsStartMap()) {
-        StartMapSpecificFlags(p, p.flagbase, dxr.flags.settings.starting_map);
-    }
-
     switch(dxr.localURL) {
     case "02_NYC_BATTERYPARK":
         if(dxr.flags.settings.starting_map > 20) {
@@ -84,6 +80,13 @@ function PreFirstEntry()
             }
         }
         break;
+    }
+}
+
+function PostFirstEntry()
+{
+    if(IsStartMap()) {
+        StartMapSpecificFlags(player(), dxr.flagbase, dxr.flags.settings.starting_map);
     }
 }
 

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -467,13 +467,13 @@ static function AddNote(#var(PlayerPawn) player, bool bEmptyNotes, string text)
     }
 }
 
-function MarkConvPlayed(name flagname, bool bFemale)
+function MarkConvPlayed(string flagname, bool bFemale)
 {
-    flagname = StringToName(flagname$"_Played");
-    dxr.flagbase.SetBool(flagname,true,,-1);
+    flagname = flagname$"_Played";
+    dxr.flagbase.SetBool(StringToName(flagname),true,,-1);
     if(bFemale) {
-        flagname = StringToName("FemJC"$flagname);
-        dxr.flagbase.SetBool(flagname,true,,-1);
+        flagname = "FemJC"$flagname;
+        dxr.flagbase.SetBool(StringToName(flagname),true,,-1);
     }
 }
 
@@ -486,19 +486,19 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
 
     switch(start_flag/10) {
         case 4:
-            MarkConvPlayed('DL_SeeManderley', bFemale);
+            MarkConvPlayed("DL_SeeManderley", bFemale);
             break;
         case 5:
             if(start_flag > 50) {
                 AddNote(player, bEmptyNotes, "Facility exit: 1125.");
                 AddNote(player, bEmptyNotes, "Until the grid is fully restored, the detention block door code has been reset to 4089 while _all_ detention cells have been reset to 4679.");
-                MarkConvPlayed('DL_NoPaul', bFemale);
+                MarkConvPlayed("DL_NoPaul", bFemale);
                 flagbase.SetBool('MS_InventoryRemoved',true,,6);
             }
         case 7:
             flagbase.SetBool('Have_ROM',true,,-1);
-            MarkConvPlayed('MeetTracerTong', bFemale);// do we need FemJC versions for these?
-            MarkConvPlayed('TriadCeremony', bFemale);
+            MarkConvPlayed("MeetTracerTong", bFemale);// do we need FemJC versions for these?
+            MarkConvPlayed("TriadCeremony", bFemale);
             break;
         case 8:
             flagbase.SetBool('KnowsSmugglerPassword',true,,-1);
@@ -506,7 +506,7 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
             break;
         case 9:
             flagbase.SetBool('M08WarnedSmuggler',true,,-1);
-            MarkConvPlayed('DL_BadNews', bFemale);
+            MarkConvPlayed("DL_BadNews", bFemale);
             flagbase.SetBool('HelpSailor',true,,-1);
             flagbase.SetBool('SandraWentToCalifornia',true,,-1);//Make sure Sandra spawns at the gas station
             break;
@@ -533,13 +533,13 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
     switch(start_flag) {
         case 21:
             flagbase.SetBool('EscapeSuccessful',true,,-1);
-            MarkConvPlayed('DL_SubwayComplete', bFemale);
+            MarkConvPlayed("DL_SubwayComplete", bFemale);
             flagbase.SetBool('SubTerroristsDead',true,,-1);
-            MarkConvPlayed('MS_DL', bFemale);
+            MarkConvPlayed("MS_DL", bFemale);
             break;
 
         case 45:
-            MarkConvPlayed('PaulInjured', bFemale);
+            MarkConvPlayed("PaulInjured", bFemale);
             flagbase.SetBool('KnowsSmugglerPassword',true,,-1); // Paul ordinarily tells you the password if you don't know it
             flagbase.SetBool('GatesOpen',true,,5);
             break;
@@ -547,14 +547,14 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
         case 75:
         case 71:// anything greater than 70 should get these, even though this isn't an actual value currently
             AddNote(player, bEmptyNotes, "Access code to the Versalife nanotech research wing on Level 2: 55655.  There is a back entrance at the north end of the Canal Road Tunnel, which is just east of the temple.");
-            MarkConvPlayed('M07Briefing', bFemale);// also spawns big spider in MJ12Lab
+            MarkConvPlayed("M07Briefing", bFemale);// also spawns big spider in MJ12Lab
         case 70://fallthrough
         case 68:
             AddNote(player, bEmptyNotes, "VersaLife elevator code: 6512.");
         case 67://fallthrough
             AddNote(player, bEmptyNotes, "Versalife employee ID: 06288.  Use this to access the VersaLife elevator north of the market.");
-            MarkConvPlayed('MeetTracerTong', bFemale);
-            MarkConvPlayed('MeetTracerTong2', bFemale);
+            MarkConvPlayed("MeetTracerTong", bFemale);
+            MarkConvPlayed("MeetTracerTong2", bFemale);
             flagbase.SetBool('KillswitchFixed',true,,-1);
         case 66://fallthrough
             AddNote(player, bEmptyNotes, "Luminous Path door-code: 1997.");
@@ -562,7 +562,7 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
             flagbase.SetBool('QuickConvinced',true,,-1);
         case 65://fallthrough
             flagbase.SetBool('Have_Evidence',true,,-1); // found the DTS, evidence against Maggie Chow
-            MarkConvPlayed('DL_Tong_00', bFemale); // disable "Now take the sword to Max Chen" infolink you would have heard already
+            MarkConvPlayed("DL_Tong_00", bFemale); // disable "Now take the sword to Max Chen" infolink you would have heard already
             flagbase.SetBool('PaidForLuckyMoney',true,,-1);
             break;
         case 81:
@@ -574,45 +574,45 @@ function StartMapSpecificFlags(#var(PlayerPawn) player, FlagBase flagbase, int s
             break;
 
         case 129:
-            MarkConvPlayed('GaryHostageBriefing', bFemale);
+            MarkConvPlayed("GaryHostageBriefing", bFemale);
             flagbase.SetBool('Heliosborn',true,,-1); //Make sure Daedalus and Icarus have merged
             break;
         case 145:
             flagbase.SetBool('schematic_downloaded',true,,-1); //Make sure the oceanlab UC schematics are downloaded
             break;
         case 153:
-            MarkConvPlayed('DL_Helios_Door1', bFemale);         // Not yet.  No... I will not allow you to enter Sector 4 until you have received my instructions.
-            MarkConvPlayed('DL_Helios_Intro', bFemale);         // I will now explain why you have been allowed to reach Sector 3.
-            MarkConvPlayed('DL_Final_Page03', bFemale);         // Don't get your hopes up; my compound is quite secure.
+            MarkConvPlayed("DL_Helios_Door1", bFemale);         // Not yet.  No... I will not allow you to enter Sector 4 until you have received my instructions.
+            MarkConvPlayed("DL_Helios_Intro", bFemale);         // I will now explain why you have been allowed to reach Sector 3.
+            MarkConvPlayed("DL_Final_Page03", bFemale);         // Don't get your hopes up; my compound is quite secure.
             flagbase.SetBool('MS_PaulOrGaryAppeared',true,,-1);        // It let me through... I can't believe it.
-            MarkConvPlayed('MeetHelios', bFemale);              // You will go to Sector 4 and deactivate the uplink locks, yes.
+            MarkConvPlayed("MeetHelios", bFemale);              // You will go to Sector 4 and deactivate the uplink locks, yes.
             flagbase.SetBool('MS_TongAppeared',true,,-1);              // We can get you into Sector 3 -- but no further.
             GivePlayerImage(player, class'Image15_Area51_Sector3');
             AddGoalFromConv(player, 'DestroyArea51', 'M15MeetTong', true);
             AddGoalFromConv(player, 'DeactivateLocks', 'MeetHelios', true);
             // fallthrough
         case 152:
-            MarkConvPlayed('DL_Final_Page02', bFemale);         // Barely a scratch.
-            MarkConvPlayed('DL_elevator', bFemale);             // Bet you didn't know your mom and dad tried to protest when we put you in training.
-            MarkConvPlayed('DL_conveyor_room', bFemale);        // Page is further down.  Find the elevator.
-            MarkConvPlayed('M15MeetEverett', bFemale);          // Not far.  You will reach Page. I just wanted to let you know that Alex hacked the Sector 2 security grid
+            MarkConvPlayed("DL_Final_Page02", bFemale);         // Barely a scratch.
+            MarkConvPlayed("DL_elevator", bFemale);             // Bet you didn't know your mom and dad tried to protest when we put you in training.
+            MarkConvPlayed("DL_conveyor_room", bFemale);        // Page is further down.  Find the elevator.
+            MarkConvPlayed("M15MeetEverett", bFemale);          // Not far.  You will reach Page. I just wanted to let you know that Alex hacked the Sector 2 security grid
             flagbase.SetBool('MS_EverettAppeared',true,,-1);
             AddNote(player, bEmptyNotes, "Crew-complex security code: 8946.");
             AddGoalFromConv(player, 'KillPage', 'M15MeetEverett', true);
             // fallthrough
         case 151:
-            MarkConvPlayed('DL_tong1', bFemale);                // Here's a satellite image of the damage from the missile.
-            MarkConvPlayed('DL_tong_reached_bunker', bFemale);  // Good work.  You've reached the bunker.
-            MarkConvPlayed('DL_JockDeathTongComment', bFemale); // I don't believe it!  JC!  We lost Jock!
-            MarkConvPlayed('DL_JockDeath', bFemale);            // JC!  Got a problem.  Someone planted a bo-----
-            MarkConvPlayed('DL_Bunker_Start', bFemale);         // Just spotted a sniper in the tower.
-            MarkConvPlayed('DL_Bunker_PowerRoom', bFemale);     // You're nearing the power room.
-            MarkConvPlayed('DL_Bunker_Power', bFemale);         // The elevator power is online.
-            MarkConvPlayed('DL_Bunker_Hangar', bFemale);        // I saw some soldiers running away from the hangar.
-            // MarkConvPlayed('DL_Bunker_Fan', bFemale);        // Jump!  You can make it!
-            MarkConvPlayed('DL_Bunker_Elevator', bFemale);      // The power to the elevator is down.
-            MarkConvPlayed('DL_Bunker_blastdoor', bFemale);     // The schematics show an elevator to the west, but utility power is down.
-            MarkConvPlayed('DL_blastdoor_shut', bFemale);       // These blast doors are the reason I don't have to worry about nukes -- or you.
+            MarkConvPlayed("DL_tong1", bFemale);                // Here's a satellite image of the damage from the missile.
+            MarkConvPlayed("DL_tong_reached_bunker", bFemale);  // Good work.  You've reached the bunker.
+            MarkConvPlayed("DL_JockDeathTongComment", bFemale); // I don't believe it!  JC!  We lost Jock!
+            MarkConvPlayed("DL_JockDeath", bFemale);            // JC!  Got a problem.  Someone planted a bo-----
+            MarkConvPlayed("DL_Bunker_Start", bFemale);         // Just spotted a sniper in the tower.
+            MarkConvPlayed("DL_Bunker_PowerRoom", bFemale);     // You're nearing the power room.
+            MarkConvPlayed("DL_Bunker_Power", bFemale);         // The elevator power is online.
+            MarkConvPlayed("DL_Bunker_Hangar", bFemale);        // I saw some soldiers running away from the hangar.
+            // MarkConvPlayed("DL_Bunker_Fan", bFemale);        // Jump!  You can make it!
+            MarkConvPlayed("DL_Bunker_Elevator", bFemale);      // The power to the elevator is down.
+            MarkConvPlayed("DL_Bunker_blastdoor", bFemale);     // The schematics show an elevator to the west, but utility power is down.
+            MarkConvPlayed("DL_blastdoor_shut", bFemale);       // These blast doors are the reason I don't have to worry about nukes -- or you.
             GivePlayerImage(player, class'Image15_Area51Bunker');
             break;
     }

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -1664,6 +1664,11 @@ exec function PlayerLoc()
     ClientMessage("Player location: (" $ Location.x $ ", " $ Location.y $ ", " $ Location.z $ ")");
 }
 
+exec function PlayerRot()
+{
+    ClientMessage("Player rotation: (" $ Rotation.pitch $ ", " $ Rotation.yaw $ ", " $ Rotation.roll $ ")");
+}
+
 exec function ShowRefused()
 {
     local string refusals, msg;


### PR DESCRIPTION
* `GetGoalText` takes an optional parameter to indicate which version of the goal it should return the text of
* `AddGoalFromConv` allows setting the goal to primary or secondary, and has an optional parameter for the version of the goal to use
* Most places where goals are added now use `AddGoalFromConv`
* `StartMapSpecificFlags` split into `PreFirstEntryStartMapFixes` and `PostFirstEntryStartMapFixes`
* Restores the "NSF Defection (Streets)" start
  * As far as I can find, the only change necessary is to `_GetStartMap`