### PR TITLE
give "Trash" and "Not Trash" separate keyboard shortcuts

### DIFF
--- a/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
+++ b/DXRVanilla/DeusEx/Classes/PersonaScreenInventory.uc
@@ -1,7 +1,7 @@
 class PersonaScreenInventory injects PersonaScreenInventory;
 
 const RefuseLabel = "|&Trash";
-const AcceptLabel = "Not |&Trash";
+const AcceptLabel = "|&Not Trash";
 
 var PersonaActionButtonWindow btnRefusal;
 


### PR DESCRIPTION
Nitram requested this change. This way you don't have to spend any mental energy on whether you've already trashed something or not.