### PR TITLE
Don't allow adding augmentation cannisters to refusal list

### DIFF
--- a/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
+++ b/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
@@ -193,6 +193,9 @@ function EnableButtons()
             } else {
                 if (WeaponMod(inv) != None || AugmentationUpgradeCannister(inv) != None || DeusExWeapon(inv) != None) {
                     btnUse.DisableWindow();
+                } else if (AugmentationCannister(inv) != None) {
+                    btnRefusal.DisableWindow();
+                    btnUse.DisableWindow();
                 } else {
                     if ((inv == player.inHand ) || (inv == player.inHandPending))
                         btnEquip.SetButtonText(UnequipButtonLabel);


### PR DESCRIPTION
Since all augmentation cannisters share the same class, they're incompatible with DXR's loot refusal system.