### PR TITLE
bingo failure fixes

### DIFF
--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -1547,13 +1547,6 @@ function MarkBingoFailedSpecial()
         FailIfCorpseNotHeld(class'#var(prefix)TerroristCommanderCarcass', "LeoToTheBar");
         FailIfCorpseNotHeld(class'#var(prefix)PaulDentonCarcass', "PaulToTong");
         break;
-    case "06_HONGKONG_VERSALIFE":
-    case "06_HONGKONG_STORAGE":
-        if (dxr.flagbase.GetBool('Have_ROM')) {
-            class'DXREventsBase'.static.MarkBingoAsFailed(dxr, "MarketKid_Dead");
-            class'DXREventsBase'.static.MarkBingoAsFailed(dxr, "MarketKid_BindNameUnconscious");
-        }
-        break;
     case "08_NYC_STREET":
     case "09_NYC_DOCKYARD":
         FailIfCorpseNotHeld(class'#var(prefix)TerroristCommanderCarcass', "LeoToTheBar");
@@ -1569,6 +1562,15 @@ function MarkBingoFailedSpecial()
     case "11_PARIS_EVERETT":
     case "12_VANDENBERG_CMD":
         FailIfCorpseNotHeld(class'#var(prefix)TerroristCommanderCarcass', "LeoToTheBar");
+        break;
+    }
+
+    switch (dxr.dxInfo.missionNumber) {
+    case 6:
+        if (dxr.flagbase.GetBool('Have_ROM')) {
+            class'DXREventsBase'.static.MarkBingoAsFailed(dxr, "MarketKid_Dead");
+            class'DXREventsBase'.static.MarkBingoAsFailed(dxr, "MarketKid_BindNameUnconscious");
+        }
         break;
     }
 }

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -1547,8 +1547,8 @@ function MarkBingoFailedSpecial()
         FailIfCorpseNotHeld(class'#var(prefix)TerroristCommanderCarcass', "LeoToTheBar");
         FailIfCorpseNotHeld(class'#var(prefix)PaulDentonCarcass', "PaulToTong");
         break;
-    case "06_HONGKONG_WANCHAI_MARKET":
-    case "06_HONGKONG_WANCHAI_CANAL":
+    case "06_HONGKONG_VERSALIFE":
+    case "06_HONGKONG_STORAGE":
         if (dxr.flagbase.GetBool('Have_ROM')) {
             class'DXREventsBase'.static.MarkBingoAsFailed(dxr, "MarketKid_Dead");
             class'DXREventsBase'.static.MarkBingoAsFailed(dxr, "MarketKid_BindNameUnconscious");

--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -1466,6 +1466,8 @@ function RunTests()
 
     testint(BingoActiveMission(1, 0), 1, "BingoActiveMission maybe");
     testint(BingoActiveMission(1, (1<<1)), 2, "BingoActiveMission");
+    testint(BingoActiveMission(2, (1<<1)), -1, "BingoActiveMission too late");
+    testint(BingoActiveMission(2, FAILED_MISSION_MASK), -1, "BingoActiveMission failed");
     testint(BingoActiveMission(15, (1<<15)), 2, "BingoActiveMission");
     testint(BingoActiveMission(3, (1<<15)), 0, "BingoActiveMission false");
 }

--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -1417,7 +1417,7 @@ static function int BingoActiveMission(int currentMission, int missionsMask)
     if(missionAnded != 0) return 2;// 2==true
 #endif
 
-    if((missionsMask & FAILED_MISSION_MASK) != 0) {
+    if(missionsMask < (1<<minMission) || (missionsMask & FAILED_MISSION_MASK) != 0) {
         return -1;// goal is failed
     }
 

--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -1,5 +1,7 @@
 class DXREventsBase extends DXRActorsBase;
 
+const FAILED_MISSION_MASK = 1;
+
 var bool died;
 var name watchflags[32];
 var int num_watchflags;
@@ -88,8 +90,9 @@ function MarkBingoFailedGeneric()
     local PlayerDataItem data;
     local int curMission;
 
-    data = class'PlayerDataItem'.static.GiveItem(player());
     curMission = dxr.dxInfo.missionNumber;
+    if (curMission == 98) return;
+    data = class'PlayerDataItem'.static.GiveItem(player());
     data.CheckForExpiredBingoGoals(curMission);
 }
 
@@ -1414,8 +1417,8 @@ static function int BingoActiveMission(int currentMission, int missionsMask)
     if(missionAnded != 0) return 2;// 2==true
 #endif
 
-    if(missionsMask < (1<<minMission)) {
-        return -1;// impossible in future missions
+    if((missionsMask & FAILED_MISSION_MASK) != 0) {
+        return -1;// goal is failed
     }
 
     return 0;// 0==false
@@ -1463,7 +1466,6 @@ function RunTests()
 
     testint(BingoActiveMission(1, 0), 1, "BingoActiveMission maybe");
     testint(BingoActiveMission(1, (1<<1)), 2, "BingoActiveMission");
-    testint(BingoActiveMission(2, (1<<1)), -1, "BingoActiveMission too late");
     testint(BingoActiveMission(15, (1<<15)), 2, "BingoActiveMission");
     testint(BingoActiveMission(3, (1<<15)), 0, "BingoActiveMission false");
 }


### PR DESCRIPTION
Bingo goals don't get marked as failed prematurely during the intro sequence. Failed goal squares are red again.