### PR TITLE
Faster Highlighting

### DIFF
--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -15,6 +15,8 @@ var Rotator ShakeRotator;
 
 var travel int LastBrowsedAugPage, LastBrowsedAug; //OAT, 1/12/24: By popular demand.
 
+var Actor FrobTargetFromHighlight;
+
 function ClientMessage(coerce string msg, optional Name type, optional bool bBeep)
 {
     // HACK: 2 spaces because destroyed item pickups do ClientMessage( Item.PickupMessage @ Item.itemArticle @ Item.ItemName, 'Pickup' );
@@ -861,9 +863,88 @@ function bool IsFrobbable(actor A)
 
 function HighlightCenterObject()
 {
-    local Vector loc;
+    HighlightCenterObjectMain();
+    HighlightCenterObjectLaser();
+}
 
-    Super.HighlightCenterObject();
+function HighlightCenterObjectMain()
+{
+    local Actor target, smallestTarget;
+    local Vector HitLoc, HitNormal, StartTrace, EndTrace;
+    local DeusExRootWindow root;
+    local float minSize;
+    local bool bFirstTarget;
+
+    if (IsInState('Dying'))
+        return;
+
+    root = DeusExRootWindow(rootWindow);
+
+    // only do the trace every hundredth of a second, this is 10 times faster than vanilla
+    if (FrobTime >= 0.01)
+    {
+        // figure out how far ahead we should trace
+        StartTrace = Location;
+        EndTrace = Location + (Vector(ViewRotation) * MaxFrobDistance);
+
+        // adjust for the eye height
+        StartTrace.Z += BaseEyeHeight;
+        EndTrace.Z += BaseEyeHeight;
+
+        smallestTarget = None;
+        minSize = 99999;
+        bFirstTarget = True;
+
+        // find the object that we are looking at
+        // make sure we don't select the object that we're carrying
+        // use the last traced object as the target...this will handle
+        // smaller items under larger items for example
+        // ScriptedPawns always have precedence, though
+        foreach TraceActors(class'Actor', target, HitLoc, HitNormal, EndTrace, StartTrace)
+        {
+            if (IsFrobbable(target) && (target != CarriedDecoration))
+            {
+                if (target.IsA('ScriptedPawn'))
+                {
+                    smallestTarget = target;
+                    break;
+                }
+                else if (target.IsA('Mover') && bFirstTarget)
+                {
+                    smallestTarget = target;
+                    break;
+                }
+                else if (target.CollisionRadius < minSize)
+                {
+                    minSize = target.CollisionRadius;
+                    smallestTarget = target;
+                    bFirstTarget = False;
+                }
+            }
+        }
+
+        // if we already have a frob target, and the player looks away such as that no item is being
+        // traced, we still wait for the full 100ms vanilla duration before clearing the frob
+        // target.
+        //
+        // note that this means we don't wait for the full 100ms vanilla duration if the player is
+        // rapidly changing frob target.
+        if ((FrobTime < 0.1) && (FrobTargetFromHighlight != None) && (smallestTarget == None))
+        {
+            return;
+        }
+
+        FrobTarget = smallestTarget;
+        FrobTargetFromHighlight = smallestTarget;
+
+        // reset our frob timer
+        FrobTime = 0;
+    }
+}
+
+function HighlightCenterObjectLaser()
+{
+    local Vector loc;
 
     //Activate the aim laser any time you aren't seeing through your eyes
     if (class'DXRAimLaserEmitter'.static.AimLaserShouldBeOn(self)){

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -878,8 +878,8 @@ function HighlightCenterObjectMain()
 
     if(LevelInfo(target) != None) target = None;
 
-    if(target != None) {
-        t = HighlightCenterObjectRay(vect(0,0,1.5), dist2);
+    if(target != None && class'MenuChoice_FixGlitches'.default.enabled) {
+        t = HighlightCenterObjectRay(vect(0,-0.2,1.5), dist2);
         fails += int(t!=target && dist2 < dist && (LevelInfo(t)!=None || Brush(t)!=None));
 
         t = HighlightCenterObjectRay(vect(0,-1,-1), dist2);


### PR DESCRIPTION
This PR changes the 100ms timer on highlighting down to 10ms. Once an object is acquired, it will keep it highlighted for 100ms, if the player has moved their crosshairs to nothing. If they move their crosshairs to a different object, the target will be refresh in 10ms or less.

I tried to preserve the way the original code worked, well the laser aim code that was added on top of vanilla runs indiscriminately even if target is dying (I assume that's how it works when you call Super and then run the laser code without taking into account where the Super method might have returned early).

I managed to build and tested that this works and has an effect. But I'm not knowledgeable enough to have tested less obvious potential edge cases.