### PR TITLE
disable "NSF everywhere" infolink if 'StatueMissionComplete'

### DIFF
--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
@@ -197,6 +197,8 @@ function AnyEntryMapFixes()
     GetConversation('DL_FrontEntrance').AddFlagRef('StatueMissionComplete', false);
     // "you might be able to avoid some of the security by entering this way"
     GetConversation('DL_BackEntrance').AddFlagRef('StatueMissionComplete', false);
+    // NSF everywhere, JC.  Your orders are to shoot on sight.
+    GetConversation('DL_LeaveDockNoGun').AddFlagRef('StatueMissionComplete', false);
 
     //Cut out the dialog for Paul giving you equipment
     if(dxr.flags.IsReducedRando()) return; // but not in reduced rando


### PR DESCRIPTION
It was only really possible when Leo was at the south dock, because the infolink requires that you've talked to Paul.