### PR TITLE
v3.2.0.1 Beta

### DIFF
--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -935,6 +935,28 @@ function ConEventAddGoal GetGoalConEvent(name goalName, name convname, optional 
     return GetGoalConEventStatic(goalName, GetConversation(convname), which);
 }
 
+// Creates or updates a goal with text taken from a Conversation
+function DeusExGoal AddGoalFromConv(#var(PlayerPawn) player, name goaltag, name convname, optional int which, optional bool replaceText)
+{
+    local DeusExGoal goal;
+    local ConEventAddGoal ceag;
+
+    ceag = GetGoalConEvent(goaltag, convname, which);
+    if (ceag == None)
+        return None;
+    goal = player.FindGoal(goaltag);
+
+    if (goal == None)
+        goal = player.AddGoal(goaltag, ceag.bPrimaryGoal);
+    else if (replaceText == false)
+        return goal;
+
+    goal.SetText(ceag.goalText);
+
+    return goal;
+}
+
+
 static function string GetActorName(Actor a)
 {
     local #var(PlayerPawn) player;
@@ -1786,21 +1808,4 @@ static function bool ChangeInitialAlliance(ScriptedPawn pawn, Name allianceName,
     pawn.InitialAlliances[i].bPermanent = bPermanent;
 
     return true;
-}
-
-function DeusExGoal AddGoalFromConv(#var(PlayerPawn) player, name goaltag, name convname, optional int which)
-{
-    local DeusExGoal goal;
-    local ConEventAddGoal ceag;
-
-    goal = player.FindGoal(goaltag);
-
-    if (goal == None) {
-        ceag = GetGoalConEvent(goaltag, convname, which);
-        if (ceag == None) return None;
-        goal = player.AddGoal(goaltag, ceag.bPrimaryGoal);
-        goal.SetText(ceag.goalText);
-    }
-
-    return goal;
 }

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -730,10 +730,7 @@ function bool HasConversation(Actor a) {
 }
 
 function bool HasBased(Actor a) {
-    local Actor b;
-    foreach a.BasedActors(class'Actor', b)
-        return true;
-    return false;
+    return a.StandingCount > 0;
 }
 
 function bool DestroyActor( Actor d )

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -320,13 +320,17 @@ static function Inventory GiveExistingItem(Pawn p, Inventory item, optional int 
     return item;
 }
 
-static function inventory GiveItem(Pawn p, class<Inventory> iclass, optional int add_ammo)
+static function inventory GiveItem(Pawn p, class<Inventory> iclass, optional int amount)
 {
     local inventory item;
 
     item = p.Spawn(iclass, p);
     if( item == None ) return None;
-    return GiveExistingItem(p, item, add_ammo);
+    if(DeusExPickup(item)!=None && amount > 0) {
+        DeusExPickup(item).NumCopies = amount;
+        amount = 0;
+    }
+    return GiveExistingItem(p, item, amount);
 }
 
 static function ThrowItem(Inventory item, float VelocityMult)

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -1733,8 +1733,8 @@ static function Actor GlowUp(Actor a, optional byte hue, optional byte saturatio
 function DebugMarkKeyActor(Actor a, coerce string id)
 {
     local ActorDisplayWindow actorDisplay;
-    if( ! #defined(debug)) {
-        err("Don't call DebugMarkKeyActor without debug mode! Add debug to the compiler_settings.default.json file");
+    if( ! #defined(locdebug)) {
+        err("Don't call DebugMarkKeyActor without locdebug mode! Add locdebug to the compiler_settings.default.json file");
         return;
     }
 
@@ -1759,8 +1759,8 @@ function DebugMarkKeyPosition(vector pos, coerce string id)
 {
     local ActorDisplayWindow actorDisplay;
     local Actor a;
-    if( ! #defined(debug)) {
-        err("Don't call DebugMarkKeyPosition without debug mode! Add debug to the compiler_settings.default.json file");
+    if( ! #defined(locdebug)) {
+        err("Don't call DebugMarkKeyPosition without locdebug mode! Add locdebug to the compiler_settings.default.json file");
         return;
     }
 

--- a/DXRCore/DeusEx/Classes/DXRBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRBase.uc
@@ -39,6 +39,11 @@ simulated function DXRando GetDXR()
     return dxr;
 }
 
+static function DXRBase Find()
+{
+    return class'DXRando'.default.dxr.FindModule(default.class);
+}
+
 simulated event PostNetBeginPlay()
 {
     Super.PostNetBeginPlay();

--- a/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -5,7 +5,7 @@ simulated static function CurrentVersion(optional out int major, optional out in
     major=3;
     minor=2;
     patch=0;
-    build=0;//build can't be higher than 99
+    build=1;//build can't be higher than 99
 }
 
 simulated static function bool VersionIsStable()
@@ -18,7 +18,7 @@ simulated static function string VersionString(optional bool full)
     local int major,minor,patch,build;
     local string status;
 
-    status = "Alpha";
+    status = "Beta";
 
     if(status!="") {
         status = " " $ status;

--- a/DXRCore/DeusEx/Classes/DXRandoTests.uc
+++ b/DXRCore/DeusEx/Classes/DXRandoTests.uc
@@ -31,7 +31,7 @@ function PostBeginPlay()
 
     SetTimer(0, false);
 
-    foreach AllActors(class'DXRando', dxr) { break; }
+    dxr = class'DXRando'.default.dxr;
 
     if( dxr.localURL != "12_VANDENBERG_TUNNELS" ) {
         dxr.Destroy();
@@ -52,7 +52,7 @@ function Timer()
 {
     local DXRando dxr;
 
-    foreach AllActors(class'DXRando', dxr) { break; }
+    dxr = class'DXRando'.default.dxr;
     if( dxr.bTickEnabled ) {
         log("waiting... dxr: " $ dxr $ ", dxr.bTickEnabled: " $ dxr.bTickEnabled );
         return;

--- a/DXRCore/DeusEx/Classes/DataStorage.uc
+++ b/DXRCore/DeusEx/Classes/DataStorage.uc
@@ -185,7 +185,7 @@ simulated function static DataStorage GetObjFromPlayer(Actor p)
     }
 #endif
 
-    foreach p.AllActors(class'DXRando', dxr) { break; }
+    dxr = class'DXRando'.default.dxr;
     if(dxr == None)
         return None;
 

--- a/DXRFixes/DeusEx/Classes/Animal.uc
+++ b/DXRFixes/DeusEx/Classes/Animal.uc
@@ -29,7 +29,7 @@ function EndPetting(optional bool bInterrupted)
 
         if (!bHasBeenPet && !bInterrupted){
             bHasBeenPet=True;
-            class'DXREvents'.static.MarkBingo(camera.dxr,"PetAnimal_"$Class.Name);
+            class'DXREvents'.static.MarkBingo("PetAnimal_"$Class.Name);
         }
         camera.player().bBlockAnimations=False;
         camera.player().AnimEnd(); //Kicks the appropriate normal animations off again

--- a/DXRFixes/DeusEx/Classes/ElevatorMover.uc
+++ b/DXRFixes/DeusEx/Classes/ElevatorMover.uc
@@ -1,7 +1,50 @@
 class ElevatorMover merges ElevatorMover;
 // can't do injects because it uses a state
 
-var float lastTime;
+var float lastTime, moveSpeed, originalMoveTime;
+var int numKeyPos;
+var bool initialized;
+
+function Initialize()
+{
+    local SequenceTrigger st;
+    local float dist, maxDist, avgDist, distSum;
+    local int validKeyPos[8];
+    local int i, j;
+
+    if (initialized) return;
+
+    // calculate numKeyPos and make a list of valid KeyPos indices
+    foreach AllActors(class'SequenceTrigger', st) {
+        if (st.event != tag) continue;
+
+        // check if st.seqnum is already in the list
+        for (i = 0; i < numKeyPos; i++) {
+            if (validKeyPos[i] == st.seqnum) {
+                break;
+            }
+        }
+        // if not, add it and increment numKeyPos
+        if (i == numKeyPos) {
+            validKeyPos[numKeyPos++] = st.seqnum;
+        }
+    }
+
+    // do calculations using only valid KeyPos elements
+    for (i = 0; i < numKeyPos; i++) {
+        for (j = i + 1; j < numKeyPos; j++) {
+            dist = VSize(KeyPos[validKeyPos[i]] - KeyPos[validKeyPos[j]]);
+            maxDist = FMax(maxDist, dist);
+            distSum += dist;
+        }
+    }
+
+    avgDist = distSum / (numKeyPos * (numKeyPos - 1) / 2.0);
+    moveSpeed = (maxDist*0.33 + avgDist*0.67) / MoveTime;
+    originalMoveTime = MoveTime;
+
+    initialized = true;
+}
 
 function bool EncroachingOn( actor Other )
 {
@@ -23,17 +66,23 @@ function SetSeq(int seqnum)
     local int prevKeyNum;
     local float dist;
 
-    if( MoveTime/2 < Level.TimeSeconds-lastTime )
+    Initialize();
+
+    if( MoveTime/10 < Level.TimeSeconds-lastTime )
         oldSeq = true;
 
     if ( bIsMoving && !oldSeq )
         return;
 
+    dist = VSize(BasePos + KeyPos[seqnum] - Location);
+
+    if (numKeyPos > 2)
+        MoveTime = FMax(dist / moveSpeed, originalMoveTime / 2.5);
+
     if (KeyNum != seqnum || oldSeq)
     {
         prevKeyNum = KeyNum;
         KeyNum = seqnum;
-        dist = VSize(BasePos + KeyPos[seqnum] - Location);
 
         GotoState('ElevatorMover', 'Next');
 

--- a/DXRFixes/DeusEx/Classes/POVCorpse.uc
+++ b/DXRFixes/DeusEx/Classes/POVCorpse.uc
@@ -14,7 +14,8 @@ function InitFor(DeusExCarcass carc)
     MaxDamage = carc.MaxDamage;
     CorpseItemName = carc.itemName;
     CarcassName = carc.CarcassName;
-    ZombieTime = class'DXRHalloween'.static.GetZombieTime(carc);
+    if(!bNotDead)
+        ZombieTime = class'DXRHalloween'.static.GetZombieTime(carc);
 }
 
 static function POVCorpse Create(DeusExPlayer player, DeusExCarcass carc)
@@ -65,7 +66,8 @@ function DeusExCarcass Drop(vector dropVect)
     carc.SetScaleGlow();
     if (carc.SetLocation(dropVect))
     {
-        class'DXRHalloween'.static.SetZombieTime(carc, ZombieTime);
+        if(!bNotDead)
+            class'DXRHalloween'.static.SetZombieTime(carc, ZombieTime);
         Destroy();
         return carc;
     }

--- a/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
+++ b/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
@@ -571,7 +571,7 @@ function EnableCheckDestLoc(bool bEnable)
     if( loopCounter > 10 ) {
         message = "EnableCheckDestLoc, bEnable: "$bEnable$", loopCounter: "$loopCounter$", destPoint: "$destPoint$", lastEnableCheckDestLocTime: "$lastEnableCheckDestLocTime;
         log(self$": WARNING: "$message);
-        foreach AllActors(class'DXRando', dxr) break;
+        dxr = class'DXRando'.default.dxr;
         if( dxr != None ) class'DXRTelemetry'.static.SendLog(dxr, Self, "WARNING", message);
 
         //calling the BackOff() function also works and makes them attempt to patrol again after, but I expect it would always just fail over and over

--- a/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
+++ b/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
@@ -209,8 +209,7 @@ function TakeDamageBase(int Damage, Pawn instigatedBy, Vector hitlocation, Vecto
     _TakeDamageBase(Damage,instigatedBy,hitLocation,momentum,baseDamageType,bPlayAnim);
 
     if (!wasOnFire && bOnFire && instigatedBy==GetPlayerPawn()){
-        h = Human(GetPlayerPawn());
-        class'DXREvents'.static.MarkBingo(h.dxr,"IgnitedPawn");
+        class'DXREvents'.static.MarkBingo("IgnitedPawn");
     }
 
     if (bBurnedToDeath) {
@@ -225,11 +224,8 @@ function TakeDamageBase(int Damage, Pawn instigatedBy, Vector hitlocation, Vecto
     }
 
     if ((Health < -100) && !IsA('Robot') && !IsA('Animal'))
-	{
-        if (h==None){
-            h = Human(GetPlayerPawn());
-            class'DXREvents'.static.MarkBingo(h.dxr,"GibbedPawn");
-        }
+    {
+        class'DXREvents'.static.MarkBingo("GibbedPawn");
     }
 }
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -28,10 +28,6 @@ function PostFirstEntryMapFixes()
             a = AddActor(class'Barrel1', vect(-27.953907, -3493.229980, 45.101418));
             Barrel1(a).SkinColor = SC_Explosive;
             a.BeginPlay();
-
-            if(dxr.flags.autosave==7 || dxr.flags.autosave==8) {// fixed saves needs a computer in M03 before helibase
-                AddActor(class'#var(prefix)ComputerPublic', vect(-1417.867065, -1937.349854, 446), rot(0,16384,0));
-            }
         }
         break;
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -28,6 +28,10 @@ function PostFirstEntryMapFixes()
             a = AddActor(class'Barrel1', vect(-27.953907, -3493.229980, 45.101418));
             Barrel1(a).SkinColor = SC_Explosive;
             a.BeginPlay();
+
+            if(dxr.flags.autosave==7 || dxr.flags.autosave==8) {// fixed saves needs a computer in M03 before helibase
+                AddActor(class'#var(prefix)ComputerPublic', vect(-1417.867065, -1937.349854, 446), rot(0,16384,0));
+            }
         }
         break;
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -282,16 +282,8 @@ function BalanceJailbreak()
     local DXRMissions missions;
     local string PaulLocation;
     local #var(prefix)DataLinkTrigger dlt;
-    local #var(prefix)AnnaNavarre anna;
 
     SetSeed("BalanceJailbreak");
-
-    if(dxr.flags.settings.starting_map > 50) {
-        foreach AllActors(class'#var(prefix)AnnaNavarre', anna) {
-            anna.Destroy();
-        }
-        return;
-    }
 
     // move the items instead of letting Mission05.uc do it
     // Revision also removes ammo and credits, and spawns special weapons from Paul if you saved him

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -158,15 +158,6 @@ function PreFirstEntryMapFixes()
                     break;
             }
         }
-
-        if (dxr.flags.settings.starting_map > 66) {
-            // set Tong to patrol his control room, which is his correct behavior after talking to him after he deactivates your killswitch
-            foreach AllActors(class'#var(prefix)OrdersTrigger', ot, 'TracerWanders') {
-                ot.Trigger(self, None);
-                break;
-            }
-        }
-
         break;
     case "06_HONGKONG_WANCHAI_MARKET":
         if (VanillaMaps) {

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -393,6 +393,15 @@ function PreFirstEntryMapFixes()
             }
         }
 
+        if (dxr.flagbase.GetBool('Meet_MJ12Lab_Supervisor_Played')) { // 70+ starts set this to true
+            foreach AllActors(class'#var(prefix)ScriptedPawn', p, 'Businessman1') {
+                if (p.BindName == "MJ12Lab_Supervisor") {
+                    p.SetOrders('Wandering');
+                    break;
+                }
+            }
+        }
+
         Spawn(class'PlaceholderItem',,, vectm(-1.95,1223.1,810.3)); //Table over entrance
         Spawn(class'PlaceholderItem',,, vectm(1022.24,-1344.15,450.3)); //Bathroom counter
         Spawn(class'PlaceholderItem',,, vectm(1519.6,-1251,442.3)); //Conference room side table

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
@@ -448,6 +448,11 @@ function PreFirstEntryMapFixes_Page()
     local #var(prefix)ScriptedPawn sp;
     local vector cloneCubeLoc[4];
     local string cloneCubeText[4];
+    local AmbientSound as;
+    local DXRAmbientSoundTrigger ast;
+    local bool VanillaMaps;
+
+    VanillaMaps = class'DXRMapVariants'.static.IsVanillaMaps(player());
 
     // fix in-fighting
     foreach AllActors(class'#var(prefix)ScriptedPawn', sp) {
@@ -529,6 +534,17 @@ function PreFirstEntryMapFixes_Page()
         if (dlt.datalinkTag=='DL_Final_Helios06'){
             dlt.Tag='PasswordCall';
             break;
+        }
+    }
+
+    if (VanillaMaps) {
+        foreach AllActors(class'AmbientSound', as) {
+            if (as.AmbientSound == Sound'Ambient.Ambient.GeigerLoop') {
+                ast = class'DXRAmbientSoundTrigger'.static.ReplaceAmbientSound(as, 'Gray_rad');
+                ast.CopyValsToUntriggered(ast);
+                ast.UntriggeredSoundVolume /= 3;
+                break;
+            }
         }
     }
 }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
@@ -76,10 +76,6 @@ function PreFirstEntryMapFixes_Bunker()
     local #var(prefix)Fan1 fan;
     local #var(prefix)WaltonSimons ws;
 
-    if (dxr.flags.settings.starting_map < 151) {
-        player().DeleteAllGoals();
-    }
-
     // doors_lower is for backtracking
     AddSwitch( vect(4309.076660, -1230.640503, -7522.298340), rot(0, 16384, 0), 'doors_lower');
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -10,6 +10,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)TobyAtanwe toby;
     local #var(prefix)JaimeReyes j;
     local #var(prefix)DamageTrigger dt;
+    local #var(prefix)DataLinkTrigger dlt;
     local #var(prefix)ComputerSecurity cs;
     local #var(prefix)AutoTurret at;
     local #var(prefix)WIB wib;
@@ -23,6 +24,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)Teleporter tele;
     local Businesswoman1 bw;
     local #var(prefix)NicoletteDuclare nico;
+    local #var(prefix)NanoKey k;
 
     VanillaMaps = class'DXRMapVariants'.static.IsVanillaMaps(player());
 
@@ -125,6 +127,25 @@ function PreFirstEntryMapFixes()
             foreach AllActors(class'#var(prefix)JaimeReyes', j) {
                 RemoveFears(j);
             }
+
+            //Add a key for the media store
+            if(!dxr.flags.IsZeroRando()) {
+                //On the table in the cafe
+                k = Spawn(class'#var(prefix)NanoKey',,, vectm(-2020,1115,340));
+                k.KeyID = 'mediastore_door';
+                k.Description = "Media Store Door Key";
+                if(dxr.flags.settings.keysrando > 0)
+                    GlowUp(k);
+
+                //The media store datalinkTrigger is basically inside the door we want
+                foreach AllActors (class'#var(prefix)DataLinkTrigger',dlt){
+                    if (dlt.datalinkTag=='DL_mediastore') break;
+                }
+                m = DeusExMover(findNearestToActor(class'DeusExMover',dlt));
+                m.KeyIDNeeded='mediastore_door';
+            }
+
+
 
             // make the apartment stairs less hidden, not safe to have stairs without a light!
             CandleabraLight(vect(1825.758057, 1481.900024, 576.077698), rot(0, 16384, 0));

--- a/DXRMissions/DeusEx/Classes/DXRMissionsParis.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsParis.uc
@@ -291,6 +291,7 @@ function AfterMoveGoalToLocation(Goal g, GoalLocation Loc)
     local DXRPasswords passwords;
     local #var(prefix)NanoKey key;
     local string guestName;
+    local DynamicLight dl;
     local bool VanillaMaps;
 
     VanillaMaps = class'DXRMapVariants'.static.IsVanillaMaps(player());
@@ -327,6 +328,15 @@ function AfterMoveGoalToLocation(Goal g, GoalLocation Loc)
         passwords = DXRPasswords(dxr.FindModule(class'DXRPasswords'));
         if(passwords != None && guestName != "") {
             passwords.ReplacePassword("   Room 1 is currently unoccupied", "  Guest: "$guestName);
+        }
+    }
+
+    if (Loc.name=="Media Store"){
+        if ((g.name=="Nicolette") || (g.name=="Jaime" && dxr.flagbase.GetBool('JaimeLeftBehind'))){
+            //Spawn a small spotlight just to make it a bit easier to spot them through the window
+            dl = Spawn(class'DynamicLight',,,vectm(1025,1768,200));
+            dl.LightRadius=3;
+            dl.LightBrightness=100;
         }
     }
 

--- a/DXRModules/DeusEx/Classes/DXRAutosave.uc
+++ b/DXRModules/DeusEx/Classes/DXRAutosave.uc
@@ -51,6 +51,8 @@ function PreFirstEntry()
             NeedSave();
         }
     }
+
+    MapAdjustments();
 }
 
 function ReEntry(bool IsTravel)
@@ -322,4 +324,41 @@ function doAutosave()
     }
 
     info("doAutosave() completed, save_delay: "$save_delay);
+}
+
+simulated function PlayerLogin(#var(PlayerPawn) p)
+{
+    Super.PlayerLogin(p);
+
+    if(dxr.flags.autosave == FixedSaves || dxr.flags.autosave == LimitedSaves) { // Limited Saves
+        GiveItem(p, class'MemConUnit', 2);// start with 2?
+    }
+}
+
+function MapAdjustments()
+{
+    local Actor a;
+    local vector loc;
+    local bool fixed, limited;
+
+    fixed = dxr.flags.autosave==FixedSaves || dxr.flags.autosave==UnlimitedFixedSaves;
+    limited = dxr.flags.autosave == FixedSaves || dxr.flags.autosave == LimitedSaves;
+
+    switch(dxr.localURL) {
+    case "03_NYC_BrooklynBridgeStation":
+        // fixed saves needs a computer in M03 before helibase
+        if(fixed) {
+            AddActor(class'#var(prefix)ComputerPublic', vect(-1417.867065, -1937.349854, 446), rot(0,16384,0));
+        }
+        break;
+    }
+
+    if(limited) {
+        SetSeed("spawn MCU");
+        if(chance_single(80)) {
+            loc = GetRandomPositionFine();
+            a = Spawn(class'MemConUnit',,, loc);
+            l("MapAdjustments() spawned MCU " $ a $ " at " $ loc);
+        }
+    }
 }

--- a/DXRModules/DeusEx/Classes/DXRDatacubes.uc
+++ b/DXRModules/DeusEx/Classes/DXRDatacubes.uc
@@ -642,8 +642,8 @@ function _RandoInfoDev(#var(injectsprefix)InformationDevices id, bool containers
             bads++;
             continue;
         }
-#ifdef debug
-        if(id.textTag == '03_Datacube10') DebugMarkKeyPosition(inv.Location, id.textTag);
+#ifdef locdebug
+        if(id.textTag == '#var(locdebug)') DebugMarkKeyPosition(inv.Location, id.textTag);
 #endif
         temp[num++] = inv;
     }
@@ -657,7 +657,7 @@ function _RandoInfoDev(#var(injectsprefix)InformationDevices id, bool containers
                 continue;
             }
             if( HasBased(c) ) continue;
-#ifdef debug
+#ifdef locdebug
             DebugMarkKeyPosition(c.Location, id.textTag);
 #endif
             temp[num++] = c;

--- a/DXRModules/DeusEx/Classes/DXRDatacubes.uc
+++ b/DXRModules/DeusEx/Classes/DXRDatacubes.uc
@@ -658,7 +658,7 @@ function _RandoInfoDev(#var(injectsprefix)InformationDevices id, bool containers
             }
             if( HasBased(c) ) continue;
 #ifdef locdebug
-            DebugMarkKeyPosition(c.Location, id.textTag);
+            if(id.textTag == '#var(locdebug)') DebugMarkKeyPosition(c.Location, id.textTag);
 #endif
             temp[num++] = c;
         }

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -631,7 +631,7 @@ function SetWatchFlags() {
     case "04_NYC_UNATCOISLAND":
         bt = class'BingoTrigger'.static.Create(self,'CommsPit',vectm(-6385.640625,1441.881470,-247.901276),40,40);
         if (dxr.flagbase.GetBool('M03PlayerKilledAnna')) {
-            class'DXREventsBase'.static.MarkBingo(dxr, "LebedevLived");
+            MarkBingo(dxr, "LebedevLived");
         }
         break;
     case "05_NYC_UNATCOMJ12LAB":
@@ -888,7 +888,7 @@ function SetWatchFlags() {
         bt.bingoEvent="MadeBasket";
         WatchFlag('StantonAmbushDefeated');
         WatchFlag('GreenKnowsAboutDowd');
-        class'DXREventsBase'.static.MarkBingo(dxr, "MaggieLived");
+        MarkBingo(dxr, "MaggieLived");
         break;
     case "08_NYC_SMUG":
         WatchFlag('M08WarnedSmuggler');
@@ -1049,7 +1049,7 @@ function SetWatchFlags() {
                 wib.bImportant = true;
         }
         WatchFlag('SilhouetteHostagesAllRescued');
-        class'DXREventsBase'.static.MarkBingo(dxr, "AimeeLeMerchantLived");
+        MarkBingo(dxr, "AimeeLeMerchantLived");
         break;
     case "10_PARIS_METRO":
         WatchFlag('M10EnteredBakery');
@@ -1506,7 +1506,7 @@ function bool FailIfCorpseNotHeld(class<#var(DeusExPrefix)Carcass> carcClass, st
 
     p = player();
     if (POVCorpse(p.inHand) == None || string(carcClass) != POVCorpse(p.inHand).carcClassString) {
-        class'DXREventsBase'.static.MarkBingoAsFailed(dxr, goal);
+        MarkBingoAsFailed(goal);
         return true;
     }
     return false;
@@ -1531,11 +1531,11 @@ function MarkBingoFailedSpecial()
         // the last Terrorist left is Miguel
         progress = data.GetBingoProgress("Terrorist_ClassDead", maxProgress);
         if (maxProgress - progress > 1) {
-            class'DXREventsBase'.static.MarkBingoAsFailed(dxr, "Terrorist_ClassDead");
+            MarkBingoAsFailed("Terrorist_ClassDead");
         }
         progress = data.GetBingoProgress("Terrorist_ClassUnconscious", maxProgress);
         if (maxProgress - progress > 1) {
-            class'DXREventsBase'.static.MarkBingoAsFailed(dxr, "Terrorist_ClassUnconscious");
+            MarkBingoAsFailed("Terrorist_ClassUnconscious");
         }
 
         break;
@@ -1554,9 +1554,9 @@ function MarkBingoFailedSpecial()
     case "09_NYC_GRAVEYARD":
         FailIfCorpseNotHeld(class'#var(prefix)TerroristCommanderCarcass', "LeoToTheBar");
         if (! HasItem(player(), class'VialAmbrosia')) {
-            class'DXREventsBase'.static.MarkBingoAsFailed(dxr, "GaveDowdAmbrosia");
+            MarkBingoAsFailed("GaveDowdAmbrosia");
         }
-        class'DXREventsBase'.static.MarkBingoAsFailed(dxr, "ChangeClothes");
+        MarkBingoAsFailed("ChangeClothes");
         break;
     case "10_PARIS_CATACOMBS":
     case "11_PARIS_EVERETT":
@@ -1568,8 +1568,8 @@ function MarkBingoFailedSpecial()
     switch (dxr.dxInfo.missionNumber) {
     case 6:
         if (dxr.flagbase.GetBool('Have_ROM')) {
-            class'DXREventsBase'.static.MarkBingoAsFailed(dxr, "MarketKid_Dead");
-            class'DXREventsBase'.static.MarkBingoAsFailed(dxr, "MarketKid_BindNameUnconscious");
+            MarkBingoAsFailed("MarketKid_Dead");
+            MarkBingoAsFailed("MarketKid_BindNameUnconscious");
         }
         break;
     }
@@ -2104,7 +2104,7 @@ function string RemapBingoEvent(string eventname)
 
 }
 
-static function int GetBingoFailedEvents(DXRando dxr, string eventname, out string failed[5])
+static function int GetBingoFailedEvents(string eventname, out string failed[5])
 {
     local int num_failed;
 
@@ -2177,7 +2177,7 @@ static function int GetBingoFailedEvents(DXRando dxr, string eventname, out stri
             failed[num_failed++] = "FamilySquabbleWrapUpGilbertDead_Played";
             return num_failed;
         case "GilbertRenton_Dead":
-            if (dxr.localURL != "04_NYC_HOTEL") {
+            if (class'DXRando'.default.dxr.localURL != "04_NYC_HOTEL") {
                 failed[num_failed++] = "FamilySquabbleWrapUpGilbertDead_Played";
             }
             failed[num_failed++] = "GaveRentonGun";

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -335,15 +335,12 @@ function SetWatchFlags() {
         WatchFlag('Shannon_Dead');
         if(RevisionMaps){
             bt = class'BingoTrigger'.static.Create(self,'AlexCloset',vectm(1725,-1062,-40),95,40);
-            bt = class'BingoTrigger'.static.Create(self,'BathroomFlags',vectm(1130,-150,310),80,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)FlagPole');
+            class'BingoTrigger'.static.ProxCreate(self,'BathroomFlags',vectm(1130,-150,310),80,40,class'#var(prefix)FlagPole');
         } else {
             bt = class'BingoTrigger'.static.Create(self,'AlexCloset',vectm(1551.508301,-820.408875,-39.901726),95,40);
-            bt = class'BingoTrigger'.static.Create(self,'BathroomFlags',vectm(240.180969,-385.104431,280.098511),80,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)FlagPole');
+            class'BingoTrigger'.static.ProxCreate(self,'BathroomFlags',vectm(240.180969,-385.104431,280.098511),80,40,class'#var(prefix)FlagPole');
 
-            bt = class'BingoTrigger'.static.Create(self,'un_bboard_peepedtex',vectm(497,1660,317.7),80,40);
-            bt.MakePeepable();
+            class'BingoTrigger'.static.PeepCreate(self,'un_bboard_peepedtex',vectm(497,1660,317.7),80,40);
         }
 
         foreach AllActors(class'#var(prefix)Female2',f) {
@@ -402,9 +399,7 @@ function SetWatchFlags() {
         break;
     case "02_NYC_UNDERGROUND":
         WatchFlag('FordSchickRescued');
-
-        bt = class'BingoTrigger'.static.Create(self,'SewerSurfin',vectm(-50,-125,-1000),750,40);
-        bt.MakeClassProximityTrigger(class'#var(prefix)JoeGreeneCarcass');
+        class'BingoTrigger'.static.ProxCreate(self,'SewerSurfin',vectm(-50,-125,-1000),750,40,class'#var(prefix)JoeGreeneCarcass');
         break;
     case "02_NYC_BAR":
         WatchFlag('JockSecondStory');
@@ -469,15 +464,12 @@ function SetWatchFlags() {
         WatchFlag('MeetInjuredTrooper2_Played');
         if(RevisionMaps){
             bt = class'BingoTrigger'.static.Create(self,'AlexCloset',vectm(1725,-1062,-40),95,40);
-            bt = class'BingoTrigger'.static.Create(self,'BathroomFlags',vectm(1130,-150,310),80,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)FlagPole');
+            class'BingoTrigger'.static.ProxCreate(self,'BathroomFlags',vectm(1130,-150,310),80,40,class'#var(prefix)FlagPole');
         } else {
             bt = class'BingoTrigger'.static.Create(self,'AlexCloset',vectm(1551.508301,-820.408875,-39.901726),95,40);
-            bt = class'BingoTrigger'.static.Create(self,'BathroomFlags',vectm(240.180969,-385.104431,280.098511),80,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)FlagPole');
+            class'BingoTrigger'.static.ProxCreate(self,'BathroomFlags',vectm(240.180969,-385.104431,280.098511),80,40,class'#var(prefix)FlagPole');
 
-            bt = class'BingoTrigger'.static.Create(self,'un_bboard_peepedtex',vectm(497,1660,317.7),80,40);
-            bt.MakePeepable();
+            class'BingoTrigger'.static.PeepCreate(self,'un_bboard_peepedtex',vectm(497,1660,317.7),80,40);
         }
 
         foreach AllActors(class'#var(prefix)Female2',f) {
@@ -560,8 +552,7 @@ function SetWatchFlags() {
         bt = class'BingoTrigger'.static.Create(self,'TonThirdFloor',vectm(-630,-1955,424),150,40);
         break;
     case "04_NYC_UNDERGROUND":
-        bt = class'BingoTrigger'.static.Create(self,'SewerSurfin',vectm(-50,-125,-1000),750,40);
-        bt.MakeClassProximityTrigger(class'#var(prefix)JoeGreeneCarcass');
+        class'BingoTrigger'.static.ProxCreate(self,'SewerSurfin',vectm(-50,-125,-1000),750,40,class'#var(prefix)JoeGreeneCarcass');
         break;
     case "05_NYC_UNATCOISLAND":
         bt = class'BingoTrigger'.static.Create(self,'nsfwander',vectm(0,0,0));
@@ -598,20 +589,15 @@ function SetWatchFlags() {
         WatchFlag('Shannon_Dead');
         WatchFlag('M04MeetWalton_Played');
         if(RevisionMaps){
-            bt = class'BingoTrigger'.static.Create(self,'AlexCloset',vectm(1725,-1062,-40),95,40);
-            bt = class'BingoTrigger'.static.Create(self,'BathroomFlags',vectm(1130,-150,310),80,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)FlagPole');
-            bt = class'BingoTrigger'.static.Create(self,'PresentForManderley',vectm(960,234,297),350,60);
-            bt.MakeClassProximityTrigger(class'#var(prefix)JuanLebedevCarcass');
+            class'BingoTrigger'.static.Create(self,'AlexCloset',vectm(1725,-1062,-40),95,40);
+            class'BingoTrigger'.static.ProxCreate(self,'BathroomFlags',vectm(1130,-150,310),80,40,class'#var(prefix)FlagPole');
+            class'BingoTrigger'.static.ProxCreate(self,'PresentForManderley',vectm(960,234,297),350,60,class'#var(prefix)JuanLebedevCarcass');
         } else {
-            bt = class'BingoTrigger'.static.Create(self,'AlexCloset',vectm(1551.508301,-820.408875,-39.901726),95,40);
-            bt = class'BingoTrigger'.static.Create(self,'BathroomFlags',vectm(240.180969,-385.104431,280.098511),80,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)FlagPole');
-            bt = class'BingoTrigger'.static.Create(self,'PresentForManderley',vectm(220,4,280),300,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)JuanLebedevCarcass');
+            class'BingoTrigger'.static.Create(self,'AlexCloset',vectm(1551.508301,-820.408875,-39.901726),95,40);
+            class'BingoTrigger'.static.ProxCreate(self,'BathroomFlags',vectm(240.180969,-385.104431,280.098511),80,40,class'#var(prefix)FlagPole');
+            class'BingoTrigger'.static.ProxCreate(self,'PresentForManderley',vectm(220,4,280),300,40,class'#var(prefix)JuanLebedevCarcass');
 
-            bt = class'BingoTrigger'.static.Create(self,'un_bboard_peepedtex',vectm(497,1660,317.7),80,40);
-            bt.MakePeepable();
+            class'BingoTrigger'.static.PeepCreate(self,'un_bboard_peepedtex',vectm(497,1660,317.7),80,40);
         }
 
         foreach AllActors(class'#var(prefix)Female2',f) {
@@ -677,16 +663,13 @@ function SetWatchFlags() {
         bt = class'BingoTrigger'.static.Create(self,'BrowserHistoryCleared',cp.Location);
 
         if(RevisionMaps){
-            bt = class'BingoTrigger'.static.Create(self,'AlexCloset',vectm(1725,-1062,-40),95,40);
-            bt = class'BingoTrigger'.static.Create(self,'BathroomFlags',vectm(1130,-150,310),80,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)FlagPole');
+            class'BingoTrigger'.static.Create(self,'AlexCloset',vectm(1725,-1062,-40),95,40);
+            class'BingoTrigger'.static.ProxCreate(self,'BathroomFlags',vectm(1130,-150,310),80,40,class'#var(prefix)FlagPole');
         } else {
-            bt = class'BingoTrigger'.static.Create(self,'AlexCloset',vectm(1551.508301,-820.408875,-39.901726),95,40);
-            bt = class'BingoTrigger'.static.Create(self,'BathroomFlags',vectm(240.180969,-385.104431,280.098511),80,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)FlagPole');
+            class'BingoTrigger'.static.Create(self,'AlexCloset',vectm(1551.508301,-820.408875,-39.901726),95,40);
+            class'BingoTrigger'.static.ProxCreate(self,'BathroomFlags',vectm(240.180969,-385.104431,280.098511),80,40,class'#var(prefix)FlagPole');
 
-            bt = class'BingoTrigger'.static.Create(self,'un_bboard_peepedtex',vectm(497,1660,317.7),80,40);
-            bt.MakePeepable();
+            class'BingoTrigger'.static.PeepCreate(self,'un_bboard_peepedtex',vectm(497,1660,317.7),80,40);
         }
 
         foreach AllActors(class'#var(prefix)Female2',f) {
@@ -788,10 +771,9 @@ function SetWatchFlags() {
             maid.BarkBindName = "MaySung";
         }
 
-        bt = class'BingoTrigger'.static.Create(self,'TonnochiBillboard',vectm(0,550,870),300,40);
+        class'BingoTrigger'.static.Create(self,'TonnochiBillboard',vectm(0,550,870),300,40);
 
-        bt = class'BingoTrigger'.static.Create(self,'MaggieCanFly',vectm(-30,-1950,1400),600,40);
-        bt.MakeClassProximityTrigger(class'#var(prefix)MaggieChowCarcass');
+        class'BingoTrigger'.static.ProxCreate(self,'MaggieCanFly',vectm(-30,-1950,1400),600,40,class'#var(prefix)MaggieChowCarcass');
 
         break;
     case "06_HONGKONG_WANCHAI_MARKET":
@@ -837,14 +819,9 @@ function SetWatchFlags() {
         bt = class'BingoTrigger'.static.Create(self,'TongsHotTub',water.Location);
 
         //Need to make sure these are slightly out of the wall so that explosions hit them
-        bt = class'BingoTrigger'.static.Create(self,'TongTargets',vectm(-596.3,1826,40),40,100);
-        bt.MakeShootingTarget();
-
-        bt = class'BingoTrigger'.static.Create(self,'TongTargets',vectm(-466.5,1826,40),40,100);
-        bt.MakeShootingTarget();
-
-        bt = class'BingoTrigger'.static.Create(self,'TongTargets',vectm(-337.2,1826,40),40,100);
-        bt.MakeShootingTarget();
+        class'BingoTrigger'.static.ShootCreate(self,'TongTargets',vectm(-596.3,1826,40),40,100);
+        class'BingoTrigger'.static.ShootCreate(self,'TongTargets',vectm(-466.5,1826,40),40,100);
+        class'BingoTrigger'.static.ShootCreate(self,'TongTargets',vectm(-337.2,1826,40),40,100);
 
         WatchFlag('PaulToTong');
 
@@ -857,9 +834,7 @@ function SetWatchFlags() {
                 break;
             }
         }
-        bt = class'BingoTrigger'.static.Create(self,'HongKongBBall',trig.Location,14,3);
-        bt.MakeClassProximityTrigger(class'#var(prefix)Basketball');
-
+        class'BingoTrigger'.static.ProxCreate(self,'HongKongBBall',trig.Location,14,3,class'#var(prefix)Basketball');
         break;
     case "06_HONGKONG_MJ12LAB":
         foreach AllActors(class'ZoneInfo',zone){
@@ -908,13 +883,12 @@ function SetWatchFlags() {
         InitPoolBalls();
         break;
     case "08_NYC_HOTEL":
-        bt = class'BingoTrigger'.static.Create(self,'TonThirdFloor',vectm(-630,-1955,424),150,40);
+        class'BingoTrigger'.static.Create(self,'TonThirdFloor',vectm(-630,-1955,424),150,40);
         WatchFlag('GreenKnowsAboutDowd');
         break;
     case "08_NYC_UNDERGROUND":
         WatchFlag('GreenKnowsAboutDowd');
-        bt = class'BingoTrigger'.static.Create(self,'SewerSurfin',vectm(-50,-125,-1000),750,40);
-        bt.MakeClassProximityTrigger(class'#var(prefix)JoeGreeneCarcass');
+        class'BingoTrigger'.static.ProxCreate(self,'SewerSurfin',vectm(-50,-125,-1000),750,40,class'#var(prefix)JoeGreeneCarcass');
         break;
     case "08_NYC_FREECLINIC":
         WatchFlag('GreenKnowsAboutDowd');
@@ -1064,13 +1038,10 @@ function SetWatchFlags() {
             starr.BindName = "Starr";
         }
         if(RevisionMaps){
-            bt = class'BingoTrigger'.static.Create(self,'Cremation',vectm(217,-5306,328),50,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)ChefCarcass');
+            class'BingoTrigger'.static.ProxCreate(self,'Cremation',vectm(217,-5306,328),50,40,class'#var(prefix)ChefCarcass');
         } else {
-            bt = class'BingoTrigger'.static.Create(self,'Cremation',vectm(-2983.597168,774.217407,312.100128),70,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)ChefCarcass');
-            bt = class'BingoTrigger'.static.Create(self,'Cremation',vectm(-2984.404785,662.764954,312.100128),70,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)ChefCarcass');
+            class'BingoTrigger'.static.ProxCreate(self,'Cremation',vectm(-2983.597168,774.217407,312.100128),70,40,class'#var(prefix)ChefCarcass');
+            class'BingoTrigger'.static.ProxCreate(self,'Cremation',vectm(-2984.404785,662.764954,312.100128),70,40,class'#var(prefix)ChefCarcass');
         }
 
         // SoldRenaultZyme
@@ -1139,23 +1110,16 @@ function SetWatchFlags() {
         WatchFlag('M11WaltonHolo_Played');
 
         if (RevisionMaps){
-            bt = class'BingoTrigger'.static.Create(self,'CathedralUnderwater',vectm(2614,-2103,-120),500,180);
-            bt = class'BingoTrigger'.static.Create(self,'Cremation',vectm(3811,-3200,-64),20,15);
-            bt.MakeClassProximityTrigger(class'#var(prefix)ChefCarcass');
-            bt = class'BingoTrigger'.static.Create(self,'Cremation',vectm(3869,-4256,-64),20,15);
-            bt.MakeClassProximityTrigger(class'#var(prefix)ChefCarcass');
-            bt = class'BingoTrigger'.static.Create(self,'Cremation',vectm(3387,-3233,-7.9),50,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)ChefCarcass');
-            bt = class'BingoTrigger'.static.Create(self,'Cremation',vectm(4100,-3469,-6.9),50,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)ChefCarcass');
+            class'BingoTrigger'.static.Create(self,'CathedralUnderwater',vectm(2614,-2103,-120),500,180);
+            class'BingoTrigger'.static.ProxCreate(self,'Cremation',vectm(3811,-3200,-64),20,15,class'#var(prefix)ChefCarcass');
+            class'BingoTrigger'.static.ProxCreate(self,'Cremation',vectm(3869,-4256,-64),20,15,class'#var(prefix)ChefCarcass');
+            class'BingoTrigger'.static.ProxCreate(self,'Cremation',vectm(3387,-3233,-7.9),50,40,class'#var(prefix)ChefCarcass');
+            class'BingoTrigger'.static.ProxCreate(self,'Cremation',vectm(4100,-3469,-6.9),50,40,class'#var(prefix)ChefCarcass');
         } else {
-            bt = class'BingoTrigger'.static.Create(self,'CathedralUnderwater',vectm(771,-808,-706),500,180);
-            bt = class'BingoTrigger'.static.Create(self,'Cremation',vectm(2019,-2256,-704),20,15);
-            bt.MakeClassProximityTrigger(class'#var(prefix)ChefCarcass');
-            bt = class'BingoTrigger'.static.Create(self,'Cremation',vectm(2076.885254,-3248.189941,-704.369995),20,15);
-            bt.MakeClassProximityTrigger(class'#var(prefix)ChefCarcass');
-            bt = class'BingoTrigger'.static.Create(self,'Cremation',vectm(1578,-2286,-647),50,40);
-            bt.MakeClassProximityTrigger(class'#var(prefix)ChefCarcass');
+            class'BingoTrigger'.static.Create(self,'CathedralUnderwater',vectm(771,-808,-706),500,180);
+            class'BingoTrigger'.static.ProxCreate(self,'Cremation',vectm(2019,-2256,-704),20,15,class'#var(prefix)ChefCarcass');
+            class'BingoTrigger'.static.ProxCreate(self,'Cremation',vectm(2076.885254,-3248.189941,-704.369995),20,15,class'#var(prefix)ChefCarcass');
+            class'BingoTrigger'.static.ProxCreate(self,'Cremation',vectm(1578,-2286,-647),50,40,class'#var(prefix)ChefCarcass');
         }
         bt = class'BingoTrigger'.static.Create(self,'secretdoor01',vectm(0,0,0));
 
@@ -1234,16 +1198,13 @@ function SetWatchFlags() {
 
         bt = class'BingoTrigger'.static.Create(self,'VandenbergWaterTower',vectm(-1030,80,-1600),350,40);
 
-        bt = class'BingoTrigger'.static.Create(self,'CliffSacrifice',vectm(1915,2795,-3900),10000,40);
-        bt.MakeClassProximityTrigger(class'#var(DeusExPrefix)Carcass');
+        class'BingoTrigger'.static.ProxCreate(self,'CliffSacrifice',vectm(1915,2795,-3900),10000,40,class'#var(DeusExPrefix)Carcass');
 
-        bt = class'BingoTrigger'.static.Create(self,'CliffSacrifice',vectm(-190,-1350,-2760),8000,40);
-        bt.MakeClassProximityTrigger(class'#var(DeusExPrefix)Carcass');
+        class'BingoTrigger'.static.ProxCreate(self,'CliffSacrifice',vectm(-190,-1350,-2760),8000,40,class'#var(DeusExPrefix)Carcass');
 
         bt = class'BingoTrigger'.static.Create(self,'VandenbergShaft',vectm(1442.694580,1303.784180,-1755),110,10);
 
-        bt = class'BingoTrigger'.static.Create(self,'VandenbergAntenna',vectm(1800,2590,344.44),40,60);
-        bt.MakeShootingTarget();
+        class'BingoTrigger'.static.ShootCreate(self,'VandenbergAntenna',vectm(1800,2590,344.44),40,60);
 
         bt = class'BingoTrigger'.static.Create(self,'VandenbergHazLab',vectm(0,0,0));
         bt.bUntrigger=True;
@@ -1332,15 +1293,9 @@ function SetWatchFlags() {
         //Same location in Revision and Vanilla
         bt = class'BingoTrigger'.static.Create(self,'OceanLabShed',vectm(618.923523,4063.243896,-391.901031),160,40);
 
-        bt = class'BingoTrigger'.static.Create(self,'SubBaseSatellite',vectm(2717.3,3874.84,1342),100,100);
-        bt.MakeShootingTarget();
-
-        bt = class'BingoTrigger'.static.Create(self,'SubBaseSatellite',vectm(2817,3771,1571),100,100);
-        bt.MakeShootingTarget();
-
-        bt = class'BingoTrigger'.static.Create(self,'SubBaseSatellite',vectm(2817,3965,1839),100,100);
-        bt.MakeShootingTarget();
-
+        class'BingoTrigger'.static.ShootCreate(self,'SubBaseSatellite',vectm(2717.3,3874.84,1342),100,100);
+        class'BingoTrigger'.static.ShootCreate(self,'SubBaseSatellite',vectm(2817,3771,1571),100,100);
+        class'BingoTrigger'.static.ShootCreate(self,'SubBaseSatellite',vectm(2817,3965,1839),100,100);
         break;
     case "15_AREA51_BUNKER":
         WatchFlag('JockBlewUp');

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -1653,7 +1653,7 @@ simulated function string tweakBingoDescription(string event, string desc)
 {
     local DXRando dxr;
 
-    foreach AllActors(class'DXRando', dxr) {break;}
+    dxr = class'DXRando'.default.dxr;
 
     switch(event){
         //FemJC gets a male character instead.  Russ normally, Noah in Revision

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -631,7 +631,7 @@ function SetWatchFlags() {
     case "04_NYC_UNATCOISLAND":
         bt = class'BingoTrigger'.static.Create(self,'CommsPit',vectm(-6385.640625,1441.881470,-247.901276),40,40);
         if (dxr.flagbase.GetBool('M03PlayerKilledAnna')) {
-            MarkBingo(dxr, "LebedevLived");
+            MarkBingo("LebedevLived");
         }
         break;
     case "05_NYC_UNATCOMJ12LAB":
@@ -888,7 +888,7 @@ function SetWatchFlags() {
         bt.bingoEvent="MadeBasket";
         WatchFlag('StantonAmbushDefeated');
         WatchFlag('GreenKnowsAboutDowd');
-        MarkBingo(dxr, "MaggieLived");
+        MarkBingo("MaggieLived");
         break;
     case "08_NYC_SMUG":
         WatchFlag('M08WarnedSmuggler');
@@ -1049,7 +1049,7 @@ function SetWatchFlags() {
                 wib.bImportant = true;
         }
         WatchFlag('SilhouetteHostagesAllRescued');
-        MarkBingo(dxr, "AimeeLeMerchantLived");
+        MarkBingo("AimeeLeMerchantLived");
         break;
     case "10_PARIS_METRO":
         WatchFlag('M10EnteredBakery');

--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -744,7 +744,7 @@ static function AddDeath(Pawn victim, optional Actor Killer, optional coerce str
     player = #var(PlayerPawn)(victim);
     sp = #var(prefix)ScriptedPawn(victim);
     if(player != None) {
-        foreach victim.AllActors(class'DXRando', dxr) break;
+        dxr = class'DXRando'.default.dxr;
         AddPlayerDeath(dxr, player, Killer, damageType, HitLocation);
     }
     else if(sp != None)

--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -766,7 +766,7 @@ static function PaulDied(DXRando dxr)
     js.static.End(j);
     dxr.flagbase.SetBool('DXREvents_PaulDead', true,, 999);
     class'DXRTelemetry'.static.SendEvent(dxr, dxr.player, j);
-    MarkBingo(dxr, "PaulDenton_Dead");
+    MarkBingo("PaulDenton_Dead");
 }
 
 static function SavedPaul(DXRando dxr, #var(PlayerPawn) player, optional int health)
@@ -782,7 +782,7 @@ static function SavedPaul(DXRando dxr, #var(PlayerPawn) player, optional int hea
     js.static.End(j);
 
     class'DXRTelemetry'.static.SendEvent(dxr, dxr.player, j);
-    MarkBingo(dxr, "SavedPaul");
+    MarkBingo("SavedPaul");
 }
 
 static function BeatGame(DXRando dxr, int ending)
@@ -846,7 +846,7 @@ static function ExtinguishFire(DXRando dxr, string extinguisher, DeusExPlayer pl
     js.static.End(j);
 
     class'DXRTelemetry'.static.SendEvent(dxr, player, j);
-    MarkBingo(dxr, "ExtinguishFire");
+    MarkBingo("ExtinguishFire");
 }
 
 static function GeneralEventData(DXRando dxr, out string j)
@@ -1322,11 +1322,11 @@ function _MarkBingo(coerce string eventname)
     }
 }
 
-static function MarkBingo(DXRando dxr, coerce string eventname)
+static function MarkBingo(coerce string eventname)
 {
     local DXREvents e;
-    e = DXREvents(dxr.FindModule(class'DXREvents'));
-    log(e$".MarkBingo "$dxr$", "$eventname);
+    e = DXREvents(Find());
+    log(e$".MarkBingo "$eventname);
     if(e != None) {
         e._MarkBingo(eventname);
     }

--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -36,7 +36,7 @@ simulated function bool WatchGuntherKillSwitch();
 function SetWatchFlags();
 
 // for goals that can be detected as impossible by an event
-static function int GetBingoFailedEvents(DXRando dxr, string eventname, out string failed[5]);
+static function int GetBingoFailedEvents(string eventname, out string failed[5]);
 // for goals that can not be detected as impossible by an event
 function MarkBingoFailedSpecial();
 
@@ -510,7 +510,7 @@ function SendFlagEvent(coerce string eventname, optional bool immediate, optiona
     }
 
     _MarkBingo(eventname);
-    MarkBingoFailedEvents(dxr, eventname);
+    MarkBingoFailedEvents(eventname);
 
     j = js.static.Start("Flag");
     js.static.Add(j, "flag", eventname);
@@ -594,7 +594,7 @@ static function AddPlayerDeath(DXRando dxr, #var(PlayerPawn) player, optional Ac
         class'DXRHints'.static.AddDeath(dxr, player);
     else {
         // for nonvanilla, because GameInfo.Died is called before the player's Dying state calls root.ClearWindowStack();
-        ev = DXREvents(dxr.FindModule(class'DXREvents'));
+        ev = DXREvents(Find());
         if(ev != None)
             ev.died = true;
     }
@@ -625,13 +625,10 @@ static function AddPlayerDeath(DXRando dxr, #var(PlayerPawn) player, optional Ac
 
 static function AddPawnDeath(ScriptedPawn victim, optional Actor Killer, optional coerce string damageType, optional vector HitLocation)
 {
-    local DXRando dxr;
     local DXREvents e;
-    foreach victim.AllActors(class'DXRando', dxr) break;
 
-    if(dxr != None)
-        e = DXREvents(dxr.FindModule(class'DXREvents'));
-    log(e$".AddPawnDeath "$dxr$", "$victim);
+    e = DXREvents(Find());
+    log(e$".AddPawnDeath, "$victim);
     if(e != None)
         e._AddPawnDeath(victim, Killer, damageType, HitLocation);
 }
@@ -719,7 +716,7 @@ function _AddPawnDeath(ScriptedPawn victim, optional Actor Killer, optional coer
     }
 
     // note that this treats both kills and knockouts the same
-    MarkBingoFailedEvents(dxr, victim.bindName $ "_Dead");
+    MarkBingoFailedEvents(victim.bindName $ "_Dead");
 
     if(!victim.bImportant)
         return;
@@ -1352,23 +1349,23 @@ function _MarkBingoAsFailed(coerce string eventname)
     }
 }
 
-static function MarkBingoAsFailed(DXRando dxr, coerce string eventname)
+static function MarkBingoAsFailed(coerce string eventname)
 {
     local DXREvents e;
-    e = DXREvents(dxr.FindModule(class'DXREvents'));
+    e = DXREvents(Find());
     if (e != None) {
         e._MarkBingoAsFailed(eventname);
     }
 }
 
-static function MarkBingoFailedEvents(DXRando dxr, coerce string eventname)
+static function MarkBingoFailedEvents(coerce string eventname)
 {
     local string failed[5];
     local int i, num_failed;
 
-    num_failed = GetBingoFailedEvents(dxr, eventname, failed);
+    num_failed = GetBingoFailedEvents(eventname, failed);
     for (i = 0; i < num_failed; i++) {
-        MarkBingoAsFailed(dxr, failed[i]);
+        MarkBingoAsFailed(failed[i]);
     }
 }
 

--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -833,10 +833,13 @@ static function BeatGame(DXRando dxr, int ending)
     class'DXRTelemetry'.static.SendEvent(dxr, dxr.player, j);
 }
 
-static function ExtinguishFire(DXRando dxr, string extinguisher, DeusExPlayer player)
+static function ExtinguishFire(string extinguisher, DeusExPlayer player)
 {
     local string j;
+    local DXRando dxr;
     local class<Json> js;
+
+    dxr = class'DXRando'.default.dxr;
     js = class'Json';
 
     j = js.static.Start("ExtinguishFire");

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -290,6 +290,7 @@ function FixFOV()
 
     // interpolate between 75 FOV and 120 FOV, multiply vanilla values by n and wide FOV values by w
     // wide values provided by Tundoori https://discord.com/channels/823629359931195394/823629360929046530/1282526555536625778
+    // X is distance from camera, Y is left/right, Z is up/down
 
     // POVCorpse
     v =  vect(20, 12, -5) * n;
@@ -402,10 +403,10 @@ function FixFOV()
 
     // WeaponNanoSword
     v =  vect(21, -16, -27) * n;
-    v += vect(13, -16, -27) * w;
+    v += vect(7, -16, -30) * w;
     class'WeaponNanoSword'.default.PlayerViewOffset = v;
     v =  vect(-21, 16, 27) * n;
-    v += vect(-13, 16, 27) * w;
+    v += vect(-7, 16, 30) * w;
     class'WeaponNanoSword'.default.FireOffset = v;
 
     // WeaponNanoVirusGrenade

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -284,11 +284,11 @@ function FixFOV()
     if(!#defined(vanilla)) return; // would need to check the defaults in other mods
 
     w = class'Human'.default.DefaultFOV;
-    w = (w - 75) / (110 - 75); // put it on a range of 0-1 for 75 to 110
+    w = (w - 75) / (120 - 75); // put it on a range of 0-1 for 75 to 120
     w = FClamp(w, 0, 1);
     n = 1-w;
 
-    // interpolate between 75 FOV and 110 FOV, multiply vanilla values by n and wide FOV values by w
+    // interpolate between 75 FOV and 120 FOV, multiply vanilla values by n and wide FOV values by w
     // wide values provided by Tundoori https://discord.com/channels/823629359931195394/823629360929046530/1282526555536625778
 
     // POVCorpse
@@ -322,10 +322,10 @@ function FixFOV()
 
     // WeaponAssaultShotgun
     v =  vect(30, -10, -12) * n;
-    v += vect(38, -10, -18) * w;
+    v += vect(17.5, -10, -18) * w;
     class'WeaponAssaultShotgun'.default.PlayerViewOffset = v;
     v =  vect(-30, 10, 12) * n;
-    v += vect(-38, 10, 18) * w;
+    v += vect(-17.5, 10, 18) * w;
     class'WeaponAssaultShotgun'.default.FireOffset = v;
 
     // WeaponBaton

--- a/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -760,7 +760,7 @@ function string GameModeName(int gamemode)
     case WaltonWarex3:
         return "WaltonWare x3";
     case HalloweenMode:
-        if(IsOctoberUnlocked()) return "Halloween Mode (Alpha)";// maybe needs a better name
+        if(IsOctoberUnlocked()) return "Halloween Mode";// maybe needs a better name
         break;
     }
     //EnumOption("Kill Bob Page (Alpha)", 3, f.gamemode);

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -1216,6 +1216,7 @@ function ExtendedTests()
     text = VersionString();
     testbool(VersionIsStable(), InStr(text, "Alpha")==-1 && InStr(text, "Beta")==-1, "VersionIsStable() matches version text, " $ text);
     testbool( #defined(debug), false, "debug is disabled");
+    testbool( #defined(locdebug), false, "locdebug is disabled");
 }
 
 function TestTime()

--- a/DXRModules/DeusEx/Classes/DXRFlagsNGPMaxRando.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsNGPMaxRando.uc
@@ -92,7 +92,7 @@ simulated function RandomizeSettings(bool forceMenuOptions)
     settings.enemiesshuffled = 100;
     MaxRandoVal(settings.enemies_nonhumans);
 
-    if(chance_single(33)) {
+    if(chance_single(33) && !DXRFlags(self).IsHalloweenMode()) { // this cast is pretty nasty
         settings.enemyrespawn = rng(120) + 120;
     } else {
         settings.enemyrespawn = 0;

--- a/DXRModules/DeusEx/Classes/DXRHalloween.uc
+++ b/DXRModules/DeusEx/Classes/DXRHalloween.uc
@@ -112,7 +112,7 @@ static function float GetZombieTime(#var(DeusExPrefix)Carcass carc)
 {
     local DXRHalloween h;
 
-    h = DXRHalloween(class'DXRando'.default.dxr.FindModule(class'DXRHalloween'));
+    h = DXRHalloween(Find());
     if(h == None) return carc.Level.TimeSeconds;
     return h._GetZombieTime(carc);
 }

--- a/DXRModules/DeusEx/Classes/DXRHalloween.uc
+++ b/DXRModules/DeusEx/Classes/DXRHalloween.uc
@@ -163,24 +163,6 @@ static function string GetPawnClassNameFromCarcass(DXRActorsBase module, class<#
 
     //For handling special cases that we're too lazy to make unique living classes for
     switch(carcClass){
-        case class'MJ12CloneAugShield1NametagCarcass':
-            return "MJ12CloneAugShield1";
-        case class'MJ12CloneAugStealth1NametagCarcass':
-            return "MJ12CloneAugStealth1";
-        case class'MJ12CloneAugTough1NametagCarcass':
-            return "MJ12CloneAugTough1";
-        case class'NSFCloneAugShield1NametagCarcass':
-            return "NSFCloneAugShield1";
-        case class'NSFCloneAugStealth1NametagCarcass':
-            return "NSFCloneAugStealth1";
-        case class'NSFCloneAugTough1NametagCarcass':
-            return "NSFCloneAugTough1";
-        case class'UNATCOCloneAugShield1NametagCarcass':
-            return "UNATCOCloneAugShield1";
-        case class'UNATCOCloneAugStealth1NametagCarcass':
-            return "UNATCOCloneAugStealth1";
-        case class'UNATCOCloneAugTough1NametagCarcass':
-            return "UNATCOCloneAugTough1";
 #ifdef hx
         case class'HXJCDentonCarcass':
 #else
@@ -192,6 +174,7 @@ static function string GetPawnClassNameFromCarcass(DXRActorsBase module, class<#
             //(We should probably strive for this to be the norm)
             //At least in vanilla, all carcasses are the original class name + Carcass
             livingClassName = string(carcClass);
+            livingClassName = module.ReplaceText(livingClassName,"NametagCarcass","");// for our Aug guys
             livingClassName = module.ReplaceText(livingClassName,"Carcass","");
             return livingClassName;
     }
@@ -205,7 +188,9 @@ static function bool ResurrectCorpse(DXRActorsBase module, #var(DeusExPrefix)Car
     local ScriptedPawn sp,otherSP;
     local int i;
     local Inventory item, nextItem;
+    #ifndef vmd
     local DXRFashionManager fashion;
+    #endif
     local bool removeItem;
     local string s;
 
@@ -291,12 +276,14 @@ static function bool ResurrectCorpse(DXRActorsBase module, #var(DeusExPrefix)Car
         }
     }
 
+    #ifndef vmd
     if(#var(prefix)JCDouble(sp)!=None || #var(prefix)PaulDenton(sp)!=None) {
         foreach sp.AllActors(class'DXRFashionManager', fashion) { break; }
         i = 0;
         if(#var(prefix)PaulDenton(sp)!=None) i = 1;
         if(fashion!=None) fashion.ApplyClothing(sp, i);
     }
+    #endif
 
     //Give the resurrected guy a zombie swipe (a guaranteed melee weapon)
     module.GiveItem(sp,class'WeaponZombieSwipe');

--- a/DXRModules/DeusEx/Classes/DXRHalloween.uc
+++ b/DXRModules/DeusEx/Classes/DXRHalloween.uc
@@ -181,6 +181,8 @@ static function string GetPawnClassNameFromCarcass(DXRActorsBase module, class<#
             return "UNATCOCloneAugStealth1";
         case class'UNATCOCloneAugTough1NametagCarcass':
             return "UNATCOCloneAugTough1";
+        case class'#var(prefix)JCDentonMaleCarcass':
+            return "JCDouble";
         default:
             //Standard carcass with a matching living class
             //(We should probably strive for this to be the norm)
@@ -199,6 +201,7 @@ static function bool ResurrectCorpse(DXRActorsBase module, #var(DeusExPrefix)Car
     local ScriptedPawn sp,otherSP;
     local int i;
     local Inventory item, nextItem;
+    local DXRFashionManager fashion;
     local bool removeItem;
     local string s;
 
@@ -282,6 +285,13 @@ static function bool ResurrectCorpse(DXRActorsBase module, #var(DeusExPrefix)Car
         else {
             sp.AddInventory(item);
         }
+    }
+
+    if(#var(prefix)JCDouble(sp)!=None || #var(prefix)PaulDenton(sp)!=None) {
+        foreach sp.AllActors(class'DXRFashionManager', fashion) { break; }
+        i = 0;
+        if(#var(prefix)PaulDenton(sp)!=None) i = 1;
+        if(fashion!=None) fashion.ApplyClothing(sp, i);
     }
 
     //Give the resurrected guy a zombie swipe (a guaranteed melee weapon)

--- a/DXRModules/DeusEx/Classes/DXRHalloween.uc
+++ b/DXRModules/DeusEx/Classes/DXRHalloween.uc
@@ -262,6 +262,11 @@ static function bool ResurrectCorpse(DXRActorsBase module, #var(DeusExPrefix)Car
     sp.ResetReactions();
     sp.bCanStrafe = false;// messes with melee attack animations, especially on commandos
 
+    if(sp.Intelligence==BRAINS_HUMAN) {
+        sp.Intelligence = BRAINS_MAMMAL;
+    }
+    sp.RaiseAlarm = RAISEALARM_Never;
+
     //Transfer inventory from carcass back to the pawn
     for(item = carc.Inventory; item != None; item = nextItem)
     {

--- a/DXRModules/DeusEx/Classes/DXRHalloween.uc
+++ b/DXRModules/DeusEx/Classes/DXRHalloween.uc
@@ -181,8 +181,12 @@ static function string GetPawnClassNameFromCarcass(DXRActorsBase module, class<#
             return "UNATCOCloneAugStealth1";
         case class'UNATCOCloneAugTough1NametagCarcass':
             return "UNATCOCloneAugTough1";
+#ifdef hx
+        case class'HXJCDentonCarcass':
+#else
         case class'#var(prefix)JCDentonMaleCarcass':
-            return "JCDouble";
+#endif
+            return "#var(prefix)JCDouble";
         default:
             //Standard carcass with a matching living class
             //(We should probably strive for this to be the norm)

--- a/DXRModules/DeusEx/Classes/DXRKeys.uc
+++ b/DXRModules/DeusEx/Classes/DXRKeys.uc
@@ -1000,7 +1000,11 @@ function _RandoKey(#var(prefix)NanoKey k, bool containers)
         return;
     }
     vanilla_good = KeyPositionGood(k, k.Location);
-
+#ifdef locdebug
+            if(k.KeyID=='#var(locdebug)') {
+                DebugMarkKeyPosition(k.Location, k.KeyID);
+            }
+#endif
     for(tries=0; tries<5; tries++) {
         if(vanilla_good) {
             slot=rng(num+1);// +1 for vanilla, since we're not in the list

--- a/DXRModules/DeusEx/Classes/DXRKeys.uc
+++ b/DXRModules/DeusEx/Classes/DXRKeys.uc
@@ -1001,9 +1001,9 @@ function _RandoKey(#var(prefix)NanoKey k, bool containers)
     }
     vanilla_good = KeyPositionGood(k, k.Location);
 #ifdef locdebug
-            if(k.KeyID=='#var(locdebug)') {
-                DebugMarkKeyPosition(k.Location, k.KeyID);
-            }
+    if(vanilla_good && k.KeyID=='#var(locdebug)') {
+        DebugMarkKeyPosition(k.Location, k.KeyID);
+    }
 #endif
     for(tries=0; tries<5; tries++) {
         if(vanilla_good) {

--- a/DXRModules/DeusEx/Classes/DXRKeys.uc
+++ b/DXRModules/DeusEx/Classes/DXRKeys.uc
@@ -262,13 +262,61 @@ function vanilla_keys_rules()
         break;
 
     case "10_Paris_Metro":
+        //Anything on the second floor
         keys_rules[i].item_name = 'apartment12';
         keys_rules[i].min_pos = vect(-99999, -99999, 420);
         keys_rules[i].max_pos = vect(99999, 99999, 99999);
         keys_rules[i].allow = false;
         i++;
 
+        //In the media store
         keys_rules[i].item_name = 'apartment12';
+        keys_rules[i].min_pos = vect(669,2080,130);
+        keys_rules[i].max_pos = vect(1596,1634,375);
+        keys_rules[i].allow = false;
+        i++;
+
+        keys_rules[i].item_name = 'apartment12';
+        keys_rules[i].min_pos = vect(-99999, -99999, -99999);
+        keys_rules[i].max_pos = vect(99999, 99999, 420);
+        keys_rules[i].allow = true;
+        i++;
+
+        //Anything on the second floor
+        keys_rules[i].item_name = 'hotel_roomdoor';
+        keys_rules[i].min_pos = vect(-99999, -99999, 420);
+        keys_rules[i].max_pos = vect(99999, 99999, 99999);
+        keys_rules[i].allow = false;
+        i++;
+
+        //In the media store
+        keys_rules[i].item_name = 'hotel_roomdoor';
+        keys_rules[i].min_pos = vect(669,2080,130);
+        keys_rules[i].max_pos = vect(1596,1634,375);
+        keys_rules[i].allow = false;
+        i++;
+
+        keys_rules[i].item_name = 'hotel_roomdoor';
+        keys_rules[i].min_pos = vect(-99999, -99999, -99999);
+        keys_rules[i].max_pos = vect(99999, 99999, 420);
+        keys_rules[i].allow = true;
+        i++;
+
+        //Anything on the second floor
+        keys_rules[i].item_name = 'mediastore_door';
+        keys_rules[i].min_pos = vect(-99999, -99999, 420);
+        keys_rules[i].max_pos = vect(99999, 99999, 99999);
+        keys_rules[i].allow = false;
+        i++;
+
+        //In the media store
+        keys_rules[i].item_name = 'mediastore_door';
+        keys_rules[i].min_pos = vect(669,2080,130);
+        keys_rules[i].max_pos = vect(1596,1634,375);
+        keys_rules[i].allow = false;
+        i++;
+
+        keys_rules[i].item_name = 'mediastore_door';
         keys_rules[i].min_pos = vect(-99999, -99999, -99999);
         keys_rules[i].max_pos = vect(99999, 99999, 420);
         keys_rules[i].allow = true;

--- a/DXRModules/DeusEx/Classes/DXRKeys.uc
+++ b/DXRModules/DeusEx/Classes/DXRKeys.uc
@@ -970,8 +970,8 @@ function _RandoKey(#var(prefix)NanoKey k, bool containers)
         if( a == k ) continue;
         if( SkipActor(a) ) continue;
         if( KeyPositionGood(k, a.Location) == False ) continue;
-#ifdef debug
-        if(k.KeyID=='Glab') {
+#ifdef locdebug
+        if(k.KeyID=='#var(locdebug)') {
             DebugMarkKeyPosition(a.Location, k.KeyID);
             //continue;
         }
@@ -985,8 +985,8 @@ function _RandoKey(#var(prefix)NanoKey k, bool containers)
             if( SkipActor(c) ) continue;
             if( KeyPositionGood(k, c.Location) == False ) continue;
             if( HasBased(c) ) continue;
-#ifdef debug
-            if(k.KeyID=='crewkey') {
+#ifdef locdebug
+            if(k.KeyID=='#var(locdebug)') {
                 DebugMarkKeyPosition(c.Location, k.KeyID);
                 //continue;
             }

--- a/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -545,7 +545,6 @@ function AddStartingEquipment(DeusExPlayer p, bool bFrob)
         if(auglevel == 0) {
             auglevel = 1;
         }
-        GiveItem(p, class'MemConUnit');
     }
     for(i=0; i < ArrayCount(__item_sets[loadout].starting_augs); i++) {
         aclass = __item_sets[loadout].starting_augs[i];
@@ -556,7 +555,7 @@ function AddStartingEquipment(DeusExPlayer p, bool bFrob)
 
 function RandoStartingEquipment(#var(PlayerPawn) player, bool respawn)
 {
-    local Inventory item, anItem;
+    local Inventory item, nextItem;
     local DXREnemies dxre;
     local int i, start_amount;
 
@@ -574,19 +573,17 @@ function RandoStartingEquipment(#var(PlayerPawn) player, bool respawn)
 
     dxre = DXREnemies(dxr.FindModule(class'DXREnemies'));
 
-    item = player.Inventory;
-    while(item != None)
-    {
-        anItem = item;
-        item = item.Inventory;
-        l("RandoStartingEquipment("$player$") checking item "$anItem$", bDisplayableInv: "$anItem.bDisplayableInv);
-        if( Ammo(anItem) == None && ! anItem.bDisplayableInv ) continue;
-        if( #var(prefix)NanoKeyRing(anItem) != None ) continue;
-        if( dxre == None && Weapon(anItem) != None ) continue;
-        if( dxre == None && Ammo(anItem) != None ) continue;
-        l("RandoStartingEquipment("$player$") removing item: "$anItem);
-        player.DeleteInventory(anItem);
-        anItem.Destroy();
+    for(item = player.Inventory; item != None; item=nextItem) {
+        nextItem = item.Inventory;
+        l("RandoStartingEquipment("$player$") checking item "$item$", bDisplayableInv: "$item.bDisplayableInv);
+        if( Ammo(item) == None && ! item.bDisplayableInv ) continue;
+        if( #var(prefix)NanoKeyRing(item) != None ) continue;
+        if( dxre == None && Weapon(item) != None ) continue;
+        if( dxre == None && Ammo(item) != None ) continue;
+        if( MemConUnit(item) != None ) continue;
+        l("RandoStartingEquipment("$player$") removing item: "$item);
+        player.DeleteInventory(item);
+        item.Destroy();
     }
 
 #ifdef gmdx
@@ -704,17 +701,6 @@ function SpawnItems()
                 if( reducer != None && Inventory(a) != None )
                     reducer.ReduceItem(Inventory(a));
             }
-        }
-    }
-
-    if(dxr.flags.autosave == 7) { // Fixed Saves
-        SetSeed("SpawnItems() MCU");
-        aclass = class'MemConUnit';
-        chance = 80;
-        if(chance_single(chance)) {
-            loc = GetRandomPositionFine();
-            a = Spawn(aclass,,, loc);
-            l("SpawnItems() spawned "$a$" at "$loc);
         }
     }
 

--- a/DXRModules/DeusEx/Classes/DXRMapVariants.uc
+++ b/DXRModules/DeusEx/Classes/DXRMapVariants.uc
@@ -109,7 +109,7 @@ static function bool IsRevisionMaps(#var(PlayerPawn) player, optional Bool init)
     local Bool rc;
     local DXRando dxr;
 
-    foreach player.AllActors(class'DXRando',dxr){break;}
+    dxr = class'DXRando'.default.dxr;
 
     if (init){
         mapMenu = new(None) class'RevMenuChoice_Maps';

--- a/DXRModules/DeusEx/Classes/DXRPasswordsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRPasswordsBase.uc
@@ -119,7 +119,7 @@ simulated function bool UpdateString(out string str, string oldpassword, string 
     //l(str);
     //l("---");
 
-    str = ReplaceText( str, oldpassword, newpassword, true );//spaces around the password make it so you can double click to highlight it then copy it easily
+    str = ReplaceText( str, oldpassword, newpassword, true );
 
     return true;
 }
@@ -434,7 +434,7 @@ simulated function bool UpdateGoal(DeusExGoal goal, string oldpassword, string n
 
     info("found goal with password " $ oldpassword $ ", replacing with newpassword " $ newpassword);
 
-    goal.text = ReplaceText( goal.text, oldpassword, " " $ newpassword $ " ", true );//spaces around the password make it so you can double click to highlight it then copy it easily
+    goal.text = ReplaceText( goal.text, oldpassword, newpassword, true );
 
 #ifdef hx
     HXGameInfo(Level.Game).AddNote(goal.text, false, true, '');
@@ -494,7 +494,7 @@ simulated function bool UpdateNote(DeusExNote note, string oldpassword, string n
     updated++;
     info("found note with password " $ oldpassword $ ", replacing with newpassword " $ newpassword);
 
-    note.text = ReplaceText( note.text, oldpassword, " " $ newpassword $ " ", true );//spaces around the password make it so you can double click to highlight it then copy it easily
+    note.text = ReplaceText( note.text, oldpassword, newpassword, true );
 #ifdef injections
     note.SetNewPassword(newpassword);
 #elseif hx

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -36,6 +36,9 @@ function PreFirstEntry()
     local ElevatorMover eMover;
     local #var(DeusExPrefix)Mover dxMover;
     local Dispatcher disp;
+    local AllianceTrigger at;
+    local #var(prefix)AnnaNavarre anna;
+    local #var(prefix)OrdersTrigger ot;
 
     p = player();
     DeusExRootWindow(p.rootWindow).hud.startDisplay.AddMessage("Mission " $ dxr.dxInfo.missionNumber);
@@ -55,6 +58,33 @@ function PreFirstEntry()
             }
             foreach AllActors(class'ScriptedPawn', sp, 'hostageWoman') {
                 sp.Destroy();
+            }
+        }
+        break;
+
+    case "03_NYC_MOLEPEOPLE":
+        if (dxr.flags.settings.starting_map >= 35) {
+            foreach AllActors(class'AllianceTrigger', at, 'surrender') {
+                at.Trigger(None, None);
+                break;
+            }
+        }
+        break;
+
+    case "05_NYC_UNATCOMJ12LAB":
+        if(dxr.flags.settings.starting_map > 50) {
+            foreach AllActors(class'#var(prefix)AnnaNavarre', anna) {
+                anna.Destroy();
+            }
+        }
+        break;
+
+    case "06_HONGKONG_TONGBASE":
+        if (dxr.flags.settings.starting_map > 66) {
+            // set Tong to patrol his control room, which is his correct behavior after talking to him after he deactivates your killswitch
+            foreach AllActors(class'#var(prefix)OrdersTrigger', ot, 'TracerWanders') {
+                ot.Trigger(self, None);
+                break;
             }
         }
         break;
@@ -81,6 +111,9 @@ function PreFirstEntry()
                 eMover.InterpolateTo(1, 0.0);
                 break;
             }
+        }
+        if (dxr.flags.settings.starting_map < 151) {
+            player().DeleteAllGoals();
         }
         break;
 
@@ -570,11 +603,12 @@ function PreFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, 
 
         case 37:
             GiveImage(player, class'Image03_NYC_Airfield');
-            MarkConvPlayed("DL_LebedevKill_Played", bFemale);
+            MarkConvPlayed("DL_LebedevKill", bFemale);
         case 36: // fallthrough
             GiveKey(player, 'Sewerdoor', "Sewer Door");
         case 35: // fallthrough
             GiveKey(player, 'MoleRestroomKey', "Molepeople Bathroom Key");
+            MarkConvPlayed("M03MeetTerroristLeader", bFemale);
         case 34: // fallthrough
         case 33:
             AddNote(player, bEmptyNotes, "6653 -- Code to the phone-booth entrance to mole-people hideout.");
@@ -802,6 +836,9 @@ static function bool BingoGoalImpossible(string bingo_event, int start_map, int 
         case "SimonsAssassination":
         case "MeetInjuredTrooper2_Played":
             return start_map > 31;
+
+        case "surrender": //We make the mole people NSF pre-surrendered on 35+ starts
+            return start_map >=35;
 
         case "CleanerBot_ClassDead":
         case "AlexCloset":

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -638,6 +638,7 @@ function PreFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, 
             MarkConvPlayed("M07Briefing", bFemale);// also spawns big spider in MJ12Lab
         case 70://fallthrough
             flagbase.SetBool('Disgruntled_Guy_Dead', true);
+            MarkConvPlayed("Meet_MJ12Lab_Supervisor", bFemale);
         case 68://fallthrough
             AddNote(player, bEmptyNotes, "VersaLife elevator code: 6512.");
         case 67://fallthrough

--- a/DXRNonVanilla/DeusEx/Classes/DXRComputerScreenBulletins.uc
+++ b/DXRNonVanilla/DeusEx/Classes/DXRComputerScreenBulletins.uc
@@ -132,14 +132,9 @@ function string GetMapNameStripped()
 function int DxrCrc(string plaintext)
 {
     local DXRando dxr;
-    local #var(prefix)PlayerPawn pp;
-#ifdef hx
-    pp = PlayerPawn;
-#else
-    pp = player;
-#endif
 
-    foreach pp.AllActors(class'DXRando', dxr) {
+    dxr = class'DXRando'.default.dxr;
+    if (dxr!=None) {
         return dxr.Crc(plaintext);
     }
     return 0;

--- a/DXRNonVanilla/DeusEx/Classes/DXRComputerScreenEmail.uc
+++ b/DXRNonVanilla/DeusEx/Classes/DXRComputerScreenEmail.uc
@@ -133,15 +133,9 @@ function string GetMapNameStripped()
 function int DxrCrc(string plaintext)
 {
     local DXRando dxr;
-    local Actor a;
 
-#ifdef hx
-        a = PlayerPawn;
-#else
-        a = player;
-#endif
-
-    foreach a.AllActors(class'DXRando', dxr) {
+    dxr = class'DXRando'.default.dxr;
+    if (dxr!=None) {
         return dxr.Crc(plaintext);
     }
     return 0;

--- a/DXRVanilla/DeusEx/Classes/BlackHelicopter.uc
+++ b/DXRVanilla/DeusEx/Classes/BlackHelicopter.uc
@@ -53,7 +53,7 @@ function Scream()
 {
     local DXRando dxr;
 
-    foreach AllActors(class'DXRando',dxr){break;}
+    dxr = class'DXRando'.default.dxr;
     if (dxr==None) return;
     if(!class'MenuChoice_ToggleMemes'.static.IsEnabled(dxr.flags)) return;
 

--- a/DXRVanilla/DeusEx/Classes/ComputerUIWindow.uc
+++ b/DXRVanilla/DeusEx/Classes/ComputerUIWindow.uc
@@ -119,7 +119,8 @@ function int DxrCrc(string plaintext)
 {
     local DXRando dxr;
 
-    foreach player.AllActors(class'DXRando', dxr) {
+    dxr = class'DXRando'.default.dxr;
+    if (dxr!=None) {
         return dxr.Crc(plaintext);
     }
     return 0;

--- a/DXRVanilla/DeusEx/Classes/ConPlayBase.uc
+++ b/DXRVanilla/DeusEx/Classes/ConPlayBase.uc
@@ -421,3 +421,35 @@ log("  event.transferCount = " $ event.transferCount);
 
 	return itemsTransferred;
 }
+
+// ----------------------------------------------------------------------
+// SetupEventAddGoal()
+//
+// TODO: Add support for goals longer than 255 characters.
+// ----------------------------------------------------------------------
+
+function EEventAction SetupEventAddGoal( ConEventAddGoal event, out String nextLabel )
+{
+	local DeusExGoal goal;
+
+	// First check to see if this goal exists
+	goal = player.FindGoal( event.goalName );
+
+	if (( goal == None ) && ( !event.bGoalCompleted ))
+	{
+		// Add this goal to the player's goals
+		goal = player.AddGoal(event.goalName, event.bPrimaryGoal);
+	}
+	// Check if we're just marking this goal as complete
+	else if (( goal != None ) && ( event.bGoalCompleted ))
+	{
+		player.GoalCompleted(event.goalName);
+	}
+
+    if ( goal != None )
+    {
+        goal.SetText(event.goalText);
+    }
+
+	return EA_NextEvent;
+}

--- a/DXRVanilla/DeusEx/Classes/DXRNetworkTerminal.uc
+++ b/DXRVanilla/DeusEx/Classes/DXRNetworkTerminal.uc
@@ -130,11 +130,7 @@ function CloseKnownAccountsWindow()
 
 function ComputerHacked()
 {
-    local DXRando dxr;
     Super.ComputerHacked();
 
-    foreach Player.AllActors(class'DXRando',dxr){
-        class'DXREvents'.static.MarkBingo(dxr,"ComputerHacked");
-        break;
-    }
+    class'DXREvents'.static.MarkBingo("ComputerHacked");
 }

--- a/DXRVanilla/DeusEx/Classes/LuciusDeBeers.uc
+++ b/DXRVanilla/DeusEx/Classes/LuciusDeBeers.uc
@@ -67,7 +67,7 @@ function Scream()
 {
     local DXRando dxr;
 
-    foreach AllActors(class'DXRando',dxr){break;}
+    dxr = class'DXRando'.default.dxr;
     if (dxr==None) return;
     if(!class'MenuChoice_ToggleMemes'.static.IsEnabled(dxr.flags)) return;
 

--- a/DXRVanilla/DeusEx/Classes/MissionScript.uc
+++ b/DXRVanilla/DeusEx/Classes/MissionScript.uc
@@ -63,7 +63,7 @@ function FirstFrame()
 function Timer()
 {
     // ensure DXRFlags can load flags before we start
-    if( dxr == None ) foreach AllActors(class'DXRando', dxr) break;
+    if( dxr == None ) dxr = class'DXRando'.default.dxr;
     if( dxr == None ) return;
     if( dxr.flagbase == None ) return;
 

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -2169,11 +2169,19 @@ ignores SeePlayer, HearNoise, Bump, TakeDamage;
     event PlayerTick( float DeltaTime )
     {
         super.PlayerTick(DeltaTime);
+        DrugEffects(deltaTime); //Drunk and on drugs happy funtime
+        Bleed(deltaTime);   //Make blood drops happen
+        HighlightCenterObject();  //Make object highlighting actually happen
+        UpdateDynamicMusic(deltaTime); //Make sure the music can still change states while flying around
+        UpdateWarrenEMPField(deltaTime);
+        MultiplayerTick(deltaTime); //UpdateInHand, Poison, burning, shields, etc
+        FrobTime += deltaTime; //Make sure we keep track of how long you've been highlighting things
 
-        UpdateInHand();
-        //Make object highlighting work while flying or ghosting
-        HighlightCenterObject();
-        FrobTime += deltaTime;
+        CheckActiveConversationRadius(); // Check if player has walked outside a first-person convo.
+        CheckActorDistances(); // Check if all the people involved in a conversation are in a reasonable radius
+
+        UpdateTimePlayed(deltaTime); //The timer for the game save
+
     }
 }
 

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -2170,6 +2170,7 @@ ignores SeePlayer, HearNoise, Bump, TakeDamage;
     {
         super.PlayerTick(DeltaTime);
 
+        UpdateInHand();
         //Make object highlighting work while flying or ghosting
         HighlightCenterObject();
         FrobTime += deltaTime;

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -578,9 +578,20 @@ exec function ParseLeftClick()
 function InstantlyUseItem(DeusExPickup item)
 {
     local Actor A;
+    local DeusExPickup p;
     local int i;
 
     if(item == None) return;
+
+    //Only consume one of the things if it's in a stack.
+    //Spawn an individual one to split it from the stack before using it.
+    if (item.NumCopies>1){
+        p = Spawn(item.Class,,,item.Location,item.Rotation);
+        p.NumCopies=1;
+        item.NumCopies--;
+        InstantlyUseItem(p);
+        return;
+    }
 
     foreach item.BasedActors(class'Actor', A)
         A.SetBase(None);
@@ -594,8 +605,11 @@ function InstantlyUseItem(DeusExPickup item)
     Inventory = item;
     if(FireExtinguisher(item) != None) {
         // this was buggy with multiple, but it doesn't make sense and wouldn't be useful to use multiple at once anyways
+        // this shouldn't get hit anymore, but still do this, just in case
         item.NumCopies = 1;
     }
+
+    //In theory this should only be one, but just in case we slipped through the case above...
     for(i=item.NumCopies; i > 0; i--) {
         item.Activate();
     }

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -2163,6 +2163,19 @@ exec function ActivateBelt(int objectNum)
     }
 }
 
+state CheatFlying
+{
+ignores SeePlayer, HearNoise, Bump, TakeDamage;
+    event PlayerTick( float DeltaTime )
+    {
+        super.PlayerTick(DeltaTime);
+
+        //Make object highlighting work while flying or ghosting
+        HighlightCenterObject();
+        FrobTime += deltaTime;
+    }
+}
+
 defaultproperties
 {
     SkillPointsTotal=6575

--- a/DXRando/DeusEx/Classes/BingoTrigger.uc
+++ b/DXRando/DeusEx/Classes/BingoTrigger.uc
@@ -128,6 +128,37 @@ static function BingoTrigger Create(Actor a, Name bingoEvent, vector loc, option
 
 }
 
+static function BingoTrigger PeepCreate(Actor a, Name bingoEvent, vector loc, float rad, float height)
+{
+    local BingoTrigger bt;
+
+    bt = Create(a,bingoEvent,loc,rad,height);
+    bt.MakePeepable();
+
+    return bt;
+}
+
+static function BingoTrigger ProxCreate(Actor a, Name bingoEvent, vector loc, float rad, float height, class<Actor> className)
+{
+    local BingoTrigger bt;
+
+    bt = Create(a,bingoEvent,loc,rad,height);
+    bt.MakeClassProximityTrigger(className);
+
+    return bt;
+}
+
+static function BingoTrigger ShootCreate(Actor a, Name bingoEvent, vector loc, float rad, float height)
+{
+    local BingoTrigger bt;
+
+    bt = Create(a,bingoEvent,loc,rad,height);
+    bt.MakeShootingTarget();
+
+    return bt;
+}
+
+
 defaultproperties
 {
      bingoEvent=""

--- a/DXRando/DeusEx/Classes/BingoTrigger.uc
+++ b/DXRando/DeusEx/Classes/BingoTrigger.uc
@@ -61,13 +61,11 @@ function DoBingoThing()
         return;
     }
 
-    foreach AllActors(class'DXRando',dxr){
-        class'DXREvents'.static.MarkBingo(dxr,bingoEvent);
-        break;
-    }
+    class'DXREvents'.static.MarkBingo(bingoEvent);
 
     FinishedMax--;
     if(FinishedMax == 0) {
+        dxr = class'DXRando'.default.dxr;
         dxr.flagbase.SetBool(FinishedFlag, true,, 999);
     }
 

--- a/DXRando/DeusEx/Classes/ClothesRack.uc
+++ b/DXRando/DeusEx/Classes/ClothesRack.uc
@@ -77,7 +77,7 @@ function Frob(actor Frobber, Inventory frobWith)
 
         if (!bAlreadyUsed){
             bAlreadyUsed=true;
-            class'DXREvents'.static.MarkBingo(dxr,"ChangeClothes");
+            class'DXREvents'.static.MarkBingo("ChangeClothes");
         }
 
     }

--- a/DXRando/DeusEx/Classes/DXRAimLaserEmitter.uc
+++ b/DXRando/DeusEx/Classes/DXRAimLaserEmitter.uc
@@ -99,7 +99,7 @@ static function bool AimLaserShouldBeOn(#var(PlayerPawn) player)
         return False;
     }
 
-    cameraModes = DXRCameraModes(player.DXRFindModule(class'DXRCameraModes'));
+    cameraModes = DXRCameraModes(class'DXRCameraModes'.static.Find());
     if (cameraModes == None || cameraModes.aimLaserDisabled) {
         return False;
     }

--- a/DXRando/DeusEx/Classes/DXRAmbientSoundTrigger.uc
+++ b/DXRando/DeusEx/Classes/DXRAmbientSoundTrigger.uc
@@ -1,0 +1,80 @@
+// Note that this class behaves very differently from AmbientSoundTriggered.
+class DXRAmbientSoundTrigger extends AmbientSound;
+
+var sound TriggeredAmbientSound, UntriggeredAmbientSound;
+var() byte TriggeredSoundRadius, UntriggeredSoundRadius, TriggeredSoundVolume, UntriggeredSoundVolume, TriggeredSoundPitch, UntriggeredSoundPitch;
+var() bool bTriggerOnceOnly, bUntriggerOnceOnly, bAlreadyTriggered, bAlreadyUntriggered;
+
+function Trigger(Actor Other, Pawn Instigator)
+{
+    if (bTriggerOnceOnly && bAlreadyTriggered) return;
+
+    Super.Trigger(Other, Instigator);
+    AmbientSound = TriggeredAmbientSound;
+    SoundRadius = TriggeredSoundRadius;
+    SoundVolume = TriggeredSoundVolume;
+    SoundPitch = TriggeredSoundPitch;
+
+    bAlreadyTriggered = true;
+}
+
+function UnTrigger(Actor Other, Pawn Instigator)
+{
+    if (bUntriggerOnceOnly && bAlreadyUntriggered) return;
+
+    Super.UnTrigger(Other, Instigator);
+    AmbientSound = UntriggeredAmbientSound;
+    SoundRadius = UntriggeredSoundRadius;
+    SoundVolume = UntriggeredSoundVolume;
+    SoundPitch = UntriggeredSoundPitch;
+
+    bAlreadyUntriggered = true;
+}
+
+static function DXRAmbientSoundTrigger ReplaceAmbientSound(AmbientSound as, optional name spawnTag, optional Vector spawnLocation)
+{
+    local DXRAmbientSoundTrigger ast;
+
+    if (as == None) return None;
+
+    if (spawnLocation == vect(0.0, 0.0, 0.0)) {
+        spawnLocation = as.Location;
+    }
+    ast = as.Spawn(class'DXRAmbientSoundTrigger',, spawnTag, spawnLocation);
+    ast.CopyVals(as);
+    ast.CopyValsToTriggered(ast);
+
+    as.AmbientSound = None;
+
+    return ast;
+}
+
+function CopyVals(Actor other)
+{
+    AmbientSound = other.AmbientSound;
+    SoundRadius = other.SoundRadius;
+    SoundVolume = other.SoundVolume;
+    SoundPitch = other.SoundPitch;
+}
+
+function CopyValsToTriggered(Actor other)
+{
+    TriggeredAmbientSound = other.AmbientSound;
+    TriggeredSoundRadius = other.SoundRadius;
+    TriggeredSoundVolume = other.SoundVolume;
+    TriggeredSoundPitch = other.SoundPitch;
+}
+
+function CopyValsToUntriggered(Actor other)
+{
+    UntriggeredAmbientSound = other.AmbientSound;
+    UntriggeredSoundRadius = other.SoundRadius;
+    UntriggeredSoundVolume = other.SoundVolume;
+    UntriggeredSoundPitch = other.SoundPitch;
+}
+
+defaultproperties
+{
+    bStatic=false
+    bCollideActors=false
+}

--- a/DXRando/DeusEx/Classes/DXRBinoculars.uc
+++ b/DXRando/DeusEx/Classes/DXRBinoculars.uc
@@ -44,7 +44,6 @@ simulated function Timer()
     local Vector HitNormal, HitLocation, StartTrace, EndTrace;
     local Actor peepee;// pronounced peep-ee, not pee-pee
     local Actor target;
-    local DXRando dxr;
     local bool newPeepee, newPeepTex;
     local name texName,texGroup;
     local int flags, i;
@@ -87,11 +86,6 @@ simulated function Timer()
 
     //peeper.ClientMessage("Peeping "$peepee.Name$" in state "$peepee.GetStateName());
 
-    foreach AllActors(class'DXRando', dxr) {break;}
-
-    if (dxr==None){
-        return;
-    }
 
     if(peepee.IsA('LevelInfo')){
         peepee=None;
@@ -124,11 +118,11 @@ simulated function Timer()
     if (newPeepee){
         //peeper.ClientMessage("New peeped actor is "$peepee.class.Name);
         //This should probably only trigger once per thing - TODO, will probably be tracked in DXREvents and PlayerDataItem, like function ReadText(name textTag)
-        class'DXREvents'.static.MarkBingo(dxr,peepee.Class.Name$"_peeped");
+        class'DXREvents'.static.MarkBingo(peepee.Class.Name$"_peeped");
 
         if (ScriptedPawn(peepee)!=None){
-            class'DXREvents'.static.MarkBingo(dxr,"PawnState_"$peepee.GetStateName());
-            class'DXREvents'.static.MarkBingo(dxr,"PawnAnim_"$peepee.AnimSequence);
+            class'DXREvents'.static.MarkBingo("PawnState_"$peepee.GetStateName());
+            class'DXREvents'.static.MarkBingo("PawnAnim_"$peepee.AnimSequence);
         }
 
         if (BingoTrigger(peepee)!=None){
@@ -136,12 +130,12 @@ simulated function Timer()
         }
     } else if (newPeepTex) {
         //peeper.ClientMessage("New peeped texture is "$lastWatchedTex);
-        class'DXREvents'.static.MarkBingo(dxr,lastWatchedTex$"_peepedtex");
+        class'DXREvents'.static.MarkBingo(lastWatchedTex$"_peepedtex");
     } else {
         watchTime++;
         if(watchTime>=4){
             watchTime=0;
-            class'DXREvents'.static.MarkBingo(dxr,peepee.Class.Name$"_peeptime");
+            class'DXREvents'.static.MarkBingo(peepee.Class.Name$"_peeptime");
         }
     }
 }

--- a/DXRando/DeusEx/Classes/DXRCeilingFan.uc
+++ b/DXRando/DeusEx/Classes/DXRCeilingFan.uc
@@ -79,19 +79,13 @@ function ToggleFan()
 
 function Frob(actor Frobber, Inventory frobWith)
 {
-    local DXRando dxr;
-
     Super.Frob(Frobber, frobWith);
 
     ToggleFan();
 
-    dxr = class'DXRando'.default.dxr;
-    if (dxr == None)
-        return;
-
     if (!bAlreadyUsed){
         bAlreadyUsed=true;
-        class'DXREvents'.static.MarkBingo(dxr,"NotABigFan");
+        class'DXREvents'.static.MarkBingo("NotABigFan");
     }
 }
 

--- a/DXRando/DeusEx/Classes/DXRCigaretteMachine.uc
+++ b/DXRando/DeusEx/Classes/DXRCigaretteMachine.uc
@@ -3,20 +3,16 @@ class DXRCigaretteMachine injects CigaretteMachine;
 function Frob(Actor frobber, Inventory frobWith)
 {
     local int usesBefore;
-    local DXRando dxr;
 
     usesBefore = numUses;
 
     Super.Frob(frobber, frobWith);
 
     if (numUses != usesBefore) {
-        foreach AllActors(class'DXRando', dxr) {
-            class'DXREvents'.static.MarkBingo(dxr, "VendingMachineDispense_Cigs");
-            class'DXREvents'.static.MarkBingo(dxr, "VendingMachineDispense");
-            if (numUses == 0) {
-                class'DXREvents'.static.MarkBingo(dxr, "VendingMachineEmpty");
-            }
-            break;
+        class'DXREvents'.static.MarkBingo("VendingMachineDispense_Cigs");
+        class'DXREvents'.static.MarkBingo("VendingMachineDispense");
+        if (numUses == 0) {
+            class'DXREvents'.static.MarkBingo("VendingMachineEmpty");
         }
     }
 }

--- a/DXRando/DeusEx/Classes/DXRDataVaultImage.uc
+++ b/DXRando/DeusEx/Classes/DXRDataVaultImage.uc
@@ -18,7 +18,7 @@ static function UpdateDataVaultImageTextures(DataVaultImage newImage)
 {
     local DXRando dxr;
 
-    foreach newImage.AllActors(class'DXRando',dxr) {break;}
+    dxr = class'DXRando'.default.dxr;
 
     //Check if we're ready or not
     if (dxr==None) return;

--- a/DXRando/DeusEx/Classes/DXRFemur.uc
+++ b/DXRando/DeusEx/Classes/DXRFemur.uc
@@ -2,11 +2,7 @@ class DXRFemur injects #var(prefix)BoneFemur;
 
 function Destroyed()
 {
-    local DXRando dxr;
-
-    foreach AllActors(class'DXRando', dxr) {
-        class'DXREvents'.static.MarkBingo(dxr,"FightSkeletons");
-    }
+    class'DXREvents'.static.MarkBingo("FightSkeletons");
 
     Super.Destroyed();
 }

--- a/DXRando/DeusEx/Classes/DXRMissionEndgame.uc
+++ b/DXRando/DeusEx/Classes/DXRMissionEndgame.uc
@@ -151,7 +151,7 @@ function PrintEndgameQuote(int num)
     bQuotePrinted = True;
     flags.SetBool('EndgameExplosions', False);
 
-    foreach AllActors(class'DXRando',dxr) break;
+    dxr = class'DXRando'.default.dxr;
 
     qMgr = Spawn(class'EndgameQuoteManager');
     qMgr.LoadQuotes();

--- a/DXRando/DeusEx/Classes/DXRMissionIntro.uc
+++ b/DXRando/DeusEx/Classes/DXRMissionIntro.uc
@@ -22,10 +22,8 @@ local DXRando dxr;
             started_conv = true;
             Level.Game.SetGameSpeed(1);
             SetTimer(checkTime, True);
-            foreach AllActors(class'DXRando',dxr){
-                dxr.flags.SaveFlags();
-                break;
-            }
+            dxr = class'DXRando'.default.dxr;
+            dxr.flags.SaveFlags();
         }
     } else {
         if (ran_first_frame && !started_conv){

--- a/DXRando/DeusEx/Classes/DXRRevMissionEndgame.uc
+++ b/DXRando/DeusEx/Classes/DXRRevMissionEndgame.uc
@@ -30,7 +30,7 @@ function PrintEndgameQuote(int num)
     bQuotePrinted = True;
     flags.SetBool('EndgameExplosions', False);
 
-    foreach AllActors(class'DXRando',dxr) break;
+    dxr = class'DXRando'.default.dxr;
 
     qMgr = Spawn(class'EndgameQuoteManager');
     qMgr.LoadQuotes();

--- a/DXRando/DeusEx/Classes/DXRSkull.uc
+++ b/DXRando/DeusEx/Classes/DXRSkull.uc
@@ -2,11 +2,7 @@ class DXRSkull injects #var(prefix)BoneSkull;
 
 function Destroyed()
 {
-    local DXRando dxr;
-
-    foreach AllActors(class'DXRando', dxr) {
-        class'DXREvents'.static.MarkBingo(dxr,"FightSkeletons");
-    }
+    class'DXREvents'.static.MarkBingo("FightSkeletons");
 
     Super.Destroyed();
 }

--- a/DXRando/DeusEx/Classes/DXRStatLog.uc
+++ b/DXRando/DeusEx/Classes/DXRStatLog.uc
@@ -25,7 +25,6 @@ function LogPickup(Inventory Item, Pawn Other)
 //Called any
 function LogItemActivate(Inventory Item, Pawn Other)
 {
-    local DXRando dxr;
     local string className;
 
     if ( (Item == None) )
@@ -47,7 +46,5 @@ function LogItemActivate(Inventory Item, Pawn Other)
     //Strip any package names for simplicity
     className = class'DXRInfo'.static.ReplaceText(className,"DeusEx.","");
     className = class'DXRInfo'.static.ReplaceText(className,"HX.HX","");
-    foreach AllActors(class'DXRando',dxr){
-        class'DXREvents'.static.MarkBingo(dxr,className$"_Activated");
-    }
+    class'DXREvents'.static.MarkBingo(className$"_Activated");
 }

--- a/DXRando/DeusEx/Classes/DXRVendingMachine.uc
+++ b/DXRando/DeusEx/Classes/DXRVendingMachine.uc
@@ -3,7 +3,6 @@ class DXRVendingMachine injects #var(prefix)VendingMachine;
 function Frob(actor Frobber, Inventory frobWith)
 {
     local int usesBefore;
-    local DXRando dxr;
     local String vendType;
 
     usesBefore = numUses;
@@ -15,20 +14,18 @@ function Frob(actor Frobber, Inventory frobWith)
     }
 
     //If you actually succeeded in buying something, mark purchase for the specific type and in general
-    foreach AllActors(class'DXRando', dxr) {
-        if (usesBefore!=0 && numUses!=usesBefore){
-            if (SkinColor==SC_Drink){
-                vendType="Drink";
-            } else if (SkinColor==SC_Snack){
-                vendType="Candy";
-            }
-            class'DXREvents'.static.MarkBingo(dxr,"VendingMachineDispense_"$vendType);
-            class'DXREvents'.static.MarkBingo(dxr,"VendingMachineDispense");
-            //Mark if you actually empty a machine
-            if (numUses==0){
-                class'DXREvents'.static.MarkBingo(dxr,"VendingMachineEmpty_"$vendType);
-                class'DXREvents'.static.MarkBingo(dxr,"VendingMachineEmpty");
-            }
+    if (usesBefore!=0 && numUses!=usesBefore){
+        if (SkinColor==SC_Drink){
+            vendType="Drink";
+        } else if (SkinColor==SC_Snack){
+            vendType="Candy";
+        }
+        class'DXREvents'.static.MarkBingo("VendingMachineDispense_"$vendType);
+        class'DXREvents'.static.MarkBingo("VendingMachineDispense");
+        //Mark if you actually empty a machine
+        if (numUses==0){
+            class'DXREvents'.static.MarkBingo("VendingMachineEmpty_"$vendType);
+            class'DXREvents'.static.MarkBingo("VendingMachineEmpty");
         }
     }
 }

--- a/DXRando/DeusEx/Classes/EndgameQuoteManager.uc
+++ b/DXRando/DeusEx/Classes/EndgameQuoteManager.uc
@@ -193,7 +193,7 @@ function PickRandomQuote(out string quote, out string attrib)
     local DXRando dxr;
     local EndQuote q;
 
-    foreach AllActors(class'DXRando',dxr) break;
+    dxr = class'DXRando'.default.dxr;
 
     if(dxr != None) {
         q = quotes[dxr.rng(numQuotes)];

--- a/DXRando/DeusEx/Classes/Faucet.uc
+++ b/DXRando/DeusEx/Classes/Faucet.uc
@@ -3,7 +3,6 @@ class DXRFaucet injects #var(prefix)Faucet;
 function Frob(actor Frobber, Inventory frobWith)
 {
 	local #var(PlayerPawn) player;
-    local DXRando      dxr;
     local bool         wasOnFire;
 
 	player = #var(PlayerPawn)(Frobber);
@@ -15,10 +14,7 @@ function Frob(actor Frobber, Inventory frobWith)
 	{
 		player.ClientMessage("Splish Splash!",, true);
 
-        foreach AllActors(class'DXRando', dxr) {
-            class'DXREvents'.static.ExtinguishFire(dxr,"sink",player);
-            break;
-        }
+        class'DXREvents'.static.ExtinguishFire("sink",player);
 	}
 }
 

--- a/DXRando/DeusEx/Classes/Pinball.uc
+++ b/DXRando/DeusEx/Classes/Pinball.uc
@@ -4,13 +4,9 @@ var bool bAlreadyUsed;
 
 function Frob(actor Frobber, Inventory frobWith)
 {
-    local DXRando dxr;
-
     if (!bUsing && !bAlreadyUsed){
         bAlreadyUsed=True;
-        foreach AllActors(class'DXRando', dxr) {
-            class'DXREvents'.static.MarkBingo(dxr,"PinballWizard");
-        }
+        class'DXREvents'.static.MarkBingo("PinballWizard");
     }
 
     Super.Frob(Frobber,frobWith);

--- a/DXRando/DeusEx/Classes/PlayerDataItem.uc
+++ b/DXRando/DeusEx/Classes/PlayerDataItem.uc
@@ -185,14 +185,11 @@ simulated function bool MarkBingoAsFailed(string event)
 simulated function CheckForExpiredBingoGoals(int missionNum)
 {
     local int i;
-    local DXRando dxr;
-
-    foreach AllActors(class'DXRando', dxr) {break;}
 
     for(i=0; i<ArrayCount(bingo); i++) {
         if ((bingo_missions_masks[i] & FAILED_MISSION_MASK)!=0) continue; //Skip some extra looping in MarkBingoAsFailed
         if (class'DXREvents'.static.BingoActiveMission(missionNum, bingo_missions_masks[i])==-1){
-            class'DXREvents'.static.MarkBingoAsFailed(dxr,bingo[i].event);
+            class'DXREvents'.static.MarkBingoAsFailed(bingo[i].event);
         }
     }
 }

--- a/DXRando/DeusEx/Classes/PlayerDataItem.uc
+++ b/DXRando/DeusEx/Classes/PlayerDataItem.uc
@@ -109,7 +109,7 @@ simulated function int GetBingoSpot(
     progress = bingo[x*5+y].progress;
     max = bingo[x*5+y].max;
 
-    foreach AllActors(class'DXRando', dxr) { break; }
+    dxr = class'DXRando'.default.dxr;
     if(dxr == None) return 1;// 1==maybe
 
     currentMission = dxr.dxInfo.missionNumber;

--- a/DXRando/DeusEx/Classes/ShipsWheel.uc
+++ b/DXRando/DeusEx/Classes/ShipsWheel.uc
@@ -4,18 +4,15 @@ var bool bAlreadyUsed;
 
 function Frob(actor Frobber, Inventory frobWith)
 {
-	local #var(PlayerPawn) player;
-    local DXRando      dxr;
+    local #var(PlayerPawn) player;
 
-	Super.Frob(Frobber, frobWith);
+    Super.Frob(Frobber, frobWith);
 
-	player = #var(PlayerPawn)(Frobber);
+    player = #var(PlayerPawn)(Frobber);
     if (player!=None){
         if (!bAlreadyUsed){
             bAlreadyUsed = true;
-            foreach AllActors(class'DXRando', dxr) {
-                class'DXREvents'.static.MarkBingo(dxr,"SpinShipsWheel");
-            }
+            class'DXREvents'.static.MarkBingo("SpinShipsWheel");
         }
     }
 }

--- a/DXRando/DeusEx/Classes/ShowerFaucet.uc
+++ b/DXRando/DeusEx/Classes/ShowerFaucet.uc
@@ -3,7 +3,6 @@ class DXRShowerFaucet injects #var(prefix)ShowerFaucet;
 function Frob(actor Frobber, Inventory frobWith)
 {
 	local #var(PlayerPawn) player;
-    local DXRando      dxr;
     local bool         wasOnFire;
 
 	player = #var(PlayerPawn)(Frobber);
@@ -15,10 +14,7 @@ function Frob(actor Frobber, Inventory frobWith)
 	{
 		player.ClientMessage("Splish Splash!",, true);
 
-        foreach AllActors(class'DXRando', dxr) {
-            class'DXREvents'.static.ExtinguishFire(dxr,"shower",player);
-            break;
-        }
+        class'DXREvents'.static.ExtinguishFire("shower",player);
 	}
 }
 

--- a/DXRando/DeusEx/Classes/Toilet.uc
+++ b/DXRando/DeusEx/Classes/Toilet.uc
@@ -34,9 +34,7 @@ function Frob(actor Frobber, Inventory frobWith)
     if (player!=None){
         if (!bAlreadyUsed){
             bAlreadyUsed = true;
-            foreach AllActors(class'DXRando', dxr) {
-                class'DXREvents'.static.MarkBingo(dxr,"FlushToilet");
-            }
+            class'DXREvents'.static.MarkBingo("FlushToilet");
         }
     }
 }

--- a/DXRando/DeusEx/Classes/Toilet.uc
+++ b/DXRando/DeusEx/Classes/Toilet.uc
@@ -12,7 +12,6 @@ function BeginPlay()
 function Frob(actor Frobber, Inventory frobWith)
 {
 	local #var(PlayerPawn) player;
-    local DXRando      dxr;
 
 	Super.Frob(Frobber, frobWith);
 
@@ -22,13 +21,10 @@ function Frob(actor Frobber, Inventory frobWith)
 		player.ClientMessage("Splish Splash!",, true);
 		player.ExtinguishFire();
 
-        foreach AllActors(class'DXRando', dxr) {
-            if (SkinColor==SC_Clean){
-                class'DXREvents'.static.ExtinguishFire(dxr,"clean toilet",player);
-            } else {
-                class'DXREvents'.static.ExtinguishFire(dxr,"filthy toilet",player);
-            }
-            break;
+        if (SkinColor==SC_Clean){
+            class'DXREvents'.static.ExtinguishFire("clean toilet",player);
+        } else {
+            class'DXREvents'.static.ExtinguishFire("filthy toilet",player);
         }
 	}
     if (player!=None){

--- a/DXRando/DeusEx/Classes/Toilet2.uc
+++ b/DXRando/DeusEx/Classes/Toilet2.uc
@@ -27,9 +27,7 @@ function Frob(actor Frobber, Inventory frobWith)
     if (player!=None){
         if (!bAlreadyUsed){
             bAlreadyUsed = true;
-            foreach AllActors(class'DXRando', dxr) {
-                class'DXREvents'.static.MarkBingo(dxr,"FlushUrinal");
-            }
+            class'DXREvents'.static.MarkBingo("FlushUrinal");
         }
     }
 }

--- a/DXRando/DeusEx/Classes/Toilet2.uc
+++ b/DXRando/DeusEx/Classes/Toilet2.uc
@@ -5,7 +5,6 @@ var bool bAlreadyUsed;
 function Frob(actor Frobber, Inventory frobWith)
 {
 	local #var(PlayerPawn) player;
-    local DXRando      dxr;
 
 	Super.Frob(Frobber, frobWith);
 
@@ -15,13 +14,10 @@ function Frob(actor Frobber, Inventory frobWith)
 		player.ClientMessage("Splish Splash!",, true);
 		player.ExtinguishFire();
 
-        foreach AllActors(class'DXRando', dxr) {
-            if (SkinColor==SC_Clean){
-                class'DXREvents'.static.ExtinguishFire(dxr,"clean urinal",player);
-            } else {
-                class'DXREvents'.static.ExtinguishFire(dxr,"filthy urinal",player);
-            }
-            break;
+        if (SkinColor==SC_Clean){
+            class'DXREvents'.static.ExtinguishFire("clean urinal",player);
+        } else {
+            class'DXREvents'.static.ExtinguishFire("filthy urinal",player);
         }
     }
     if (player!=None){

--- a/DXRando/DeusEx/Classes/Trashbag.uc
+++ b/DXRando/DeusEx/Classes/Trashbag.uc
@@ -2,12 +2,8 @@ class DXRTrashbag injects #var(prefix)Trashbag;
 
 function Destroyed()
 {
-    local DXRando dxr;
-
     if (IsInState('Burning')){
-        foreach AllActors(class'DXRando',dxr){
-            class'DXREvents'.static.MarkBingo(dxr,"BurnTrash");
-        }
+        class'DXREvents'.static.MarkBingo("BurnTrash");
     }
 
     class'TrashContainerCommon'.static.DestroyTrashbag(self);

--- a/DXRando/DeusEx/Classes/Trashbag2.uc
+++ b/DXRando/DeusEx/Classes/Trashbag2.uc
@@ -2,12 +2,8 @@ class DXRTrashbag2 injects #var(prefix)Trashbag2;
 
 function Destroyed()
 {
-    local DXRando dxr;
-
     if (IsInState('Burning')){
-        foreach AllActors(class'DXRando',dxr){
-            class'DXREvents'.static.MarkBingo(dxr,"BurnTrash");
-        }
+        class'DXREvents'.static.MarkBingo("BurnTrash");
     }
 
     class'TrashContainerCommon'.static.DestroyTrashbag(self);

--- a/DXRando/DeusEx/Classes/WHPiano.uc
+++ b/DXRando/DeusEx/Classes/WHPiano.uc
@@ -84,18 +84,15 @@ simulated function Tick(float deltaTime)
 {
     if (bUsing){
         if (PlayDoneTime<=Level.TimeSeconds) {
-            if (dxr==None){
-                foreach AllActors(class'DXRando', dxr) {break;}
-            }
 
             if (!PianoIsBroken() && SongPlayed[currentSong]==0){
                 SongPlayed[currentSong]++;
-                class'DXREvents'.static.MarkBingo(dxr,"PianoSong"$currentSong$"Played");
+                class'DXREvents'.static.MarkBingo("PianoSong"$currentSong$"Played");
                 if (ValidSong(currentSong)){
-                    class'DXREvents'.static.MarkBingo(dxr,"PianoSongPlayed");
+                    class'DXREvents'.static.MarkBingo("PianoSongPlayed");
                 }
             } else if (currentSong==BROKEN_PIANO_SONG) {
-                class'DXREvents'.static.MarkBingo(dxr,"BrokenPianoPlayed");
+                class'DXREvents'.static.MarkBingo("BrokenPianoPlayed");
             }
 
             if(player != None) {

--- a/DXRando/DeusEx/Classes/WaterCooler.uc
+++ b/DXRando/DeusEx/Classes/WaterCooler.uc
@@ -7,7 +7,6 @@ function Frob(Actor Frobber, Inventory frobWith)
 {
     local bool oldUsing, newUsing;
     local int oldNumUses;
-    local DXRando dxr;
     local bool chugged;
 
 #ifdef hx
@@ -37,9 +36,7 @@ function Frob(Actor Frobber, Inventory frobWith)
         if (chugged)
         {
             PlayDrown(Frobber);
-            foreach AllActors(class'DXRando', dxr) {
-                class'DXREvents'.static.MarkBingo(dxr,"ChugWater");
-            }
+            class'DXREvents'.static.MarkBingo("ChugWater");
         }
     }
 }
@@ -68,11 +65,7 @@ simulated static function PlayDrown(Actor a)
 
 function Destroyed()
 {
-    local DXRando dxr;
-
-    foreach AllActors(class'DXRando', dxr) {
-        class'DXREvents'.static.MarkBingo(dxr,"Dehydrated");
-    }
+    class'DXREvents'.static.MarkBingo("Dehydrated");
 
     Super.Destroyed();
 }

--- a/DXRando/DeusEx/Classes/WaterFountain.uc
+++ b/DXRando/DeusEx/Classes/WaterFountain.uc
@@ -7,7 +7,6 @@ function Frob(Actor Frobber, Inventory frobWith)
 {
     local bool oldUsing, newUsing;
     local int oldNumUses;
-    local DXRando dxr;
     local bool chugged;
 
 #ifdef hx
@@ -41,20 +40,14 @@ function Frob(Actor Frobber, Inventory frobWith)
 #else
             class'DXRWaterCooler'.static.PlayDrown(Frobber);
 #endif
-            foreach AllActors(class'DXRando', dxr) {
-                class'DXREvents'.static.MarkBingo(dxr,"ChugWater");
-            }
+            class'DXREvents'.static.MarkBingo("ChugWater");
         }
     }
 }
 
 function Destroyed()
 {
-    local DXRando dxr;
-
-    foreach AllActors(class'DXRando', dxr) {
-        class'DXREvents'.static.MarkBingo(dxr,"Dehydrated");
-    }
+    class'DXREvents'.static.MarkBingo("Dehydrated");
 
     Super.Destroyed();
 }

--- a/GUI/DeusEx/Classes/FrobDisplayWindow.uc
+++ b/GUI/DeusEx/Classes/FrobDisplayWindow.uc
@@ -31,7 +31,7 @@ function CheckSettings()
 
     if( player == None || player.FlagBase == None ) return;
 
-    foreach player.AllActors(class'DXRando',dxr){break;}
+    dxr = class'DXRando'.default.dxr;
     if (dxr==None) return;
 
     inited = true;

--- a/GUI/DeusEx/Classes/PersonaScreenAugmentations.uc
+++ b/GUI/DeusEx/Classes/PersonaScreenAugmentations.uc
@@ -60,7 +60,6 @@ function UpgradeAugmentation()
     local AugmentationUpgradeCannister augCan;
     local bool wasFrobTarget;
     local int levelBefore;
-    local DXRando dxr;
 
     if (selectedAug!=None){
         levelBefore = selectedAug.CurrentLevel;
@@ -107,11 +106,9 @@ function UpgradeAugmentation()
 
     if (selectedAug!=None){
         if (selectedAug.CurrentLevel!=levelBefore){
-            foreach player.AllActors(class'DXRando',dxr){break;}
-            class'DXREvents'.static.MarkBingo(dxr,"AugUpgraded"); //General "Upgrade x augs" kind of situation
-            class'DXREvents'.static.MarkBingo(dxr,selectedAug.Class.Name$"Upgraded"); //aug-specific upgrade goals
-            class'DXREvents'.static.MarkBingo(dxr,"AugLevel"$(selectedAug.CurrentLevel+1)); //"Get X Augs to level Y" type goals
-
+            class'DXREvents'.static.MarkBingo("AugUpgraded"); //General "Upgrade x augs" kind of situation
+            class'DXREvents'.static.MarkBingo(selectedAug.Class.Name$"Upgraded"); //aug-specific upgrade goals
+            class'DXREvents'.static.MarkBingo("AugLevel"$(selectedAug.CurrentLevel+1)); //"Get X Augs to level Y" type goals
         }
     }
 }

--- a/GUI/DeusEx/Classes/PersonaScreenBingo.uc
+++ b/GUI/DeusEx/Classes/PersonaScreenBingo.uc
@@ -116,7 +116,7 @@ function ShowBingoGoalHelp( Window bingoTile )
 
     msgbox = BingoHintMsgBox(root.PushWindow(class'BingoHintMsgBox',False));
     if(#defined(bingocheat)) {
-        class'DXREvents'.static.MarkBingo(class'DXRando'.default.dxr, bt.event);
+        class'DXREvents'.static.MarkBingo(bt.event);
         bt.progress++;
     }
     msgbox.SetTitle(bt.GetText());

--- a/GUI/DeusEx/Classes/PersonaScreenGoals.uc
+++ b/GUI/DeusEx/Classes/PersonaScreenGoals.uc
@@ -32,7 +32,8 @@ function CreateControls()
 
     CreateKeysAndDatacubesButtons();
 
-    foreach player.AllActors(class'DXRando',dxr){
+    dxr = class'DXRando'.default.dxr;
+    if (dxr!=None){
         if (dxr.flags.settings.goals > 0) {
             btnGoalHints = PersonaActionButtonWindow(winClient.NewChild(Class'DXRPersonaActionButtonWindow'));
             btnGoalHints.SetButtonText("|&Goal Randomization Wiki");
@@ -63,7 +64,6 @@ function CreateControls()
                 btnEntranceSpoilers.SetSensitivity(true);
             }
         }
-        break;
     }
 }
 

--- a/GUI/DeusEx/Classes/PersonaScreenImages.uc
+++ b/GUI/DeusEx/Classes/PersonaScreenImages.uc
@@ -232,7 +232,6 @@ function ClearViewedImageFlags()
 function MarkViewed(DataVaultImage newImage)
 {
     local string bingoName;
-    local DXRando dxr;
 
     if (newImage!=None && newImage.bPlayerViewedImage==False){
         bingoName = newImage.imageDescription;
@@ -242,9 +241,7 @@ function MarkViewed(DataVaultImage newImage)
         bingoName = class'DXRInfo'.static.ReplaceText(bingoName,",","");
         bingoName = "ImageOpened_"$bingoName;
 
-        foreach newImage.AllActors(class'DXRando', dxr) {
-            class'DXREvents'.static.MarkBingo(dxr,bingoName);
-        }
+        class'DXREvents'.static.MarkBingo(bingoName);
 
         newImage.bPlayerViewedImage = True;
     }

--- a/GUI/DeusEx/Classes/PersonaScreenSkills.uc
+++ b/GUI/DeusEx/Classes/PersonaScreenSkills.uc
@@ -61,7 +61,6 @@ static function UpdateSwimSpeed(Skill s, #var(prefix)Human p)
 function UpgradeSkill()
 {
     local int levelBefore;
-    local DXRando dxr;
 
     if (selectedSkill!=None){
         levelBefore=selectedSkill.CurrentLevel;
@@ -74,10 +73,9 @@ function UpgradeSkill()
     if (selectedSkill!=None){
         if (selectedSkill.CurrentLevel!=levelBefore){
             //Skill upgraded
-            foreach player.AllActors(class'DXRando',dxr){break;}
-            class'DXREvents'.static.MarkBingo(dxr,"SkillUpgraded"); //General "Upgrade x skills" kind of situation
-            class'DXREvents'.static.MarkBingo(dxr,selectedSkill.Class.Name$"Upgraded"); //Skill-specific upgrade goals
-            class'DXREvents'.static.MarkBingo(dxr,"SkillLevel"$(selectedSkill.CurrentLevel+1)); //"Get X skills to level Y" type goals
+            class'DXREvents'.static.MarkBingo("SkillUpgraded"); //General "Upgrade x skills" kind of situation
+            class'DXREvents'.static.MarkBingo(selectedSkill.Class.Name$"Upgraded"); //Skill-specific upgrade goals
+            class'DXREvents'.static.MarkBingo("SkillLevel"$(selectedSkill.CurrentLevel+1)); //"Get X skills to level Y" type goals
         }
     }
 }

--- a/GUI/DeusEx/Classes/ScopeView.uc
+++ b/GUI/DeusEx/Classes/ScopeView.uc
@@ -77,7 +77,6 @@ simulated function PeepTimer(int timerID, int invocations, int clientData)
     local Vector HitNormal, HitLocation, StartTrace, EndTrace;
     local Actor peepee;// pronounced peep-ee, not pee-pee
     local Actor target;
-    local DXRando dxr;
     local bool newPeepee, newPeepTex;
     local name texName,texGroup;
     local int flags, i;
@@ -120,12 +119,6 @@ simulated function PeepTimer(int timerID, int invocations, int clientData)
 
     //peeper.ClientMessage("Peeping "$peepee.Name$" in state "$peepee.GetStateName());
 
-    foreach Player.AllActors(class'DXRando', dxr) {break;}
-
-    if (dxr==None){
-        return;
-    }
-
     if(peepee.IsA('LevelInfo')){
         peepee=None;
     }
@@ -157,11 +150,11 @@ simulated function PeepTimer(int timerID, int invocations, int clientData)
     if (newPeepee){
         //peeper.ClientMessage("New peeped actor is "$peepee.class.Name);
         //This should probably only trigger once per thing - TODO, will probably be tracked in DXREvents and PlayerDataItem, like function ReadText(name textTag)
-        class'DXREvents'.static.MarkBingo(dxr,peepee.Class.Name$"_peeped");
+        class'DXREvents'.static.MarkBingo(peepee.Class.Name$"_peeped");
 
         if (ScriptedPawn(peepee)!=None){
-            class'DXREvents'.static.MarkBingo(dxr,"PawnState_"$peepee.GetStateName());
-            class'DXREvents'.static.MarkBingo(dxr,"PawnAnim_"$peepee.AnimSequence);
+            class'DXREvents'.static.MarkBingo("PawnState_"$peepee.GetStateName());
+            class'DXREvents'.static.MarkBingo("PawnAnim_"$peepee.AnimSequence);
         }
 
         if (BingoTrigger(peepee)!=None){
@@ -169,12 +162,12 @@ simulated function PeepTimer(int timerID, int invocations, int clientData)
         }
     } else if (newPeepTex) {
         //peeper.ClientMessage("New peeped texture is "$lastWatchedTex);
-        class'DXREvents'.static.MarkBingo(dxr,lastWatchedTex$"_peepedtex");
+        class'DXREvents'.static.MarkBingo(lastWatchedTex$"_peepedtex");
     } else {
         watchTime++;
         if(watchTime>=4){
             watchTime=0;
-            class'DXREvents'.static.MarkBingo(dxr,peepee.Class.Name$"_peeptime");
+            class'DXREvents'.static.MarkBingo(peepee.Class.Name$"_peeptime");
         }
     }
 }

--- a/Pawns/DeusEx/Classes/Merchant.uc
+++ b/Pawns/DeusEx/Classes/Merchant.uc
@@ -34,10 +34,7 @@ function EnterConversationState(bool bFirstPerson, optional bool bAvoidState)
     local int newHint;
     local string hint, details;
 
-    foreach AllActors(class'DXRando', dxr) {
-        hints = DXRHints(dxr.FindModule(class'DXRHints'));
-        break;
-    }
+    hints = DXRHints(class'DXRHints'.static.Find());
 
     con = ConListItem(ConListItems).con;
 


### PR DESCRIPTION
# Major changes since v3.1.1

- New game modes: Halloween Mode, WaltonWare Halloween, and Zombies Horde Mode
  - Rough draft trailer: https://www.youtube.com/watch?v=cXOSsPtoQss
  - Mr H is immortal but you can hurt him to make him run away for a bit
  - Zombies!
  - You need to loot your Halloween costumes...

# Minor changes since v3.2.0.0 Alpha

- Fixed FOV adjustments for assault shotgun and DTS
- Tweaks with Mr H
- Area 51 gray room Geiger sound is quieter after generators are turned off
- Fixes for goal texts being updated
- Some zombie fixes
- Added a public terminal to Brooklyn Bridge Station to help with fixed saving modes
- Limited saving modes start with 2 memory containment units instead of 1
- NG+ Halloween modes no longer enable respawning enemies (because they already have zombies)
- Never add extra spaces around passwords
- Fixed locations for nanokeys in Paris street/metro, and added a key for the media store
- Added a spotlight in the Paris Media Store when a goal character is inside
- Prevent quick consume from using more than one in a stack
- Elevators now have more consistent movement speeds
- More fixes for various mid-mission start locations in WaltonWare

# Minor changes since v3.1.1

- Slightly increased Payphone collision radius as a lazy fix for badly placed payphones
- Fixes for weapon display on high FOV
- DXRMissions smarter mutual exclusions for fewer retries
- Maintain Paris Chill % across NG+ loops
- Improvements to handling of failed bingo goals
- New option to show or hide messages about bingo progress
- Fixes for more mid-mission starts in WaltonWare
- 03_NYC_AIRFIELDHELIBASE disable camera and turrets after finishing 747
- Fixed issues with upgrading active augs