### PR TITLE
ElevatorMovers always move at approximately the same speed

### DIFF
--- a/DXRFixes/DeusEx/Classes/ElevatorMover.uc
+++ b/DXRFixes/DeusEx/Classes/ElevatorMover.uc
@@ -2,7 +2,7 @@ class ElevatorMover merges ElevatorMover;
 // can't do injects because it uses a state
 
 var float lastTime;
-var float moveSpeed;
+var float moveSpeed, originalMoveTime;
 
 function bool EncroachingOn( actor Other )
 {
@@ -21,17 +21,25 @@ function bool EncroachingOn( actor Other )
 function float GetMoveSpeed()
 {
     // assumes no valid KeyPos elements after the first are (0, 0, 0)
-    local float maxDist;
+    local float maxDist, avgDist, distSum, dist;
     local int i, j;
 
     if (moveSpeed == 0.0) {
         for (i = 0; i < ArrayCount(KeyPos); i++) {
+            if (i > 0 && KeyPos[i] == vect(0.0, 0.0, 0.0)) break;
+
             for (j = i + 1; j < ArrayCount(KeyPos); j++) {
-                if (KeyPos[j] == vect(0.0, 0.0, 0.0)) continue;
-                maxDist = Max(maxDist, VSize(KeyPos[i] - KeyPos[j]));
+                if (KeyPos[j] == vect(0.0, 0.0, 0.0)) break;
+
+                dist = VSize(KeyPos[i] - KeyPos[j]);
+                maxDist = FMax(maxDist, dist);
+                distSum += dist;
             }
         }
-        moveSpeed = maxDist / MoveTime;
+
+        avgDist = distSum / (i * (i - 1) / 2.0);
+        moveSpeed = (maxDist*0.33 + avgDist*0.67) / MoveTime;
+        originalMoveTime = MoveTime;
     }
 
     return moveSpeed;
@@ -43,17 +51,17 @@ function SetSeq(int seqnum)
     local int prevKeyNum;
     local float dist;
 
+    if ( bIsMoving && !oldSeq )
+        return;
+
     if( MoveTime/2 < Level.TimeSeconds-lastTime )
         oldSeq = true;
 
     dist = VSize(BasePos + KeyPos[seqnum] - Location);
 
-    if (KeyPos[0] == vect(0.0, 0.0, 0.0)) {
-        MoveTime = dist / GetMoveSpeed();
+    if (KeyPos[2] != vect(0.0, 0.0, 0.0)) {
+        MoveTime = FMax(dist / GetMoveSpeed(), originalMoveTime / 2.5);
     }
-
-    if ( bIsMoving && !oldSeq )
-        return;
 
     if (KeyNum != seqnum || oldSeq)
     {

--- a/DXRFixes/DeusEx/Classes/ElevatorMover.uc
+++ b/DXRFixes/DeusEx/Classes/ElevatorMover.uc
@@ -2,6 +2,7 @@ class ElevatorMover merges ElevatorMover;
 // can't do injects because it uses a state
 
 var float lastTime;
+var float moveSpeed;
 
 function bool EncroachingOn( actor Other )
 {
@@ -17,6 +18,25 @@ function bool EncroachingOn( actor Other )
     return false;
 }
 
+function float GetMoveSpeed()
+{
+    // assumes no valid KeyPos elements after the first are (0, 0, 0)
+    local float maxDist;
+    local int i, j;
+
+    if (moveSpeed == 0.0) {
+        for (i = 0; i < ArrayCount(KeyPos); i++) {
+            for (j = i + 1; j < ArrayCount(KeyPos); j++) {
+                if (KeyPos[j] == vect(0.0, 0.0, 0.0)) continue;
+                maxDist = Max(maxDist, VSize(KeyPos[i] - KeyPos[j]));
+            }
+        }
+        moveSpeed = maxDist / MoveTime;
+    }
+
+    return moveSpeed;
+}
+
 function SetSeq(int seqnum)
 {
     local bool oldSeq;
@@ -26,6 +46,12 @@ function SetSeq(int seqnum)
     if( MoveTime/2 < Level.TimeSeconds-lastTime )
         oldSeq = true;
 
+    dist = VSize(BasePos + KeyPos[seqnum] - Location);
+
+    if (KeyPos[0] == vect(0.0, 0.0, 0.0)) {
+        MoveTime = dist / GetMoveSpeed();
+    }
+
     if ( bIsMoving && !oldSeq )
         return;
 
@@ -33,7 +59,6 @@ function SetSeq(int seqnum)
     {
         prevKeyNum = KeyNum;
         KeyNum = seqnum;
-        dist = VSize(BasePos + KeyPos[seqnum] - Location);
 
         GotoState('ElevatorMover', 'Next');
 

--- a/DXRFixes/DeusEx/Classes/ElevatorMover.uc
+++ b/DXRFixes/DeusEx/Classes/ElevatorMover.uc
@@ -68,7 +68,7 @@ function SetSeq(int seqnum)
 
     Initialize();
 
-    if( MoveTime/2 < Level.TimeSeconds-lastTime )
+    if( MoveTime/10 < Level.TimeSeconds-lastTime )
         oldSeq = true;
 
     if ( bIsMoving && !oldSeq )


### PR DESCRIPTION
More specifically, the time it takes to move between stops is scaled by their distance. It seems that `InterpolateTo()` does an acceleration effect scaled by `MoveTime`, with the unfortunate result that elevators feel like they're faster when moving between very close stops. Still, I feel like this is overall a big improvement.

#938 