### PR TITLE
v3.2.0.2 Beta

### DIFF
--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -1734,7 +1734,7 @@ static function Actor GlowUp(Actor a, optional byte hue, optional byte saturatio
 function DebugMarkKeyActor(Actor a, coerce string id)
 {
     local ActorDisplayWindow actorDisplay;
-    if( ! #defined(locdebug)) {
+    if( ! #bool(locdebug)) {
         err("Don't call DebugMarkKeyActor without locdebug mode! Add locdebug to the compiler_settings.default.json file");
         return;
     }
@@ -1760,7 +1760,7 @@ function DebugMarkKeyPosition(vector pos, coerce string id)
 {
     local ActorDisplayWindow actorDisplay;
     local Actor a;
-    if( ! #defined(locdebug)) {
+    if( ! #bool(locdebug)) {
         err("Don't call DebugMarkKeyPosition without locdebug mode! Add locdebug to the compiler_settings.default.json file");
         return;
     }

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -1711,6 +1711,17 @@ function bool PositionIsSafeLenient(Vector oldloc, Actor test, Vector newloc)
     return _PositionIsSafeOctant(oldloc, GetCenter(test), newloc);
 }
 
+function RemoveDXMoverPrePivot(#var(DeusExPrefix)Mover dxm)
+{
+    local vector pivot;
+    local rotator r;
+
+    pivot = dxm.PrePivot >> dxm.Rotation;
+    dxm.BasePos = dxm.BasePos - vectm(pivot.X,pivot.Y,pivot.Z);
+    dxm.PrePivot=vect(0,0,0);
+    dxm.SetLocation(dxm.BasePos);
+}
+
 static function Actor GlowUp(Actor a, optional byte hue, optional byte saturation)
 {
     // if `a` is a datacube, spawn a new light instead

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -48,6 +48,11 @@ function SwapAll(string classname, float percent_chance)
         temp[num++] = a;
     }
 
+    if(num<2) {
+        l("SwapAll(" $ classname $ ", " $ percent_chance $ ") only found " $ num);
+        return;
+    }
+
     for(i=0; i<num; i++) {
         if( percent_chance<100 && !chance_single(percent_chance) ) continue;
         slot=rng(num-1);// -1 because we skip ourself

--- a/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -1309,6 +1309,8 @@ function vector GetRandomPosition(optional vector target, optional float mindist
         maxdist = 9999999;
 
     foreach RadiusActors(class'NavigationPoint', p, maxdist, target) {
+        if(Teleporter(p)!=None) continue;
+        if(MapExit(p)!=None) continue;
         if( (!allowSky) && p.Region.Zone.IsA('SkyZoneInfo') ) continue;
         if( (!allowWater) && p.Region.Zone.bWaterZone ) continue;
         if( (!allowPain) && (p.Region.Zone.bKillZone || p.Region.Zone.bPainZone ) ) continue;

--- a/DXRCore/DeusEx/Classes/DXRBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRBase.uc
@@ -41,6 +41,7 @@ simulated function DXRando GetDXR()
 
 static function DXRBase Find()
 {
+    if(class'DXRando'.default.dxr == None) return None;
     return class'DXRando'.default.dxr.FindModule(default.class);
 }
 

--- a/DXRCore/DeusEx/Classes/DXRInfo.uc
+++ b/DXRCore/DeusEx/Classes/DXRInfo.uc
@@ -58,14 +58,13 @@ simulated final function #var(PlayerPawn) player(optional bool quiet)
     local #var(PlayerPawn) p;
     local DXRando dxr;
     dxr = GetDXR();
-    //p = #var(PlayerPawn)(GetPlayerPawn());
-    p = dxr.Player;
+    if(dxr != None) p = dxr.Player;
     if( p == None ) {
         p = #var(PlayerPawn)(GetPlayerPawn());
         if(p==None){ //If GetPlayerPawn() didn't work (probably in HX)
             foreach AllActors(class'#var(PlayerPawn)', p){break;}
         }
-        dxr.Player = p;
+        if(dxr != None) dxr.Player = p;
     }
     if( p == None && !quiet ) warning("player() found None");
     return p;
@@ -227,7 +226,7 @@ function bool OnTitleScreen()
 {
     local DXRando dxr;
     dxr = class'DXRando'.default.dxr;
-
+    if(dxr == None) return true;
     return dxr.LocalURL=="DX" || dxr.LocalURL=="DXONLY";
 }
 

--- a/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -174,7 +174,7 @@ function string SetEnumValue(int e, string text)
     // HACK: this allows you to override the autosave option instead of SetDifficulty forcing it by game mode
     Super.SetEnumValue(e, text);
     if(e == gamemode_enum && #defined(injections)) {
-        if(InStr(text, "Halloween Mode")==0 || InStr(text, "WaltonWare Halloween")==0)
+        if(InStr(text, "Halloween")!=-1)
         {
             Super.SetEnumValue(autosave_enum, "Limited Fixed Saves");
         }

--- a/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -139,6 +139,9 @@ function BindControls(optional string action)
         NewMenuItem("", "Use the installer to download the mirrored map files, or go to the unreal-map-flipper Releases page on Github");
         EnumOption("Mirror Map Files Not Found", -1, f.mirroredmaps);
     }
+#else
+    //Disable mirrored maps entirely if map variants aren't supported
+    f.mirroredmaps=-1;
 #endif
 
     NewMenuItem("Seed", "Enter a seed if you want to play the same game again. Leave it blank for a random seed.");

--- a/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
@@ -247,7 +247,7 @@ function BindControls(optional string action)
     NewMenuItem("Non-Human Chance %", "Reduce the chance of new enemies being non-humans.");
     Slider(f.settings.enemies_nonhumans, 0, 100);
 
-    NewMenuItem("Enemy Respawn Seconds", "(Beta) How many seconds for enemies to respawn. Leave blank or 0 to disable.");
+    NewMenuItem("Enemy Respawn Seconds", "How many seconds for enemies to respawn. Leave blank or 0 to disable.");
     Slider(f.settings.enemyrespawn, 0, 10000);
 
     NewMenuItem("Move Turrets", "Randomizes locations of turrets, cameras, and security computers for them.");

--- a/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -62,13 +62,16 @@ simulated static function int VersionNumber()
 
 simulated static function bool FeatureFlag(int major, int minor, int patch, string feature)
 {
-    #ifdef allfeatures
-        return true;
-    #elseif enablefeature
+    if(#bool(allfeatures)) return true;
+    #ifdef enablefeature
         if("#var(enablefeature)" == feature) return true;
     #endif
 
-    return VersionNumber() >= VersionToInt(major, minor, patch, 0);
+    if(VersionNumber() >= VersionToInt(major, minor, patch, 0)) {
+        log("WARNING: FeatureFlag " $ feature $ " only requires v" $ major $ "." $ minor $ "." $ patch, default.class.name);
+        return true;
+    }
+    return false;
 }
 
 simulated static function bool VersionOlderThan(int config_version, int major, int minor, int patch, int build)

--- a/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -60,7 +60,7 @@ simulated static function int VersionNumber()
     return VersionToInt(major, minor, patch, build);
 }
 
-simulated static function bool FeatureFlag(int major, int minor, int patch, string feature)
+simulated static function bool FeatureFlag(int major, int minor, int patch, string feature) // make sure to have an issue in GitHub with the feature flag name! and it should be attached to a milestone
 {
     if(#bool(allfeatures)) return true;
     #ifdef enablefeature

--- a/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -60,6 +60,17 @@ simulated static function int VersionNumber()
     return VersionToInt(major, minor, patch, build);
 }
 
+simulated static function bool FeatureFlag(int major, int minor, int patch, string feature)
+{
+    #ifdef allfeatures
+        return true;
+    #elseif enablefeature
+        if("#var(enablefeature)" == feature) return true;
+    #endif
+
+    return VersionNumber() >= VersionToInt(major, minor, patch, 0);
+}
+
 simulated static function bool VersionOlderThan(int config_version, int major, int minor, int patch, int build)
 {
     return config_version < VersionToInt(major, minor, patch, build);

--- a/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -5,7 +5,7 @@ simulated static function CurrentVersion(optional out int major, optional out in
     major=3;
     minor=2;
     patch=0;
-    build=1;//build can't be higher than 99
+    build=2;//build can't be higher than 99
 }
 
 simulated static function bool VersionIsStable()

--- a/DXRFixes/DeusEx/Classes/ElevatorMover.uc
+++ b/DXRFixes/DeusEx/Classes/ElevatorMover.uc
@@ -8,7 +8,7 @@ var bool initialized;
 function Initialize()
 {
     local SequenceTrigger st;
-    local float dist, maxDist, avgDist, distSum;
+    local float dist, maxDist, maxDist2, avgDist, distSum;
     local int validKeyPos[8];
     local int i, j;
 
@@ -34,13 +34,18 @@ function Initialize()
     for (i = 0; i < numKeyPos; i++) {
         for (j = i + 1; j < numKeyPos; j++) {
             dist = VSize(KeyPos[validKeyPos[i]] - KeyPos[validKeyPos[j]]);
-            maxDist = FMax(maxDist, dist);
+            if(dist > maxDist) {
+                maxDist2 = maxDist;
+                maxDist = dist;
+            } else if(dist > maxDist2) {
+                maxDist2 = dist;
+            }
             distSum += dist;
         }
     }
 
     avgDist = distSum / (numKeyPos * (numKeyPos - 1) / 2.0);
-    moveSpeed = (maxDist*0.33 + avgDist*0.67) / MoveTime;
+    moveSpeed = (maxDist*0.5 + maxDist2*0.5) / MoveTime;
     originalMoveTime = MoveTime;
 
     initialized = true;

--- a/DXRFixes/DeusEx/Classes/ElevatorMover.uc
+++ b/DXRFixes/DeusEx/Classes/ElevatorMover.uc
@@ -2,7 +2,7 @@ class ElevatorMover merges ElevatorMover;
 // can't do injects because it uses a state
 
 var float lastTime, moveSpeed, originalMoveTime;
-var int numKeyPos;
+var int numKeyPos, prevSeqNum;
 var bool initialized;
 
 function Initialize()
@@ -68,7 +68,7 @@ function SetSeq(int seqnum)
 
     Initialize();
 
-    if( MoveTime/10 < Level.TimeSeconds-lastTime )
+    if( seqnum != prevSeqNum && MoveTime/3 < Level.TimeSeconds-lastTime ) // HACK: for 12_vandenberg_cmd elevator
         oldSeq = true;
 
     if ( bIsMoving && !oldSeq )
@@ -81,6 +81,7 @@ function SetSeq(int seqnum)
 
     if (KeyNum != seqnum || oldSeq)
     {
+        prevSeqNum = seqnum;
         prevKeyNum = KeyNum;
         KeyNum = seqnum;
 
@@ -90,4 +91,9 @@ function SetSeq(int seqnum)
             bIsMoving = false;
         else lastTime = Level.TimeSeconds;
     }
+}
+
+defaultproperties
+{
+    prevSeqNum=-1
 }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
@@ -6,8 +6,6 @@ function PostFirstEntryMapFixes()
     local DeusExMover m;
     local BlockPlayer bp;
 
-    FixUNATCORetinalScanner();
-
     switch(dxr.localURL) {
     case "01_NYC_UNATCOISLAND":
         AddBox(class'#var(prefix)CrateUnbreakableSmall', vectm(6720.866211, -3346.700684, -445.899597));// electrical hut
@@ -28,8 +26,10 @@ function PostFirstEntryMapFixes()
         SetAllLampsState(,, false, vect(3313.0954215, -1662.294768, -176.938141), 0.01);
 
         break;
+    case "01_NYC_UNATCOHQ":
+        FixUNATCORetinalScanner();
+        break;
     }
-
 }
 
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -20,9 +20,13 @@ function PostFirstEntryMapFixes()
 
     RevisionMaps = class'DXRMapVariants'.static.IsRevisionMaps(player());
 
-    FixUNATCORetinalScanner();
-
     switch(dxr.localURL) {
+    case "03_NYC_UNATCOHQ":
+        FixUNATCORetinalScanner();
+        break;
+    case "03_NYC_BatteryPark":
+        player().StartDataLinkTransmission("dl_batterypark");
+        break;
     case "03_NYC_BrooklynBridgeStation":
         if (!RevisionMaps){
             a = AddActor(class'Barrel1', vect(-27.953907, -3493.229980, 45.101418));

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -383,7 +383,20 @@ function PreFirstEntryMapFixes()
 
 function PostFirstEntryMapFixes()
 {
-    FixUNATCORetinalScanner();
+    local DeusExGoal goal;
+
+    switch(dxr.localURL)
+    {
+        case "04_NYC_UNATCOHQ":
+            FixUNATCORetinalScanner();
+            break;
+        case "04_NYC_STREET":
+            goal = player().FindGoal('TellJaime');
+            if (goal != None) {
+                goal.SetCompleted();
+            }
+            break;
+    }
 }
 
 function AnyEntryMapFixes()

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -331,16 +331,26 @@ function BalanceJailbreak()
 
         else {
             // put the items in the surgery ward
-            itemLocations[num++] = vectm(2175,-569,-203);// paul's bed
-            itemLocations[num++] = vectm(2175,-518,-203);// paul's bed
-            itemLocations[num++] = vectm(1792,-738,-203);// bed 2
-            itemLocations[num++] = vectm(1792,-802,-203);// bed 2
-            itemLocations[num++] = vectm(1570,-739,-203);// bed 1
-            itemLocations[num++] = vectm(1570,-801,-203);// bed 1
+            itemLocations[num++] = vectm(2160,-585,-203);// paul's bed
+            itemLocations[num++] = vectm(2160,-505,-203);// paul's bed
+            itemLocations[num++] = vectm(1805,-730,-203);// middle bed
+            itemLocations[num++] = vectm(1805,-810,-203);// middle bed
+            itemLocations[num++] = vectm(1555,-730,-203);// bed near ambrosia
+            itemLocations[num++] = vectm(1555,-810,-203);// bed near ambrosia
+
+            //Third bed locations
+            itemLocations[num++] = vectm(2190,-545,-203);// paul's bed
+            itemLocations[num++] = vectm(1775,-770,-203);// middle bed
+            itemLocations[num++] = vectm(1585,-770,-203);// bed near ambrosia
+
+
             itemLocations[num++] = vectm(1270,-522,-211);// near ambrosia
-            itemLocations[num++] = vectm(1909,-376,-211);// desk with microscope and datacube
-            itemLocations[num++] = vectm(2160,-327,-211);// table with two monitors
-            itemLocations[num++] = vectm(2055,-327,-211);// table with two monitors
+            itemLocations[num++] = vectm(1275,-710,-211);// table with two microscopes and datacube (left)
+            itemLocations[num++] = vectm(1275,-805,-211);// table with two microscopes and datacube (right)
+            itemLocations[num++] = vectm(1910,-375,-211);// desk with microscope and datacube
+            itemLocations[num++] = vectm(2160,-327,-211);// table with two monitors (left)
+            itemLocations[num++] = vectm(2055,-327,-211);// table with two monitors (right)
+            itemLocations[num++] = vectm(2110,-327,-211);// table with two monitors (middle)
 
             // on the floor, at the wall with the monitors, starting in the center, working out
             itemLocations[num++] = vectm(1575,-950,-251);
@@ -360,13 +370,6 @@ function BalanceJailbreak()
             itemLocations[num++] = vectm(1500,-900,-251);
             itemLocations[num++] = vectm(1725,-900,-251);
             itemLocations[num++] = vectm(1425,-900,-251);
-            itemLocations[num++] = vectm(1800,-900,-251);
-            itemLocations[num++] = vectm(1350,-900,-251);
-            itemLocations[num++] = vectm(1875,-900,-251);
-            itemLocations[num++] = vectm(1275,-900,-251);
-
-            itemLocations[num++] = vectm(1275,-850,-251); // continuing towards the ambrosia along the wall
-            itemLocations[num++] = vectm(1350,-850,-251);
 
             foreach AllActors(class'#var(prefix)DataLinkTrigger', dlt) {
                 if(dlt.datalinkTag != 'dl_equipment') continue;

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -331,18 +331,42 @@ function BalanceJailbreak()
 
         else {
             // put the items in the surgery ward
-            itemLocations[num++] = vectm(2174.416504,-569.534729,-213.660309);// paul's bed
-            itemLocations[num++] = vectm(2176.658936,-518.937012,-213.659302);// paul's bed
-            itemLocations[num++] = vectm(1792.696533,-738.417175,-213.660248);// bed 2
-            itemLocations[num++] = vectm(1794.898682,-802.133301,-213.658630);// bed 2
-            itemLocations[num++] = vectm(1572.443237,-739.527649,-213.660095);// bed 1
-            itemLocations[num++] = vectm(1570.557007,-801.213806,-213.660095);// bed 1
-            itemLocations[num++] = vectm(1269.494019,-522.082458,-221.659180);// near ambrosia
-            itemLocations[num++] = vectm(1909.302979,-376.711639,-221.660095);// desk with microscope and datacube
-            itemLocations[num++] = vectm(1572.411865,-967.828735,-261.659546);// on the floor, at the wall with the monitors
-            itemLocations[num++] = vectm(1642.170532,-968.813354,-261.660736);
-            itemLocations[num++] = vectm(1715.513062,-965.846558,-261.657837);
-            itemLocations[num++] = vectm(1782.731689,-966.754700,-261.661041);
+            itemLocations[num++] = vectm(2175,-569,-203);// paul's bed
+            itemLocations[num++] = vectm(2175,-518,-203);// paul's bed
+            itemLocations[num++] = vectm(1792,-738,-203);// bed 2
+            itemLocations[num++] = vectm(1792,-802,-203);// bed 2
+            itemLocations[num++] = vectm(1570,-739,-203);// bed 1
+            itemLocations[num++] = vectm(1570,-801,-203);// bed 1
+            itemLocations[num++] = vectm(1270,-522,-211);// near ambrosia
+            itemLocations[num++] = vectm(1909,-376,-211);// desk with microscope and datacube
+            itemLocations[num++] = vectm(2160,-327,-211);// table with two monitors
+            itemLocations[num++] = vectm(2055,-327,-211);// table with two monitors
+
+            // on the floor, at the wall with the monitors, starting in the center, working out
+            itemLocations[num++] = vectm(1575,-950,-251);
+            itemLocations[num++] = vectm(1650,-950,-251);
+            itemLocations[num++] = vectm(1500,-950,-251);
+            itemLocations[num++] = vectm(1725,-950,-251);
+            itemLocations[num++] = vectm(1425,-950,-251);
+            itemLocations[num++] = vectm(1800,-950,-251);
+            itemLocations[num++] = vectm(1350,-950,-251);
+            itemLocations[num++] = vectm(1875,-950,-251);
+            itemLocations[num++] = vectm(1275,-950,-251);
+
+            // seriously, why do you have so much stuff, I never want to see these spots get used
+            // on the floor, at the wall with the monitors, emergency second row
+            itemLocations[num++] = vectm(1575,-900,-251);
+            itemLocations[num++] = vectm(1650,-900,-251);
+            itemLocations[num++] = vectm(1500,-900,-251);
+            itemLocations[num++] = vectm(1725,-900,-251);
+            itemLocations[num++] = vectm(1425,-900,-251);
+            itemLocations[num++] = vectm(1800,-900,-251);
+            itemLocations[num++] = vectm(1350,-900,-251);
+            itemLocations[num++] = vectm(1875,-900,-251);
+            itemLocations[num++] = vectm(1275,-900,-251);
+
+            itemLocations[num++] = vectm(1275,-850,-251); // continuing towards the ambrosia along the wall
+            itemLocations[num++] = vectm(1350,-850,-251);
 
             foreach AllActors(class'#var(prefix)DataLinkTrigger', dlt) {
                 if(dlt.datalinkTag != 'dl_equipment') continue;

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -4,6 +4,7 @@ var bool raidStarted;
 
 function CheckConfig()
 {
+    local Rotator rot;
     local int i;
 
     add_datacubes[i].map = "06_HONGKONG_VERSALIFE";
@@ -20,6 +21,13 @@ function CheckConfig()
 
     add_datacubes[i].map = "06_HONGKONG_WANCHAI_STREET";
     add_datacubes[i].text = "It's so handy being able to quickly grab some cash from the Quick Stop before getting to the club!|nAccount: 2332316 |nPIN: 1608 ";
+    i++;
+
+    add_datacubes[i].map = "06_HONGKONG_WANCHAI_STREET";
+    add_datacubes[i].text = "Miss Chow,|nOur agents have ascertained the access codes to the police evidence vault in the market.  When you are ready, our agents can enter the vault and remove the evidence located within using the code 87342.|n|nCommander Triolet";
+    add_datacubes[i].Location = vect(-300.4, -1544.0, 1970.4);
+    rot.Yaw = -2250.0;
+    add_datacubes[i].rotation = rot;
     i++;
 
     add_datacubes[i].map = "06_HONGKONG_WANCHAI_UNDERWORLD";
@@ -841,7 +849,10 @@ function AnyEntryMapFixes()
     local ConEventSpeech ces;
     local ConEventSetFlag cesf;
     local ConEventTrigger cet;
+    local OrdersTrigger ot;
     local #var(prefix)Pigeon pigeon;
+    local #var(prefix)MaggieChow maggie;
+    local #var(prefix)Maid maysung;
 
     // if flag Have_ROM, set flags Have_Evidence and KnowsAboutNanoSword?
     // or if flag Have_ROM, Gordon Quick should let you into the compound? requires Have_Evidence and MaxChenConvinced
@@ -953,8 +964,23 @@ function AnyEntryMapFixes()
             m.bLocked = false;
             m.bHighlight = true;
         }
+
         HandleJohnSmithDeath();
         FixMaggieMoveSpeed();
+
+        if (dxr.flagbase.GetBool('MaxChenConvinced')) {
+            foreach AllActors(class'#var(prefix)MaggieChow', maggie) {
+                maggie.LeaveWorld();
+                break;
+            }
+
+            dxr.flagbase.SetBool('MeetMaySung_Played', true);
+            foreach AllActors(class'OrdersTrigger', ot, 'MaySungFollows') {
+                ot.Trigger(None, None);
+                break;
+            }
+        }
+
         break;
 
     case "06_HONGKONG_WANCHAI_CANAL":

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
@@ -18,7 +18,6 @@ function AnyEntryMapFixes()
             RemoveReactions(s);
         }
 
-        Player().StartDataLinkTransmission("DL_Entry");
         RearrangeMJ12ConvergingInfolink();
         RearrangeJockExitDialog();
 
@@ -301,4 +300,9 @@ function PreFirstEntryMapFixes()
                 }
             }
     }
+}
+
+function PostFirstEntryMapFixes()
+{
+    Player().StartDataLinkTransmission("DL_Entry"); // play on any start
 }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
@@ -617,6 +617,25 @@ function AnyEntryMapFixes()
     }
 }
 
+
+function PostFirstEntryMapFixes()
+{
+    local #var(prefix)Keypad k;
+
+    switch(dxr.localURL) {
+    case "15_area51_final":
+        if(dxr.flags.IsSpeedrunMode() && FeatureFlag(3,3,0, "Area51EndingBalancePass2")) {
+            foreach AllActors(class'#var(prefix)Keypad', k) {
+                if(k.Event == 'blastdoor_upper') {
+                    k.bHackable = false;
+                    break;
+                }
+            }
+        }
+        break;
+    }
+}
+
 function TimerMapFixes()
 {
     switch(dxr.localURL)

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
@@ -233,9 +233,7 @@ function PreFirstEntryMapFixes()
 
                     //Fix prepivot, since the upper door was set way off to the side.  Just adjust both in the same way
                     //so that they are centered roughly in the middle of the door
-                    door.BasePos = door.BasePos - vectm(door.PrePivot.X,door.PrePivot.Y,door.PrePivot.Z);
-                    door.PrePivot=vect(0,0,0);
-                    door.SetLocation(door.BasePos);
+                    RemoveDXMoverPrePivot(door);
                 }
             }
             AddSwitch( vect(654.545,3889.5397,-367.262), rot(0, 16384, 0), 'ShedDoor');

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
@@ -4,6 +4,18 @@ var bool M14GaryNotDone;
 var bool M12GaryHostageBriefing;
 var int storedBotCount;// MJ12 bots in CMD
 
+function CheckConfig()
+{
+    local int i;
+
+    add_datacubes[i].map = "12_VANDENBERG_GAS";
+    add_datacubes[i].imageClass = class'Image12_Tiffany_HostagePic';
+    add_datacubes[i].location = vect(-107.1, 901.3, -939.4);
+    i++;
+
+    Super.CheckConfig();
+}
+
 function PreFirstEntryMapFixes()
 {
     local ElevatorMover e;

--- a/DXRMissions/DeusEx/Classes/DXRMissionsM03.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsM03.uc
@@ -230,9 +230,6 @@ function AnyEntry()
     Super.AnyEntry();
 
     switch(dxr.localURL) {
-    case "03_NYC_BATTERYPARK":
-        Player().StartDataLinkTransmission("dl_batterypark");
-        break;
     case "03_NYC_AIRFIELDHELIBASE":
         UpdateGoalWithRandoInfo('FindAmbrosiaBarrels', "The Ambrosia could be anywhere in the helibase or airfield.");
         break;

--- a/DXRMissions/DeusEx/Classes/DXRMissionsParis.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsParis.uc
@@ -334,9 +334,11 @@ function AfterMoveGoalToLocation(Goal g, GoalLocation Loc)
     if (Loc.name=="Media Store"){
         if ((g.name=="Nicolette") || (g.name=="Jaime" && dxr.flagbase.GetBool('JaimeLeftBehind'))){
             //Spawn a small spotlight just to make it a bit easier to spot them through the window
-            dl = Spawn(class'DynamicLight',,,vectm(1025,1768,200));
-            dl.LightRadius=3;
-            dl.LightBrightness=100;
+            dl = Spawn(class'DynamicLight',,,vectm(990,1768,300),rot(-16385,0,0));
+            dl.LightRadius=6;
+            dl.LightCone=1;
+            dl.LightBrightness=255;
+            dl.LightEffect=LE_Spotlight;
         }
     }
 

--- a/DXRMissions/DeusEx/Classes/DXRMissionsParis.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsParis.uc
@@ -334,7 +334,7 @@ function AfterMoveGoalToLocation(Goal g, GoalLocation Loc)
     if (Loc.name=="Media Store"){
         if ((g.name=="Nicolette") || (g.name=="Jaime" && dxr.flagbase.GetBool('JaimeLeftBehind'))){
             //Spawn a small spotlight just to make it a bit easier to spot them through the window
-            dl = Spawn(class'DynamicLight',,,vectm(990,1768,300),rot(-16385,0,0));
+            dl = DynamicLight(Spawnm(class'DynamicLight',,,vect(990,1768,300),rot(-16385,0,0)));
             dl.LightRadius=6;
             dl.LightCone=1;
             dl.LightBrightness=255;

--- a/DXRModules/DeusEx/Classes/DXRAutosave.uc
+++ b/DXRModules/DeusEx/Classes/DXRAutosave.uc
@@ -68,8 +68,14 @@ function ReEntry(bool IsTravel)
 
 function PostAnyEntry()
 {
+    local MemConUnit mcu;
+
     if(bNeedSave)
         NeedSave();
+
+    foreach AllActors(class'MemConUnit', mcu) {
+        mcu.PostPostBeginPlay();
+    }
 }
 
 function NeedSave()

--- a/DXRModules/DeusEx/Classes/DXRAutosave.uc
+++ b/DXRModules/DeusEx/Classes/DXRAutosave.uc
@@ -180,7 +180,7 @@ static function string GetSaveFailReason(DeusExPlayer player)
         }
     }
     if( f.autosave == FixedSaves || f.autosave == UnlimitedFixedSaves ) {
-        if(Computers(player.FrobTarget) == None) {
+        if(Computers(player.FrobTarget) == None && ATM(player.FrobTarget) == None) {
             return "You need to have a computer highlighted to save! Good Luck!";
         }
     }
@@ -242,6 +242,7 @@ static function UseSaveItem(DeusExPlayer player)
     item = DeusExPickup(player.FindInventoryType(class'MemConUnit'));
     if(item == None) return;
 
+    player.ClientMessage("You used " $ item.ItemArticle @ item.ItemName $ " to save.");
     item.UseOnce();
 }
 
@@ -343,15 +344,6 @@ function MapAdjustments()
 
     fixed = dxr.flags.autosave==FixedSaves || dxr.flags.autosave==UnlimitedFixedSaves;
     limited = dxr.flags.autosave == FixedSaves || dxr.flags.autosave == LimitedSaves;
-
-    switch(dxr.localURL) {
-    case "03_NYC_BrooklynBridgeStation":
-        // fixed saves needs a computer in M03 before helibase
-        if(fixed) {
-            AddActor(class'#var(prefix)ComputerPublic', vect(-1417.867065, -1937.349854, 446), rot(0,16384,0));
-        }
-        break;
-    }
 
     if(limited) {
         SetSeed("spawn MCU");

--- a/DXRModules/DeusEx/Classes/DXRDatacubes.uc
+++ b/DXRModules/DeusEx/Classes/DXRDatacubes.uc
@@ -551,7 +551,30 @@ function vanilla_datacubes_rules()
 
     case "15_AREA51_FINAL":
         //Code for stairwell blastdoor
+        //Not in the reactor lab
         datacubes_rules[i].item_name = '15_Datacube08';
+        datacubes_rules[i].min_pos = vect(-3868,-5302,-2096);
+        datacubes_rules[i].max_pos = vect(-2435,-3906,-1442);
+        datacubes_rules[i].allow = false;
+        i++;
+
+        //anywhere before the stairwell blastdoor
+        datacubes_rules[i].item_name = '15_Datacube08';
+        datacubes_rules[i].min_pos = vect(-5655, -5190, -1700);
+        datacubes_rules[i].max_pos = vect(-2376, -2527, -534);
+        datacubes_rules[i].allow = true;
+        i++;
+
+        //Code for Reactor lab
+        //Not in the reactor lab
+        datacubes_rules[i].item_name = '15_Datacube19';
+        datacubes_rules[i].min_pos = vect(-3868,-5302,-2096);
+        datacubes_rules[i].max_pos = vect(-2435,-3906,-1442);
+        datacubes_rules[i].allow = false;
+        i++;
+
+        //anywhere before the stairwell blastdoor
+        datacubes_rules[i].item_name = '15_Datacube19';
         datacubes_rules[i].min_pos = vect(-5655, -5190, -1700);
         datacubes_rules[i].max_pos = vect(-2376, -2527, -534);
         datacubes_rules[i].allow = true;

--- a/DXRModules/DeusEx/Classes/DXRDoors.uc
+++ b/DXRModules/DeusEx/Classes/DXRDoors.uc
@@ -203,6 +203,17 @@ function CheckConfig()
         i++;
         break;
 
+    case "15_area51_final":
+        // aquinas hub access, makes tong ending somewhat more viable
+        if(dxr.flags.IsSpeedrunMode() && FeatureFlag(3,3,0, "Area51EndingBalancePass2")) {
+            door_fixes[i].tag = 'blastdoor_upper';
+            door_fixes[i].bBreakable = false;
+            door_fixes[i].bPickable = false;
+            door_fixes[i].bHighlight = true;
+            i++;
+        }
+        break;
+
     case "15_area51_page":
         //Make it so the exploding door doesn't become breakable
         door_fixes[i].tag = 'door_clone_exit';

--- a/DXRModules/DeusEx/Classes/DXREnemies.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemies.uc
@@ -367,6 +367,15 @@ function AddDXRCredits(CreditsWindow cw)
 {
     local int i, f;
     local string weaponName, factionName;
+    local string factHeaders[6],factTexts[6],hdrs[3],texts[3];
+    #ifdef injections
+    local CreditsWindow ncw;
+    ncw=cw;
+    #else
+    local NewGamePlusCreditsWindow ncw;
+    ncw = NewGamePlusCreditsWindow(cw);
+    #endif
+
     if(dxr.flags.IsZeroRando()) return;
 
     for(f=FactionAny+1; f<FactionsEnd; f++) {
@@ -389,13 +398,35 @@ function AddDXRCredits(CreditsWindow cw)
         default:
             factionName = "Faction "$f;
         }
-        cw.PrintHeader( dxr.flags.settings.enemiesrandomized $ "% Added Enemies for "$factionName);
+        //cw.PrintHeader( dxr.flags.settings.enemiesrandomized $ "% Added Enemies for "$factionName);
+        factHeaders[f]= factionName;
+        factTexts[f]="";
         for(i=0; i < ArrayCount(_randomenemies); i++) {
             if( _randomenemies[i].type == None || _randomenemies[i].faction != f ) continue;
-            cw.PrintText(_randomenemies[i].type.default.FamiliarName $ ": " $ FloatToString(_randomenemies[i].chance, 1) $ "%" );
+            //cw.PrintText(_randomenemies[i].type.default.FamiliarName $ ": " $ FloatToString(_randomenemies[i].chance, 1) $ "%" );
+            factTexts[f] = factTexts[f] $ _randomenemies[i].type.default.FamiliarName $ ": " $ FloatToString(_randomenemies[i].chance, 1) $ "% |n";
         }
-        cw.PrintLn();
+        //cw.PrintLn();
     }
+
+    //Show the factions in a column format so they don't take up so much space
+    cw.PrintHeader( dxr.flags.settings.enemiesrandomized $ "% Added Enemies for Factions");
+
+    hdrs[0]=factHeaders[NSF];
+    hdrs[1]=factHeaders[UNATCO];
+    hdrs[2]=factHeaders[MJ12];
+    texts[0]=factTexts[NSF];
+    texts[1]=factTexts[UNATCO];
+    texts[2]=factTexts[MJ12];
+    ncw.PrintColumns(hdrs,texts);
+
+    hdrs[0]=factHeaders[Police];
+    hdrs[1]=factHeaders[FactionOther];
+    hdrs[2]="";
+    texts[0]=factTexts[Police];
+    texts[1]=factTexts[FactionOther];
+    texts[2]="";
+    ncw.PrintColumns(hdrs,texts);
 
     cw.PrintHeader("Extra Weapons For Enemies");
     for(i=0; i < ArrayCount(_randomweapons); i++) {

--- a/DXRModules/DeusEx/Classes/DXREnemies.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemies.uc
@@ -428,30 +428,60 @@ function AddDXRCredits(CreditsWindow cw)
     texts[2]="";
     ncw.PrintColumns(hdrs,texts);
 
-    cw.PrintHeader("Extra Weapons For Enemies");
+    cw.PrintLn();
+    cw.PrintHeader("Extra Weapons");
+
+    hdrs[0]="Extra Weapons For Enemies";
+    texts[0]="";
     for(i=0; i < ArrayCount(_randomweapons); i++) {
         if( _randomweapons[i].type == None ) continue;
-        cw.PrintText( _randomweapons[i].type.default.ItemName $ ": " $ FloatToString(_randomweapons[i].chance, 1) $ "%" );
+        texts[0]=texts[0]$_randomweapons[i].type.default.ItemName $ ": " $ FloatToString(_randomweapons[i].chance, 1) $ "% |n";
     }
-    cw.PrintLn();
 
-    cw.PrintHeader("Melee Weapons For Enemies");
+    hdrs[1]="Melee Weapons For Enemies";
+    texts[1]="";
     for(i=0; i < ArrayCount(_randommelees); i++) {
         if( _randommelees[i].type == None ) continue;
-        cw.PrintText( _randommelees[i].type.default.ItemName $ ": " $ FloatToString(_randommelees[i].chance, 1) $ "%" );
+        texts[1]=texts[1]$_randommelees[i].type.default.ItemName $ ": " $ FloatToString(_randommelees[i].chance, 1) $ "% |n";
     }
-    cw.PrintLn();
 
+    //We'll bundle randomized bot weapons into the same column as melee weapons
+    //to give more width per column and melee and robot weapons are short lists
     if(dxr.flags.settings.bot_weapons!=0) {
-        cw.PrintHeader("Extra Weapons For Robots");
+        texts[1]=texts[1] $ "|n|n|n|nExtra Weapons For Robots|n";
         for(i=0; i < ArrayCount(_randombotweapons); i++) {
             if( _randombotweapons[i].type == None ) continue;
-            weaponName = _randombotweapons[i].type.default.ItemName;
-            if (InStr(weaponName,"DEFAULT WEAPON NAME")!=-1){  //Many NPC weapons don't have proper names set
-                weaponName = String(_randombotweapons[i].type.default.Class);
-            }
-            cw.PrintText( weaponName $ ": " $ FloatToString(_randombotweapons[i].chance, 1) $ "%" );
+            weaponName = GetBotWeaponName(_randombotweapons[i].type);
+            texts[1]=texts[1]$weaponName $ ": " $ FloatToString(_randombotweapons[i].chance, 1) $ "% |n";
         }
-        cw.PrintLn();
+    }
+
+    hdrs[2]="";
+    texts[2]="";
+
+    ncw.PrintColumns(hdrs,texts);
+    cw.PrintLn();
+}
+
+function String GetBotWeaponName(class<DeusExWeapon> type)
+{
+    local String weaponName;
+    switch(type){
+        case class'WeaponRobotMachinegun':
+            return "Robot Machine Gun";
+        case class'WeaponRobotRocket':
+            return "Robot Rocket";
+        case class'WeaponMJ12Rocket':
+            return "MJ12 Commando Rocket";
+        case class'WeaponSpiderBot':
+            return "Big Spiderbot Zap";
+        case class'WeaponSpiderBot2':
+            return "Small Spiderbot Zap";
+        default:
+            weaponName = type.default.ItemName;
+            if (InStr(weaponName,"DEFAULT WEAPON NAME")!=-1){  //Many NPC weapons don't have proper names set
+                weaponName = String(type.default.Class);
+            }
+            return weaponName;
     }
 }

--- a/DXRModules/DeusEx/Classes/DXREnemies.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemies.uc
@@ -447,19 +447,18 @@ function AddDXRCredits(CreditsWindow cw)
 
     //We'll bundle randomized bot weapons into the same column as melee weapons
     //to give more width per column and melee and robot weapons are short lists
+    hdrs[2]="";
+    texts[2]="";
     if(dxr.flags.settings.bot_weapons!=0) {
-        texts[1]=texts[1] $ "|n|n|n|nExtra Weapons For Robots|n";
+        hdrs[2]="Extra Weapons For Robots";
         for(i=0; i < ArrayCount(_randombotweapons); i++) {
             if( _randombotweapons[i].type == None ) continue;
             weaponName = GetBotWeaponName(_randombotweapons[i].type);
-            texts[1]=texts[1]$weaponName $ ": " $ FloatToString(_randombotweapons[i].chance, 1) $ "% |n";
+            texts[2]=texts[2]$weaponName $ ": " $ FloatToString(_randombotweapons[i].chance, 1) $ "% |n";
         }
     }
 
-    hdrs[2]="";
-    texts[2]="";
-
-    ncw.PrintColumns(hdrs,texts);
+    ncw.PrintTeeColumns(hdrs,texts);
     cw.PrintLn();
 }
 

--- a/DXRModules/DeusEx/Classes/DXREnemies.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemies.uc
@@ -429,6 +429,8 @@ function AddDXRCredits(CreditsWindow cw)
     ncw.PrintColumns(hdrs,texts);
 
     cw.PrintLn();
+    cw.PrintLn();
+
     cw.PrintHeader("Extra Weapons");
 
     hdrs[0]="Extra Weapons For Enemies";

--- a/DXRModules/DeusEx/Classes/DXREnemyRespawn.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemyRespawn.uc
@@ -39,6 +39,7 @@ function PostFirstEntry()
 
     if( dxr.flags.settings.enemyrespawn <= 0 ) return;
     if( dxr.flags.IsHordeMode() ) return;
+    if( dxr.flags.IsHalloweenMode() ) return;
 
     time=0;
     foreach AllActors(class'ScriptedPawn', p) {
@@ -119,6 +120,7 @@ function AnyEntry()
     Super.AnyEntry();
 
     if( dxr.flags.IsHordeMode() ) return;
+    if( dxr.flags.IsHalloweenMode() ) return;
 
     if( dxr.flags.settings.enemyrespawn <= 0 ) return;
 

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -657,17 +657,11 @@ function FixUNATCORetinalScanner()
 {
     local RetinalScanner r;
 
-    switch(dxr.localURL) {
-    case "01_NYC_UNATCOHQ":
-    case "03_NYC_UNATCOHQ":
-    case "04_NYC_UNATCOHQ":
-        foreach AllActors(class'RetinalScanner', r) {
-            if( r.Event != 'retinal_msg_trigger' ) continue;
-            r.bHackable = false;
-            r.hackStrength = 0;
-            r.msgUsed = "";
-        }
-        break;
+    foreach AllActors(class'RetinalScanner', r) {
+        if( r.Event != 'retinal_msg_trigger' ) continue;
+        r.bHackable = false;
+        r.hackStrength = 0;
+        r.msgUsed = "";
     }
 }
 

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -20,6 +20,7 @@ struct AddDatacube {
     var string map;
     var string text;
     var vector location;// 0,0,0 for random
+    var class<DataVaultImage> imageClass;
     // spawned in PreFirstEntry, so if you set a location then it will be moved according to the logic of DXRPasswords
 };
 var AddDatacube add_datacubes[32];
@@ -950,9 +951,10 @@ function SpawnDatacubes()
             if(dxr.flags.settings.infodevices > 0)
                 GlowUp(dc);
             dc.plaintext = add_datacubes[i].text;
-            l("add_datacubes spawned "$dc @ dc.plaintext @ loc);
+            dc.imageClass = add_datacubes[i].imageClass;
+            l("add_datacubes spawned "$dc$", text: \""$dc.plaintext$"\", image: "$dc.imageClass$", location: "$loc);
         }
-        else warning("failed to spawn datacube at "$loc$", text: "$add_datacubes[i].text);
+        else warning("failed to spawn datacube at "$loc$", text: \""$add_datacubes[i].text$"\", image: "$dc.imageClass);
     }
 }
 

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -21,6 +21,7 @@ struct AddDatacube {
     var string text;
     var vector location;// 0,0,0 for random
     var class<DataVaultImage> imageClass;
+    var rotator rotation;
     // spawned in PreFirstEntry, so if you set a location then it will be moved according to the logic of DXRPasswords
 };
 var AddDatacube add_datacubes[32];
@@ -921,6 +922,7 @@ function SpawnDatacubes()
 #endif
 
     local vector loc;
+    local rotator rot;
     local int i;
 
     if(dxr.flags.IsReducedRando())
@@ -939,11 +941,13 @@ function SpawnDatacubes()
         loc = add_datacubes[i].location * coords_mult;
         if( loc.X == 0 && loc.Y == 0 && loc.Z == 0 )
             loc = GetRandomPosition();
+        rot = add_datacubes[i].rotation;
+        rot = rotm(rot.Pitch, rot.Yaw, rot.Roll, 0.0);
 
 #ifdef injections
-        dc = Spawn(class'#var(prefix)DataCube',,, loc, rotm(0,0,0,0));
+        dc = Spawn(class'#var(prefix)DataCube',,, loc, rot);
 #else
-        dc = Spawn(class'DXRInformationDevices',,, loc, rotm(0,0,0,0));
+        dc = Spawn(class'DXRInformationDevices',,, loc, rot);
 #endif
 
         if( dc != None ){

--- a/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -39,7 +39,7 @@ simulated function PlayerAnyEntry(#var(PlayerPawn) p)
     p.bCrowdControl = (crowdcontrol!=0);
 #endif
 
-    if(!VersionIsStable() || #defined(debug))
+    if(!VersionIsStable() || #bool(debug))
         p.bCheatsEnabled = true;
 
     if(difficulty_names[difficulty] == "Super Easy QA" && dxr.dxInfo.missionNumber > 0 && dxr.dxInfo.missionNumber < 99) {

--- a/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -12,7 +12,9 @@ const RandoMedium = 9;
 const WaltonWareHardcore = 10;
 const WaltonWarex3 = 11;
 const ZeroRandoPlus = 12;
-const HordeZombies = 1030;
+const HordeZombies = 1020;
+const WaltonWareHalloweenEntranceRando = 1029;
+const HalloweenEntranceRando = 1030;
 const HalloweenMode = 1031;
 const WaltonWareHalloween = 1032;// why didn't they put leap day at the end of October?
 
@@ -703,7 +705,9 @@ function int GameModeIdForSlot(int slot)
     if(slot--==0) return 0;
     if(IsOctoberUnlocked() && slot--==0) return HalloweenMode;
     if(slot--==0) return EntranceRando;
+    if(IsOctoberUnlocked() && slot--==0) return HalloweenEntranceRando;
     if(IsOctoberUnlocked() && slot--==0) return WaltonWareHalloween;
+    if(IsOctoberUnlocked() && slot--==0) return WaltonWareHalloweenEntranceRando;
     if(slot--==0) return WaltonWare;
     if(slot--==0) return WaltonWareEntranceRando;
     if(!VersionIsStable()) {
@@ -729,6 +733,8 @@ function string GameModeName(int gamemode)
 #ifdef injections
     case EntranceRando:
         return "Entrance Randomization";
+    case HalloweenEntranceRando:
+        return "Halloween Entrance Randomization";
     case HordeMode:
         return "Horde Mode";
     case HordeZombies:
@@ -755,6 +761,8 @@ function string GameModeName(int gamemode)
 #ifdef injections
     case WaltonWareEntranceRando:
         return "WaltonWare Entrance Rando";
+    case WaltonWareHalloweenEntranceRando:
+        return "WaltonWare Halloween Entrance Rando";
 #endif
     case WaltonWareHardcore:
         return "WaltonWare Hardcore";
@@ -772,7 +780,7 @@ function string GameModeName(int gamemode)
 
 function bool IsEntranceRando()
 {
-    return gamemode == EntranceRando || gamemode == WaltonWareEntranceRando;
+    return gamemode == EntranceRando || gamemode == WaltonWareEntranceRando || gamemode == HalloweenEntranceRando || gamemode == WaltonWareHalloweenEntranceRando;
 }
 
 function bool IsHordeMode()
@@ -802,7 +810,7 @@ function bool IsSpeedrunMode()
 
 function bool IsWaltonWare()
 {
-    return gamemode == WaltonWare || gamemode == WaltonWareEntranceRando || gamemode == WaltonWareHardcore || gamemode == WaltonWarex3 || gamemode == WaltonWareHalloween;
+    return gamemode == WaltonWare || gamemode == WaltonWareEntranceRando || gamemode == WaltonWareHardcore || gamemode == WaltonWarex3 || gamemode == WaltonWareHalloween || gamemode == WaltonWareHalloweenEntranceRando;
 }
 
 function bool IsWaltonWareHardcore()
@@ -812,7 +820,7 @@ function bool IsWaltonWareHardcore()
 
 function bool IsHalloweenMode()
 {
-    return gamemode == HalloweenMode || gamemode == HordeZombies || gamemode == WaltonWareHalloween;
+    return gamemode == HalloweenMode || gamemode == HordeZombies || gamemode == WaltonWareHalloween || gamemode == HalloweenEntranceRando || gamemode == WaltonWareHalloweenEntranceRando;
 }
 
 simulated function AddDXRCredits(CreditsWindow cw)

--- a/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -679,6 +679,7 @@ function FlagsSettings SetDifficulty(int new_difficulty)
     if (IsHalloweenMode()){
         clothes_looting = 1;
         settings.speedlevel = 0;// in DXRLoadouts we override level 0 speed to mean lvl 1 run silent
+        settings.enemyrespawn = 20;
     } else {
         clothes_looting = 0;
     }

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -1218,6 +1218,12 @@ function ExtendedTests()
     testbool( #defined(debug), false, "debug is disabled");
     testbool( #defined(locdebug), false, "locdebug is disabled");
     testbool( #defined(debugnames), false, "debugnames is disabled");
+    if(#defined(allfeatures)) { // we MIGHT want to ship alphas and betas with this?
+        warning("!!! allfeatures is defined !!!");
+    }
+    if(#defined(enablefeature)) {
+        warning("!!! enablefeature is defined as #var(enablefeature) !!!");
+    }
 }
 
 function TestTime()

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -1215,13 +1215,13 @@ function ExtendedTests()
 
     text = VersionString();
     testbool(VersionIsStable(), InStr(text, "Alpha")==-1 && InStr(text, "Beta")==-1, "VersionIsStable() matches version text, " $ text);
-    testbool( #defined(debug), false, "debug is disabled");
-    testbool( #defined(locdebug), false, "locdebug is disabled");
-    testbool( #defined(debugnames), false, "debugnames is disabled");
-    if(#defined(allfeatures)) { // we MIGHT want to ship alphas and betas with this?
+    testbool( #bool(debug), false, "debug is disabled");
+    testbool( #bool(locdebug), false, "locdebug is disabled");
+    testbool( #bool(debugnames), false, "debugnames is disabled");
+    if(#bool(allfeatures)) { // we MIGHT want to ship alphas and betas with this?
         warning("!!! allfeatures is defined !!!");
     }
-    if(#defined(enablefeature)) {
+    if(#bool(enablefeature)) {
         warning("!!! enablefeature is defined as #var(enablefeature) !!!");
     }
 }

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -1219,10 +1219,12 @@ function ExtendedTests()
     testbool( #bool(locdebug), false, "locdebug is disabled");
     testbool( #bool(debugnames), false, "debugnames is disabled");
     if(#bool(allfeatures)) { // we MIGHT want to ship alphas and betas with this?
-        warning("!!! allfeatures is defined !!!");
+        if(VersionIsStable()) test(false, "allfeatures is defined");
+        else warning("!!! allfeatures is defined !!!");
     }
     if(#bool(enablefeature)) {
-        warning("!!! enablefeature is defined as #var(enablefeature) !!!");
+        if(VersionIsStable()) test(false, "allfeatures is defined as #var(enablefeature)");
+        else warning("!!! enablefeature is defined as #var(enablefeature) !!!");
     }
 }
 

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -1217,6 +1217,7 @@ function ExtendedTests()
     testbool(VersionIsStable(), InStr(text, "Alpha")==-1 && InStr(text, "Beta")==-1, "VersionIsStable() matches version text, " $ text);
     testbool( #defined(debug), false, "debug is disabled");
     testbool( #defined(locdebug), false, "locdebug is disabled");
+    testbool( #defined(debugnames), false, "debugnames is disabled");
 }
 
 function TestTime()

--- a/DXRModules/DeusEx/Classes/DXRFlagsNGPMaxRando.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsNGPMaxRando.uc
@@ -92,7 +92,10 @@ simulated function RandomizeSettings(bool forceMenuOptions)
     settings.enemiesshuffled = 100;
     MaxRandoVal(settings.enemies_nonhumans);
 
-    if(chance_single(33) && !DXRFlags(self).IsHalloweenMode()) { // this cast is pretty nasty
+    if(DXRFlags(self).IsHalloweenMode()) {
+        settings.enemyrespawn = rng(10) + 15;
+    }
+    if(chance_single(33)) { // this cast is pretty nasty
         settings.enemyrespawn = rng(120) + 120;
     } else {
         settings.enemyrespawn = 0;

--- a/DXRModules/DeusEx/Classes/DXRHalloween.uc
+++ b/DXRModules/DeusEx/Classes/DXRHalloween.uc
@@ -154,6 +154,7 @@ function bool CheckResurrectCorpse(#var(DeusExPrefix)Carcass carc, float time)
     // wait for Zombie Time!
     if(time > Level.TimeSeconds) return false;
 
+    l("CheckResurrectCorpse " $ carc @ time @ Level.TimeSeconds);
     return ResurrectCorpse(self, carc);
 }
 
@@ -306,9 +307,23 @@ function MapFixes()
     local PathNode p;
     local #var(DeusExPrefix)Carcass carc;
     local class<#var(DeusExPrefix)Carcass> carcclass;
+    local ScriptedPawn sp;
     local float dist;
 
     switch(dxr.localURL) {
+    case "01_NYC_UNATCOHQ":
+    case "03_NYC_UNATCOHQ":
+    case "04_NYC_UNATCOHQ":
+        foreach AllActors(class'#var(DeusExPrefix)Carcass', carc) {
+            carc.bNotDead = true;
+            carc.itemName = ReplaceText(carc.itemName, " (Dead)", " (Unconscious)");
+        }
+        foreach AllActors(class'ScriptedPawn', sp) {
+            if(sp.bInvincible) {
+                RemoveFears(sp);
+            }
+        }
+        break;
     case "09_NYC_GRAVEYARD":
         SetSeed("DXRHalloween MapFixes graveyard bodies");
         foreach AllActors(class'PathNode', p) {

--- a/DXRModules/DeusEx/Classes/DXRHalloween.uc
+++ b/DXRModules/DeusEx/Classes/DXRHalloween.uc
@@ -77,6 +77,7 @@ function CheckCarcasses()
                 continue;
             }
         }
+        if(carc.bDeleteMe) continue;
         for(i=0; i < num_carcs; i++) {
             if(carcs[i] == carc) {
                 break;
@@ -150,11 +151,11 @@ function bool CheckResurrectCorpse(#var(DeusExPrefix)Carcass carc, float time)
 {
     // return true to compress the array
     if(carc == None) return true;
+    if(carc.bDeleteMe) return true;
 
     // wait for Zombie Time!
     if(time > Level.TimeSeconds) return false;
 
-    l("CheckResurrectCorpse " $ carc @ time @ Level.TimeSeconds);
     return ResurrectCorpse(self, carc);
 }
 
@@ -194,6 +195,8 @@ static function bool ResurrectCorpse(DXRActorsBase module, #var(DeusExPrefix)Car
     #endif
     local bool removeItem;
     local string s;
+
+    if(carc==None || carc.bDeleteMe) return False;
 
     livingClassName = GetPawnClassNameFromCarcass(module, carc.class);
     livingClass = module.GetClassFromString(livingClassName,class'ScriptedPawn');

--- a/DXRModules/DeusEx/Classes/DXRHalloween.uc
+++ b/DXRModules/DeusEx/Classes/DXRHalloween.uc
@@ -53,6 +53,12 @@ function CheckCarcasses()
 {
     local int i;
     local #var(DeusExPrefix)Carcass carc;
+    local float zombie_time, dog_zombie_time;
+
+    if( dxr.flags.settings.enemyrespawn <= 0 ) return;
+    zombie_time = dxr.flags.settings.enemyrespawn - 5;
+    zombie_time = FClamp(zombie_time, 1, 10000);
+    dog_zombie_time = zombie_time / 5;
 
     for(i=0; i < num_carcs; i++) {
         if(CheckResurrectCorpse(carcs[i], times[i])) {
@@ -86,9 +92,9 @@ function CheckCarcasses()
         if(carcs[i] != carc) {
             carcs[num_carcs] = carc;
             if(#var(prefix)DobermanCarcass(carc) != None || #var(prefix)MuttCarcass(carc) != None) { // special sauce for dogs
-                times[num_carcs] = Level.TimeSeconds + 3 + FRand()*2;
+                times[num_carcs] = Level.TimeSeconds + dog_zombie_time + FRand()*2;
             } else {
-                times[num_carcs] = Level.TimeSeconds + 15 + FRand()*10;
+                times[num_carcs] = Level.TimeSeconds + zombie_time + FRand()*10;
             }
             carc.MaxDamage = 0.1 * carc.Mass;// easier to destroy carcasses
             num_carcs++;

--- a/DXRModules/DeusEx/Classes/DXRHalloween.uc
+++ b/DXRModules/DeusEx/Classes/DXRHalloween.uc
@@ -488,6 +488,7 @@ function SpawnJackOLantern(vector loc)
         r2.Yaw = rng(20000) - 10000;
         loc = wall1.loc + (wall1.norm << r2) * 64;
         jacko = spawn(class'DXRJackOLantern',,, loc, r);
+        if(jacko == None) continue;
         size = rngf() + 0.6;
         jacko.DrawScale *= size;
         jacko.SetCollisionSize(jacko.CollisionRadius*size, jacko.CollisionHeight*size);

--- a/DXRModules/DeusEx/Classes/DXRHalloween.uc
+++ b/DXRModules/DeusEx/Classes/DXRHalloween.uc
@@ -501,6 +501,12 @@ function SpawnSpiderweb(vector loc)
     local rotator rot;
     local ZoneInfo zone;
     local class<Spiderweb> webClass;
+    // Used for texture trace
+    local vector  EndTrace, StartTrace, HitLocation, HitNormal;
+    local actor   target;
+    local int     texFlags;
+    local name    texName, texGroup;
+    local bool    bInvisibleWall;
 
     loc.X += rngfn() * 256.0;// 16 feet in either direction
     loc.Y += rngfn() * 256.0;// 16 feet in either direction
@@ -518,6 +524,14 @@ function SpawnSpiderweb(vector loc)
     foreach RadiusActors(class'Spiderweb', web, 100, loc) {
         dist = VSize(loc-web.Location);
         if(chance_single(100-dist)) return;
+    }
+
+    EndTrace = loc + vector(rot) * -32;
+    foreach TraceTexture(class'Actor', target, texName, texGroup, texFlags, HitLocation, HitNormal, EndTrace, loc) {
+        if ((texFlags & 1) !=0) { // 1 = PF_Invisible
+            return;
+        }
+        break;
     }
 
     rot.roll = rng(65536);

--- a/DXRModules/DeusEx/Classes/DXRMapVariants.uc
+++ b/DXRModules/DeusEx/Classes/DXRMapVariants.uc
@@ -142,6 +142,9 @@ static function bool IsVanillaMaps(#var(PlayerPawn) player)
 
 function int GetMirrorMapsSetting()
 {
+#ifndef injections
+    return -1; //Ignore the mirroredmaps setting, since we don't support them without injections
+#endif
     return dxr.flags.mirroredmaps;
 }
 

--- a/DXRModules/DeusEx/Classes/DXRMapVariants.uc
+++ b/DXRModules/DeusEx/Classes/DXRMapVariants.uc
@@ -242,6 +242,7 @@ function ExtendedTests()
     TestCoords("02_NYC_BatteryPark.dx", "02_NYC_BatteryPark_1_2_1.dx", 1,2,1);
     TestCoords("02_NYC_BatteryPark.dx", "02_NYC_BatteryPark_0.1_1.2_-1.3.dx", 0.1, 1.2, -1.3);
 
+    #ifdef injections
     oldmirroredmaps = dxr.flags.mirroredmaps;
     dxr.flags.mirroredmaps = 100;
     teststring(VaryURL("test#"), "test_-1_1_1#", "VaryURL 1");
@@ -250,4 +251,5 @@ function ExtendedTests()
     teststring(VaryURL("test.dx"), "test_-1_1_1.dx", "VaryURL 4");
     teststring(VaryURL("test?query=param"), "test_-1_1_1?query=param", "VaryURL 5");
     dxr.flags.mirroredmaps = oldmirroredmaps;
+    #endif
 }

--- a/DXRModules/DeusEx/Classes/DXRMemes.uc
+++ b/DXRModules/DeusEx/Classes/DXRMemes.uc
@@ -45,8 +45,8 @@ function RandomLiberty()
 
     foreach AllActors(class'NYLibertyTop',top){
         if(IsOctober()) {
-            liberty.style = STY_Translucent;
-            liberty.ScaleGlow = 0.5;
+            top.style = STY_Translucent;
+            top.ScaleGlow = 0.5;
         }
     }
 

--- a/DXRModules/DeusEx/Classes/DXRMusicPlayer.uc
+++ b/DXRModules/DeusEx/Classes/DXRMusicPlayer.uc
@@ -92,6 +92,7 @@ function ClientSetMusic( playerpawn NewPlayer, music NewSong, byte NewSection, b
 {
     local bool changed_song, set_seed;
     local bool rando_music_setting;
+    local bool use_random_music, play_music;
     local int continuous_setting;
 
     p = #var(PlayerPawn)(NewPlayer);
@@ -119,9 +120,23 @@ function ClientSetMusic( playerpawn NewPlayer, music NewSong, byte NewSection, b
         CombatSection = 26;// idk why but section 3 takes time to start playing the song
     }
 
-    // ignore complicated logic if everything is disabled
+    use_random_music=True;
+    play_music=True;
     if( p == None || dxr == None || (continuous_setting == c.default.disabled && rando_music_setting == false) ) {
-        _ClientSetMusic(NewSong, NewSection, NewCdTrack, NewTransition);
+        use_random_music = False;
+    }
+#ifdef revision
+    if (class'RevJCDentonMale'.Default.bUseRevisionSoundtrack){
+        use_random_music = False;
+        play_music=False;
+    }
+#endif
+
+    // ignore complicated logic if everything is disabled
+    if( !use_random_music ) {
+        if(play_music){
+            _ClientSetMusic(NewSong, NewSection, NewCdTrack, NewTransition);
+        }
         // really make sure we clean the config
         PrevSong = NewSong;
         PrevMusicMode = 0;
@@ -217,6 +232,11 @@ function PlayRandomSong(bool setseed)
 
     l("PlayRandomSong " $ setseed @ p);
     if(p == None) return;
+
+#ifdef revision
+    //Don't play music via the DXRMusicPlayer if Revision soundtrack is enabled
+    if (class'RevJCDentonMale'.Default.bUseRevisionSoundtrack) return;
+#endif
 
     continuous_setting = class'MenuChoice_ContinuousMusic'.default.value;
     rando_music_setting = class'MenuChoice_RandomMusic'.static.IsEnabled(dxr.flags);
@@ -317,6 +337,12 @@ simulated event Tick(float deltaTime)
 
     if(p == None && string(Level.Game.class.name) == "DXRandoTests")
         return;
+
+#ifdef revision
+    //Don't do anything with the music player if Revision soundtrack is enabled
+    if (class'RevJCDentonMale'.Default.bUseRevisionSoundtrack)
+        return;
+#endif
 
     // DEUS_EX AMSD In singleplayer, do the old thing.
     // In multiplayer, we can come out of dying.

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -523,6 +523,35 @@ static function AddNote(#var(PlayerPawn) player, bool bEmptyNotes, string text)
     }
 }
 
+function DeusExNote AddNoteFromConv(#var(PlayerPawn) player, bool bEmptyNotes, name convname, optional int which)
+{
+    local Conversation con;
+    local ConEvent ce;
+    local ConEventAddNote cean;
+    local DeusExNote note;
+
+    if (bEmptyNotes == false) {
+        return None;
+    }
+
+    con = GetConversation(convname);
+
+    // passing a negative value for `which` adds all notes, and returns None
+    for (ce = con.eventList; ce != None; ce = ce.nextEvent) {
+        cean = ConEventAddNote(ce);
+        if (cean != None) {
+            if (which <= 0) {
+                note = player.Addnote(cean.noteText);
+                if (which == 0) {
+                    return note;
+                }
+            }
+            which--;
+        }
+    }
+    return None;
+}
+
 function MarkConvPlayed(string flagname, bool bFemale)
 {
     flagname = flagname$"_Played";
@@ -545,12 +574,6 @@ function PreFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, 
             MarkConvPlayed("DL_SeeManderley", bFemale);
             break;
         case 5:
-            if(start_flag > 50) {
-                AddNote(player, bEmptyNotes, "Facility exit: 1125.");
-                AddNote(player, bEmptyNotes, "Until the grid is fully restored, the detention block door code has been reset to 4089 while _all_ detention cells have been reset to 4679.");
-                MarkConvPlayed("DL_NoPaul", bFemale);
-                flagbase.SetBool('MS_InventoryRemoved',true,,6);
-            }
             flagbase.SetBool('KnowsSmugglerPassword',true,,-1);
             break;
         case 6:
@@ -611,43 +634,44 @@ function PreFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, 
             MarkConvPlayed("M03MeetTerroristLeader", bFemale);
         case 34: // fallthrough
         case 33:
-            AddNote(player, bEmptyNotes, "6653 -- Code to the phone-booth entrance to mole-people hideout.");
+            AddNoteFromConv(player, bEmptyNotes, 'MeetCurly', 0); // 6653 -- Code to the phone-booth entrance
             MarkConvPlayed("dl_batterypark", bFemale); // We're dropping you off in Battery Park
             break;
         case 31:
             MarkConvPlayed("DL_WelcomeBack", bFemale);
             break;
 
-        case 41:
-            AddGoalFromConv(player, 'SeeManderley', 'DL_SeeManderley');
-            break;
-        case 43:
-            AddGoalFromConv(player, 'CheckOnPaul', 'DL_JockParkStart');
-            break;
         case 45:
             flagbase.SetBool('KnowsSmugglerPassword',true,,-1); // Paul ordinarily tells you the password if you don't know it
             flagbase.SetBool('GatesOpen',true,,5);
-            AddGoalFromConv(player, 'InvestigateNSF', 'PaulInjured');
             MarkConvPlayed("PaulInjured", bFemale);
             GiveImage(player, class'Image04_NSFHeadquarters');
             break;
 
-        case 75:
-        case 71:// anything greater than 70 should get these, even though this isn't an actual value currently
-            AddNote(player, bEmptyNotes, "Access code to the Versalife nanotech research wing on Level 2: 55655.  There is a back entrance at the north end of the Canal Road Tunnel, which is just east of the temple.");
+        case 55:
+            AddNoteFromConv(player, bEmptyNotes, 'PaulInMedLab', 0); // Anna Navarre's killphrase is stored in two pieces on two computers
+            AddNoteFromConv(player, bEmptyNotes, 'DL_paul', 0); // Facility exit: 1125
+            MarkConvPlayed("DL_NoPaul", bFemale);
+            MarkConvPlayed("PaulInMedLab", bFemale);
+            MarkConvPlayed("DL_Paul", bFemale);
+            flagbase.SetBool('MS_InventoryRemoved',true,,6);
+            break;
+
+        case 75:// anything greater than 70 should get these, even though this isn't an actual value currently
+            AddNoteFromConv(player, bEmptyNotes, 'M07Briefing'); // Access code to the Versalife nanotech research wing on Level 2: 55655
             MarkConvPlayed("M07Briefing", bFemale);// also spawns big spider in MJ12Lab
         case 70://fallthrough
             flagbase.SetBool('Disgruntled_Guy_Dead', true);
             MarkConvPlayed("Meet_MJ12Lab_Supervisor", bFemale);
         case 68://fallthrough
-            AddNote(player, bEmptyNotes, "VersaLife elevator code: 6512.");
+            AddNoteFromConv(player, bEmptyNotes, 'M06SupervisorConvos', 0); // VersaLife elevator code: 6512
         case 67://fallthrough
-            AddNote(player, bEmptyNotes, "Versalife employee ID: 06288.  Use this to access the VersaLife elevator north of the market.");
+            AddNoteFromConv(player, bEmptyNotes, 'MeetTracerTong2', -1); // VersaLife employee ID: 06288
             MarkConvPlayed("MeetTracerTong", bFemale);
             MarkConvPlayed("MeetTracerTong2", bFemale);
             flagbase.SetBool('KillswitchFixed',true,,-1);
         case 66://fallthrough
-            AddNote(player, bEmptyNotes, "Luminous Path door-code: 1997.");
+            AddNoteFromConv(player, bEmptyNotes, 'Gate_Guard2', 1); // Luminous Path door-code: 1997
             flagbase.SetBool('MaxChenConvinced',true,,-1);
             flagbase.SetBool('QuickLetPlayerIn',true,,-1);
             flagbase.SetBool('QuickConvinced',true,,-1);
@@ -674,6 +698,7 @@ function PreFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, 
             GiveKey(player, 'cathedralgatekey', "Gatekeeper's Key");
             GiveImage(player, class'Image11_Paris_Cathedral');
             GiveImage(player, class'Image11_Paris_CathedralEntrance');
+            MarkConvPlayed("DL_intro_cathedral", bFemale);
         case 109:
             GiveImage(player, class'Image10_Paris_Metro');
         case 106:
@@ -687,6 +712,12 @@ function PreFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, 
             MarkConvPlayed("GaryHostageBriefing", bFemale);
             flagbase.SetBool('Heliosborn',true,,-1); //Make sure Daedalus and Icarus have merged
             break;
+        case 122:
+            AddNoteFromConv(player, bEmptyNotes, 'MeetTonyMares', 0); // Gary savage is thought to be in the control room
+        case 121: // fallthrough
+            AddNoteFromConv(player, bEmptyNotes, 'MeetCarlaBrown', 0); // Backup power for the bot security system
+            break;
+
         case 145:
             flagbase.SetBool('schematic_downloaded',true,,-1); //Make sure the oceanlab UC schematics are downloaded
             // fallthrough
@@ -708,9 +739,9 @@ function PreFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, 
             MarkConvPlayed("DL_Final_Page02", bFemale);         // Barely a scratch.
             MarkConvPlayed("DL_elevator", bFemale);             // Bet you didn't know your mom and dad tried to protest when we put you in training.
             MarkConvPlayed("DL_conveyor_room", bFemale);        // Page is further down.  Find the elevator.
-            MarkConvPlayed("M15MeetEverett", bFemale);          // Not far.  You will reach Page. I just wanted to let you know that Alex hacked the Sector 2 security grid
+            // MarkConvPlayed("M15MeetEverett", bFemale);          // Not far.  You will reach Page. I just wanted to let you know that Alex hacked the Sector 2 security grid
             flagbase.SetBool('MS_EverettAppeared',true,,-1);
-            AddNote(player, bEmptyNotes, "Crew-complex security code: 8946.");
+            AddNoteFromConv(player, bEmptyNotes, 'M15MeetEverett', 0); // Crew-complex security code: 8946; TODO: figure out why Everett refuses to appear for this conversation on later starts
             // fallthrough
         case 151:
             MarkConvPlayed("DL_tong1", bFemale);                // Here's a satellite image of the damage from the missile.
@@ -748,34 +779,54 @@ function PostFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase,
         case 35:
             AddGoalFromConv(player, 'LocateAirfield', 'ManderleyDebriefing02');
             break;
+        case 36:
+            player.StartDataLinkTransmission("DL_LebedevKill");
+            break;
         case 37:
             AddGoalFromConv(player, 'AssassinateLebedev', 'DL_LebedevKill');
             break;
 
-        case 62:
-        case 63:
-        case 64:
-            AddGoalFromConv(player, 'FindTracerTong', 'DL_Jock_05');
-            AddGoalFromConv(player, 'CheckCompound', 'DL_Jock_05');
+        case 45:
+            AddGoalFromConv(player, 'InvestigateNSF', 'PaulInjured');
             break;
-        case 65:
-            AddGoalFromConv(player, 'FindTracerTong', 'DL_Jock_05');
-            AddGoalFromConv(player, 'CheckCompound', 'DL_Jock_05');
-            AddGoalFromConv(player, 'ConvinceRedArrow', 'DL_Tong_00');
+        case 43:
+            player.StartDataLinkTransmission("DL_JockParkStart");
             break;
-        case 66:
-            AddGoalFromConv(player, 'FindTracerTong', 'DL_Jock_05');
+        case 41:
+            AddGoalFromConv(player, 'SeeManderley', 'DL_SeeManderley');
             break;
-        case 67:
-        case 68:
-            AddGoalFromConv(player, 'GetROM', 'MeetTracerTong2');
+
+        case 55:
+            AddGoalFromConv(player, 'FindEquipment', 'DL_Choice');
+            AddGoalFromConv(player, 'FindAnnasKillprhase', 'PaulInMedLab');
+            break;
+
+        case 75:
+            AddGoalFromConv(player, 'GetVirusSchematic', 'M07Briefing');
+            AddGoalFromConv(player, 'HaveDrinksWithDragonHeads', 'TriadCeremony');
             break;
         case 70:
             AddGoalFromConv(player, 'ReportToTong', 'TriadCeremony');
             AddGoalFromConv(player, 'HaveDrinksWithDragonHeads', 'TriadCeremony');
             break;
-        case 75:
-            AddGoalFromConv(player, 'HaveDrinksWithDragonHeads', 'TriadCeremony');
+        case 68:
+        case 67:
+            AddGoalFromConv(player, 'GetROM', 'MeetTracerTong2');
+            break;
+        case 66:
+            AddGoalFromConv(player, 'FindTracerTong', 'DL_Jock_05');
+            AddGoalFromConv(player, 'GetSword', 'DL_Tong_00B');
+            break;
+        case 65:
+            AddGoalFromConv(player, 'FindTracerTong', 'DL_Jock_05');
+            AddGoalFromConv(player, 'CheckCompound', 'DL_Jock_05');
+            AddGoalFromConv(player, 'ConvinceRedArrow', 'DL_Tong_00');
+            AddGoalFromConv(player, 'GetSword', 'DL_Tong_00B');
+            break;
+        case 64:
+        case 63:
+        case 62:
+            player.StartDataLinkTransmission("DL_Jock_05");
             break;
 
         case 90:
@@ -803,11 +854,38 @@ function PostFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase,
             AddGoalFromConv(player, 'FindEverett', 'NicoletteOutside');
             break;
 
+        case 119:
+            goal = player.AddGoal('ContactIlluminati', true);
+            goal.SetText("Make contact with the Illuminati in Paris, where the former Illuminati leader, Morgan Everett, is rumored to be in hiding.");
+            break;
+        case 115:
+            goal = player.AddGoal('ContactIlluminati', true);
+            goal.SetText("Make contact with the Illuminati in Paris, where the former Illuminati leader, Morgan Everett, is rumored to be in hiding.");
+            AddGoalFromConv(player, 'GoToMetroStation', 'DL_morgan_uplink');
+            AddGoalFromConv(player, 'RecoverGold', 'DL_intro_cathedral');
+            break;
+        case 110:
+            goal = player.AddGoal('ContactIlluminati', true);
+            goal.SetText("Make contact with the Illuminati in Paris, where the former Illuminati leader, Morgan Everett, is rumored to be in hiding.");
+            goal = player.AddGoal('AccessTemplarComputer', true);
+            goal.SetText("Access the Templar computer system so that Morgan Everett can complete work on a cure for the Gray Death.");
+            break;
+
+        case 129:
+            AddGoalFromConv(player, 'RescueTiffany', 'GaryHostageBriefing');
+            break;
+        case 125:
+        case 122:
+            AddGoalFromConv(player, 'FindGarySavage', 'MeetTonyMares');
+            break;
+        case 121:
+            AddGoalFromConv(player, 'GoToCommunicationsCenter', 'DL_command_bots_destroyed');
+            break;
+
         case 153:
             AddGoalFromConv(player, 'DestroyArea51', 'M15MeetTong');
             AddGoalFromConv(player, 'DeactivateLocks', 'MeetHelios');
-            //fallthrough
-        case 152:
+        case 152: // fallthrough
             AddGoalFromConv(player, 'KillPage', 'M15MeetEverett');
             break;
     }

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -648,6 +648,7 @@ function PreFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, 
             flagbase.SetBool('KillswitchFixed',true,,-1);
         case 66://fallthrough
             AddNote(player, bEmptyNotes, "Luminous Path door-code: 1997.");
+            flagbase.SetBool('MaxChenConvinced',true,,-1);
             flagbase.SetBool('QuickLetPlayerIn',true,,-1);
             flagbase.SetBool('QuickConvinced',true,,-1);
             MarkConvPlayed("Gate_Guard2", bFemale);
@@ -884,19 +885,14 @@ static function bool BingoGoalImpossible(string bingo_event, int start_map, int 
         break;
 
     case 6: // Hong Kong
-        switch(bingo_event)
-        {
-        // // these two goals can actually be done with the way these starts currently work, but would normally be impossible
-        // case "ClubEntryPaid":
-        // case "M06JCHasDate":
-        //     return start_map > 65;
-        }
-    case 7: // fallthrough to 2nd half of Hong Kong
+    case 7:
         switch(bingo_event)
         {
         case "MaggieCanFly":
-        case "PoliceVaultBingo": // TODO: remove once a datacube with the vault code is added
-            return start_map > 70;
+            return start_map >= 66; // can technically be done still by carrying her body out of VersaLife but it's not really sensible to have as a goal at this point
+        // // this goal can actually be done with the way these starts currently work, but would normally be impossible
+        // case "M06JCHasDate":
+        //     return start_map > 65;
         }
         break;
 

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -296,7 +296,7 @@ static function string _GetStartMap(int start_map_val, optional out string frien
 {
     friendlyName = ""; // clear the out param to protect against reuse by the caller
 
-    if (#defined(allstarts))
+    if (#bool(allstarts))
         bShowInMenu=1;
     switch(start_map_val)
     {

--- a/DXRModules/DeusEx/Classes/DXRWeapons.uc
+++ b/DXRModules/DeusEx/Classes/DXRWeapons.uc
@@ -12,9 +12,21 @@ simulated function PlayerAnyEntry(#var(PlayerPawn) p)
     foreach AllActors(class'DeusExWeapon', w) {
         RandoWeapon(w);
     }
+    if(!#defined(injections)) SetTimer(1, true);
 }
 
-simulated function RandoWeapon(DeusExWeapon w)
+simulated function Timer()
+{
+    local DeusExWeapon w;
+    Super.Timer();
+    if( dxr == None ) return;
+
+    foreach AllActors(class'DeusExWeapon', w) {
+        RandoWeapon(w, true);
+    }
+}
+
+simulated function RandoWeapon(DeusExWeapon w, optional bool silent)
 {
     local int oldseed, i;
     local float min_weapon_dmg, max_weapon_dmg, min_weapon_shottime, max_weapon_shottime, new_damage, default_shottime;
@@ -36,7 +48,7 @@ simulated function RandoWeapon(DeusExWeapon w)
     new_damage = rngrange(new_damage, min_weapon_dmg, max_weapon_dmg);
     w.HitDamage = int(new_damage + 0.5);
     if(w.HitDamage < 2 && w.HitDamage < w.default.HitDamage) {
-        l(w $ " w.HitDamage ("$ w.HitDamage $") < 2");
+        if(!silent) l(w $ " w.HitDamage ("$ w.HitDamage $") < 2");
         w.HitDamage = 2;
     }
 
@@ -53,7 +65,7 @@ simulated function RandoWeapon(DeusExWeapon w)
     max_weapon_shottime = float(dxr.flags.settings.max_weapon_shottime) / 100;
     default_shottime = GetDefaultShottime(w);
     w.ShotTime = rngrange(default_shottime, min_weapon_shottime, max_weapon_shottime);
-    l(w $ " w.HitDamage="$ w.HitDamage $ ", ShotTime=" $ w.ShotTime);
+    if(!silent) l(w $ " w.HitDamage="$ w.HitDamage $ ", ShotTime=" $ w.ShotTime);
     /*f = w.default.ReloadTime * (rngf()+0.5);
     w.ReloadTime = f;
     f = float(w.default.MaxRange) * (rngf()+0.5);
@@ -66,7 +78,8 @@ simulated function RandoWeapon(DeusExWeapon w)
 }
 
 static function float GetDefaultShottime(DeusExWeapon w) {
-    if(w.ProjectileClass != None && (w.AmmoNames[1] != None || w.AmmoNames[2] != None)) {
+    // HACK: changing ammo types is awkward because there's no array for ShotTime, technically a nerf to the crossbow?
+    if(/*w.default.ProjectileClass == None &&*/ w.ProjectileClass != None && (w.AmmoNames[1] != None || w.AmmoNames[2] != None)) {
         return 1;// ShotTime of 1 is hardcoded when switching ammo to something with a projectile
     }
     return w.default.ShotTime;

--- a/DXRModules/DeusEx/Classes/DXRWeapons.uc
+++ b/DXRModules/DeusEx/Classes/DXRWeapons.uc
@@ -176,3 +176,10 @@ simulated function bool RandoProjectile(DeusExWeapon w, out class<Projectile> p,
 
     return true;
 }
+
+#ifndef injections
+defaultproperties
+{
+    bAlwaysTick=True
+}
+#endif

--- a/DXRNonVanilla/DeusEx/Classes/DXRandoGameInfo.uc
+++ b/DXRNonVanilla/DeusEx/Classes/DXRandoGameInfo.uc
@@ -148,7 +148,7 @@ event Super_PostLogin( playerpawn NewPlayer )
     #endif
 
     if(useDXRMusicPlayer)
-        m = DXRMusicPlayer(class'DXRMusicPlayer'.static.Find());
+        m = DXRMusicPlayer(GetDXR().LoadModule(class'DXRMusicPlayer'));// this can get called before the module is loaded
     if(m!=None)
         m.ClientSetMusic( NewPlayer, Level.Song, Level.SongSection, Level.CdTrack, MTRAN_Fade );
     else

--- a/DXRNonVanilla/DeusEx/Classes/DXRandoGameInfo.uc
+++ b/DXRNonVanilla/DeusEx/Classes/DXRandoGameInfo.uc
@@ -137,7 +137,8 @@ event Super_PostLogin( playerpawn NewPlayer )
     local Pawn P;
     local DXRMusicPlayer m;
     // Start player's music.
-    m = DXRMusicPlayer(GetDXR().LoadModule(class'DXRMusicPlayer'));
+    if(!#defined(revision))
+        m = DXRMusicPlayer(class'DXRMusicPlayer'.static.Find());
     if(m!=None)
         m.ClientSetMusic( NewPlayer, Level.Song, Level.SongSection, Level.CdTrack, MTRAN_Fade );
     else

--- a/DXRNonVanilla/DeusEx/Classes/DXRandoGameInfo.uc
+++ b/DXRNonVanilla/DeusEx/Classes/DXRandoGameInfo.uc
@@ -136,8 +136,18 @@ event Super_PostLogin( playerpawn NewPlayer )
 {
     local Pawn P;
     local DXRMusicPlayer m;
+    local bool useDXRMusicPlayer;
+
     // Start player's music.
-    if(!#defined(revision))
+    useDXRMusicPlayer=True;
+
+    #ifdef revision
+    if (class'RevJCDentonMale'.Default.bUseRevisionSoundtrack){
+        useDXRMusicPlayer=False;
+    }
+    #endif
+
+    if(useDXRMusicPlayer)
         m = DXRMusicPlayer(class'DXRMusicPlayer'.static.Find());
     if(m!=None)
         m.ClientSetMusic( NewPlayer, Level.Song, Level.SongSection, Level.CdTrack, MTRAN_Fade );

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -1313,13 +1313,14 @@ function _ClientSetMusic( music NewSong, byte NewSection, byte NewCdTrack, EMusi
 function ClientSetMusic( music NewSong, byte NewSection, byte NewCdTrack, EMusicTransition NewTransition )
 {
     local DXRMusicPlayer m;
-    m = DXRMusicPlayer(class'DXRMusicPlayer'.static.Find());
+    m = DXRMusicPlayer(dxr.LoadModule(class'DXRMusicPlayer'));// this can get called before the module is loaded
     if (m==None){
         log("WARNING: DXRMusicPlayer module not found");
         _ClientSetMusic(NewSong, NewSection, NewCdTrack, NewTransition);
         return;
+    } else {
+        m.ClientSetMusic(self, NewSong, NewSection, NewCdTrack, NewTransition);
     }
-    m.ClientSetMusic(self, NewSong, NewSection, NewCdTrack, NewTransition);
 }
 
 //=========== END OF MUSIC STUFF

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -1313,6 +1313,10 @@ function _ClientSetMusic( music NewSong, byte NewSection, byte NewCdTrack, EMusi
 function ClientSetMusic( music NewSong, byte NewSection, byte NewCdTrack, EMusicTransition NewTransition )
 {
     local DXRMusicPlayer m;
+    if (GetDXR()==None){ //Probably only during ENDGAME4?
+        log("Couldn't find a DXR so we can set the music to " $ NewSong);
+        return;
+    }
     m = DXRMusicPlayer(dxr.LoadModule(class'DXRMusicPlayer'));// this can get called before the module is loaded
     if (m==None){
         log("WARNING: DXRMusicPlayer module not found");

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -1313,14 +1313,10 @@ function _ClientSetMusic( music NewSong, byte NewSection, byte NewCdTrack, EMusi
 function ClientSetMusic( music NewSong, byte NewSection, byte NewCdTrack, EMusicTransition NewTransition )
 {
     local DXRMusicPlayer m;
-    GetDXR();
-    if (dxr==None){ //Probably only during ENDGAME4?
-        log("Couldn't find a DXR so we can set the music to " $ NewSong);
-        return;
-    }
-    m = DXRMusicPlayer(dxr.LoadModule(class'DXRMusicPlayer'));
+    m = DXRMusicPlayer(class'DXRMusicPlayer'.static.Find());
     if (m==None){
-        log("Found a DXR but no DXRMusicPlayer module to set the music");
+        log("WARNING: DXRMusicPlayer module not found");
+        _ClientSetMusic(NewSong, NewSection, NewCdTrack, NewTransition);
         return;
     }
     m.ClientSetMusic(self, NewSong, NewSection, NewCdTrack, NewTransition);

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -1330,7 +1330,7 @@ function UpdateRotation(float DeltaTime, float maxPitch)
     local DataStorage datastorage;
     local int rollAmount;
     datastorage = class'DataStorage'.static.GetObjFromPlayer(self);
-    rollAmount = int(datastorage.GetConfigKey('cc_cameraRoll'));
+    if(datastorage != None) rollAmount = int(datastorage.GetConfigKey('cc_cameraRoll'));
 
     if(rollAmount == 0) {
         Super.UpdateRotation(DeltaTime,maxPitch);

--- a/DXRVanilla/DeusEx/Classes/Weapon.uc
+++ b/DXRVanilla/DeusEx/Classes/Weapon.uc
@@ -15,7 +15,8 @@ function PostBeginPlay()
     local DXRWeapons m;
     Super.PostBeginPlay();
 
-    foreach AllActors(class'DXRWeapons', m) {
+    m = DXRWeapons(class'DXRWeapons'.static.Find());
+    if(m != None) {
         m.RandoWeapon(self);
     }
 }
@@ -146,11 +147,9 @@ function bool LoadAmmo(int ammoNum)
     ret = Super.LoadAmmo(ammoNum);
 
     // we need to re-randomize the shottime
-    if(class'DXRando'.default.dxr != None) {
-        dxrw = DXRWeapons(class'DXRando'.default.dxr.FindModule(class'DXRWeapons'));
-        if(dxrw != None) {
-            dxrw.RandoWeapon(self);
-        }
+    dxrw = DXRWeapons(class'DXRWeapons'.static.Find());
+    if(dxrw != None) {
+        dxrw.RandoWeapon(self);
     }
 
     return ret;

--- a/DXRando/DeusEx/Classes/DXRAnimTracker.uc
+++ b/DXRando/DeusEx/Classes/DXRAnimTracker.uc
@@ -44,8 +44,8 @@ function Init(string part)
     local rotator rot;
     local int a, i;
 
-    if(#defined(debug)) SaveConfig();// create/update the config file
-    if(#defined(debug) && part == config_part) return;
+    if(#bool(debug)) SaveConfig();// create/update the config file
+    if(#bool(debug) && part == config_part) return;
 
     for(a=0; a<ArrayCount(anim_offsets); a++) {
         anim_offsets[a].frames[0] = -1;
@@ -122,7 +122,7 @@ function Init(string part)
         break;
     }
 
-    if(#defined(debug)) SaveConfig();// write back new values to config
+    if(#bool(debug)) SaveConfig();// write back new values to config
 }
 
 function edit()
@@ -142,7 +142,7 @@ function edit()
 
     ForceFrame = Owner.AnimFrame;
 
-    if(!#defined(debug)) Human(GetPlayerPawn()).ClientMessage("DXRAnimTracker WARNING: not compiled in debug mode!");
+    if(!#bool(debug)) Human(GetPlayerPawn()).ClientMessage("DXRAnimTracker WARNING: not compiled in debug mode!");
 }
 
 simulated function Tick(float deltaTime)
@@ -185,14 +185,14 @@ simulated function Tick(float deltaTime)
             loc = (a_off * (1.0-f)) + (b_off * f);
         }
 
-        if(#defined(debug) && editing) {
+        if(#bool(debug) && editing) {
             Human(GetPlayerPawn()).ClientMessage(Owner.AnimSequence @ Owner.AnimFrame @ loc);
         }
         ApplyOffset(loc);
         return;
     }
 
-    if(#defined(debug) && Owner.AnimSequence != '' && editing) {
+    if(#bool(debug) && Owner.AnimSequence != '' && editing) {
         Human(GetPlayerPawn()).ClientMessage(Owner.AnimSequence @ Owner.AnimFrame);
     }
 

--- a/DXRando/DeusEx/Classes/DXRJackOLantern.uc
+++ b/DXRando/DeusEx/Classes/DXRJackOLantern.uc
@@ -42,6 +42,7 @@ function ResetScaleGlow()
 
 defaultproperties
 {
+     HitPoints=5
      FragType=class'JackOLanternFragment'
      ItemName="Jack-O'-Lantern"
      Mesh=LodMesh'DeusExDeco.Poolball'

--- a/DXRando/DeusEx/Classes/DXRandoCrowdControlEffects.uc
+++ b/DXRando/DeusEx/Classes/DXRandoCrowdControlEffects.uc
@@ -607,7 +607,7 @@ function InitOnEnter() {
 //so that they can be cleanly re-applied next time you enter
 function CleanupOnExit() {
 
-    if (dxr.OnTitleScreen()){
+    if (dxr==None || dxr.OnTitleScreen()){
         return;
     }
 

--- a/DXRando/DeusEx/Classes/MemConUnit.uc
+++ b/DXRando/DeusEx/Classes/MemConUnit.uc
@@ -7,6 +7,21 @@ function BeginPlay()
     MultiSkins[1] = Texture(DynamicLoadObject("Extras.Matrix_A00", class'Texture'));
 }
 
+function PostPostBeginPlay()
+{
+    local DXRFlags m;
+    Super.PostPostBeginPlay();
+
+    m = DXRFlags(class'DXRFlags'.static.Find());
+
+    if (m==None) return; //There should always be a DXRFlags, but better safe than sorry
+
+    if (m.autosave==7){ //Fixed Saves
+        Description=Description $ "|n|nYou must have an ATM, personal computer, public terminal, or security computer highlighted in order to save your game.";
+    }
+}
+
+
 defaultproperties
 {
      maxCopies=5

--- a/DXRando/DeusEx/Classes/MemConUnit.uc
+++ b/DXRando/DeusEx/Classes/MemConUnit.uc
@@ -17,7 +17,7 @@ function PostPostBeginPlay()
     if (m==None) return; //There should always be a DXRFlags, but better safe than sorry
 
     if (m.autosave==7){ //Fixed Saves
-        Description=Description $ "|n|nYou must have an ATM, personal computer, public terminal, or security computer highlighted in order to save your game.";
+        Description=default.Description $ "|n|nYou must have an ATM, personal computer, public terminal, or security computer highlighted in order to save your game.";
     }
 }
 

--- a/DXRando/DeusEx/Classes/TriggerEnable.uc
+++ b/DXRando/DeusEx/Classes/TriggerEnable.uc
@@ -31,7 +31,7 @@ static function DXRTriggerEnable Create(Actor a, Name tag, Name Event)
     foreach t.AllActors(class'Actor', a, Event) {
         a.SetCollision(false, a.bBlockActors, a.bBlockPlayers);
     }
-    if(#defined(debug)) {
+    if(#bool(debug)) {
         t.Trigger(None, None);
     }
     return t;

--- a/GUI/DeusEx/Classes/FrobDisplayWindow.uc
+++ b/GUI/DeusEx/Classes/FrobDisplayWindow.uc
@@ -208,6 +208,10 @@ function DrawWindowBase(GC gc, actor frobTarget)
 
     // draw object-specific info
     strInfo = GetStrInfo(frobTarget, numLines);
+    #ifdef debugnames
+    strInfo = string(frobTarget.name) @ frobTarget.Tag @ frobTarget.Event $ CR() $ strInfo;
+    numLines++;
+    #endif
 
     infoX = boxTLX + 10;
     infoY = boxTLY + 10;

--- a/GUI/DeusEx/Classes/HeaderedColumnWindow.uc
+++ b/GUI/DeusEx/Classes/HeaderedColumnWindow.uc
@@ -28,6 +28,26 @@ event InitWindow()
     winText.SetPos(0,24);
 }
 
+event ParentRequestedPreferredSize(bool bWidthSpecified, out float preferredWidth,
+                                   bool bHeightSpecified, out float preferredHeight)
+{
+    local float w,h,height;
+
+    preferredWidth=columnWidth;
+
+    height=0;
+    winTitle.QueryPreferredSize(w,h);
+    height+=h;
+    winText.QueryPreferredSize(w,h);
+    height+=h;
+}
+
+function SetTextAlignment(EHAlign newHAlign, EVAlign newVAlign)
+{
+    winTitle.SetTextAlignments(newHAlign,newVAlign);
+    winText.SetTextAlignments(newHAlign,newVAlign);
+}
+
 function SetColumnWidth(float newWidth)
 {
     SetWidth(newWidth);

--- a/GUI/DeusEx/Classes/HeaderedColumnWindow.uc
+++ b/GUI/DeusEx/Classes/HeaderedColumnWindow.uc
@@ -1,0 +1,69 @@
+class HeaderedColumnWindow extends Window;
+
+var TextWindow   winTitle;
+var TextWindow   winText;
+var Font         fontHeader;
+var Font         fontText;
+var Color        colHeader;
+var Color        colText;
+var float        columnWidth;
+
+
+event InitWindow()
+{
+    Super.InitWindow();
+    //SetSize(1000,1024);
+    //columnWidth=1000;
+
+    winTitle = TextWindow(NewChild(Class'TextWindow'));
+    winTitle.SetFont(fontHeader);
+    winTitle.SetTextColor(colHeader);
+    winTitle.SetTextAlignments(HALIGN_Center, VALIGN_Top);
+    winTitle.SetTextMargins(0, 0);
+    winTitle.SetPos(0,0);
+
+    winText = TextWindow(NewChild(Class'TextWindow'));
+    winText.SetFont(fontText);
+    winText.SetTextColor(colText);
+    winText.SetTextAlignments(HALIGN_Center, VALIGN_Top);
+    winText.SetTextMargins(0, 0);
+    winText.SetPos(0,24);
+}
+
+function SetColumnWidth(float newWidth)
+{
+    SetWidth(newWidth);
+    winTitle.SetWidth(newWidth);
+    winText.SetWidth(newWidth);
+    columnWidth=newWidth;
+    ResizeWindow();
+}
+
+function SetTitle(String newTitle)
+{
+    winTitle.SetText(newTitle);
+    ResizeWindow();
+}
+
+function SetText(String newText)
+{
+    winText.SetText(newText);
+    ResizeWindow();
+}
+
+function ResizeWindow()
+{
+    local float width,titleHeight,textHeight;
+
+    winTitle.QueryPreferredSize(width,titleHeight);
+    winText.QueryPreferredSize(width,textHeight);
+    SetSize(columnWidth,titleHeight+textHeight);
+}
+
+defaultproperties
+{
+     fontHeader=Font'DeusExUI.FontConversationLargeBold'
+     fontText=Font'DeusExUI.FontConversationLarge'
+     colHeader=(R=255,G=255,B=255)
+     colText=(R=200,G=200,B=200)
+}

--- a/GUI/DeusEx/Classes/HeaderedColumnWindow.uc
+++ b/GUI/DeusEx/Classes/HeaderedColumnWindow.uc
@@ -12,8 +12,6 @@ var float        columnWidth;
 event InitWindow()
 {
     Super.InitWindow();
-    //SetSize(1000,1024);
-    //columnWidth=1000;
 
     winTitle = TextWindow(NewChild(Class'TextWindow'));
     winTitle.SetFont(fontHeader);

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptionsAudio.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptionsAudio.uc
@@ -6,7 +6,17 @@ class MenuScreenRandoOptionsAudio expands MenuScreenRandoOptionsBase;
 
 function CreateChoices()
 {
-    if(!#defined(revision)) {
+    local bool useDXRMusicPlayer;
+
+    useDXRMusicPlayer = true;
+
+    #ifdef revision
+    if (class'RevJCDentonMale'.Default.bUseRevisionSoundtrack){
+            useDXRMusicPlayer=False;
+    }
+    #endif
+
+    if(useDXRMusicPlayer) {
         CreateChoice(class'MenuChoice_ContinuousMusic');
         CreateChoice(class'MenuChoice_RandomMusic');
         CreateChoice(class'MenuChoice_ChangeSong');
@@ -15,6 +25,11 @@ function CreateChoices()
         CreateChoice(class'MenuChoice_UTMusic');
         CreateChoice(class'MenuChoice_UnrealMusic');
         CreateChoice(class'MenuChoice_DXMusic');
+    } else {
+    #ifdef revision
+        //Show the Revision soundtrack choice option if non-vanilla is chosen
+        CreateChoice(class'RevMenuChoice_Soundtrack');
+    #endif
     }
     if(#defined(injections)){
         CreateChoice(class'MenuChoice_ChargeTimer');

--- a/GUI/DeusEx/Classes/NewGamePlusCreditsWindow.uc
+++ b/GUI/DeusEx/Classes/NewGamePlusCreditsWindow.uc
@@ -22,6 +22,30 @@ function DoNewGamePlus()
     }
 }
 
+//Draw up to 3 columns across the screen
+function PrintColumns(String colHeader[3], String colTxt[3])
+{
+    local AlignWindow winAlign;
+    local TextWindow  winText;
+    local int i;
+
+    winAlign = AlignWindow(winScroll.NewChild(Class'AlignWindow'));
+    winAlign.SetWindowAlignments(HALIGN_Center, VALIGN_Top);
+    winAlign.SetChildVAlignment(VALIGN_Top);
+    winAlign.SetChildSpacing(15);
+
+    for (i=0;i<ArrayCount(colTxt) && colTxt[i]!="";i++){
+        winText = TextWindow(winAlign.NewChild(Class'TextWindow'));
+        winText.SetFont(fontText);
+        winText.SetTextColor(colText);
+        winText.SetTextAlignments(HALIGN_Center, VALIGN_Top);
+        winText.SetTextMargins(0, 0);
+        winText.SetText(colHeader[i]$"|n"$colTxt[i]);
+    }
+
+    winAlign.SetWidth((maxTextWidth*i)/3);
+}
+
 function AddDXRCreditsGeneral()
 {
     local Texture randoTextTextures[6];

--- a/GUI/DeusEx/Classes/NewGamePlusCreditsWindow.uc
+++ b/GUI/DeusEx/Classes/NewGamePlusCreditsWindow.uc
@@ -29,7 +29,7 @@ function DoNewGamePlus()
 function PrintColumns(String colHeader[3], String colTxt[3])
 {
     local AlignWindow winAlign;
-    local TextWindow  winText;
+    local HeaderedColumnWindow winColumn;
     local int i,numCols;
 
     winAlign = AlignWindow(winScroll.NewChild(Class'AlignWindow'));
@@ -43,13 +43,10 @@ function PrintColumns(String colHeader[3], String colTxt[3])
 
     for (i=0;i<ArrayCount(colTxt);i++){
         if (colTxt[i]!=""){
-            winText = TextWindow(winAlign.NewChild(Class'TextWindow'));
-            winText.SetFont(fontText);
-            winText.SetTextColor(colText);
-            winText.SetTextAlignments(HALIGN_Center, VALIGN_Top);
-            winText.SetTextMargins(0, 0);
-            winText.SetText(colHeader[i]$"|n"$colTxt[i]);
-            winText.SetWidth(maxTextWidth/numCols);
+            winColumn = HeaderedColumnWindow(winAlign.NewChild(Class'HeaderedColumnWindow'));
+            winColumn.SetColumnWidth(maxTextWidth/numCols);
+            winColumn.SetTitle(colHeader[i]);
+            winColumn.SetText(colTxt[i]);
         }
     }
     winAlign.SetWidth(maxTextWidth);
@@ -63,40 +60,30 @@ function PrintTeeColumns(String colHeader[3], String colTxt[3])
 {
     local AlignWindow winAlign;
     local TileWindow  winTile;
-    local TextWindow  winText;
+    local HeaderedColumnWindow winColumn;
 
     winAlign = AlignWindow(winScroll.NewChild(Class'AlignWindow'));
     winAlign.SetWindowAlignments(HALIGN_Center, VALIGN_Center);
     winAlign.SetChildVAlignment(VALIGN_Top);
 
-    winText = TextWindow(winAlign.NewChild(Class'TextWindow'));
-    winText.SetFont(fontText);
-    winText.SetTextColor(colText);
-    winText.SetTextAlignments(HALIGN_Center, VALIGN_Top);
-    winText.SetTextMargins(0, 0);
-    winText.SetText(colHeader[0]$"|n"$colTxt[0]);
-    winText.SetWidth(maxTextWidth/2);
+    winColumn = HeaderedColumnWindow(winAlign.NewChild(Class'HeaderedColumnWindow'));
+    winColumn.SetColumnWidth(maxTextWidth/2);
+    winColumn.SetTitle(colHeader[0]);
+    winColumn.SetText(colTxt[0]);
 
     winTile = TileWindow(winAlign.NewChild(Class'TileWindow'));
     winTile.SetWindowAlignments(HALIGN_Center, VALIGN_Center);
     winTile.SetWidth(maxTextWidth/2);
 
-    winText = TextWindow(winTile.NewChild(Class'TextWindow'));
-    winText.SetFont(fontText);
-    winText.SetTextColor(colText);
-    winText.SetTextAlignments(HALIGN_Center, VALIGN_Center);
-    winText.SetTextMargins(0, 0);
-    winText.SetText(colHeader[1]$"|n"$colTxt[1]);
-    winText.SetWidth(maxTextWidth/2);
+    winColumn = HeaderedColumnWindow(winTile.NewChild(Class'HeaderedColumnWindow'));
+    winColumn.SetColumnWidth(maxTextWidth/2);
+    winColumn.SetTitle(colHeader[1]);
+    winColumn.SetText(colTxt[1]);
 
-    winText = TextWindow(winTile.NewChild(Class'TextWindow'));
-    winText.SetFont(fontText);
-    winText.SetTextColor(colText);
-    winText.SetTextAlignments(HALIGN_Center, VALIGN_Center);
-    winText.SetTextMargins(0, 0);
-    winText.SetText(colHeader[2]$"|n"$colTxt[2]);
-    winText.SetWidth(maxTextWidth/2);
-
+    winColumn = HeaderedColumnWindow(winTile.NewChild(Class'HeaderedColumnWindow'));
+    winColumn.SetColumnWidth(maxTextWidth/2);
+    winColumn.SetTitle(colHeader[2]);
+    winColumn.SetText(colTxt[2]);
 
     winAlign.SetWidth(maxTextWidth);
 }

--- a/GUI/DeusEx/Classes/NewGamePlusCreditsWindow.uc
+++ b/GUI/DeusEx/Classes/NewGamePlusCreditsWindow.uc
@@ -27,23 +27,29 @@ function PrintColumns(String colHeader[3], String colTxt[3])
 {
     local AlignWindow winAlign;
     local TextWindow  winText;
-    local int i;
+    local int i,numCols;
 
     winAlign = AlignWindow(winScroll.NewChild(Class'AlignWindow'));
     winAlign.SetWindowAlignments(HALIGN_Center, VALIGN_Top);
     winAlign.SetChildVAlignment(VALIGN_Top);
-    winAlign.SetChildSpacing(15);
 
-    for (i=0;i<ArrayCount(colTxt) && colTxt[i]!="";i++){
-        winText = TextWindow(winAlign.NewChild(Class'TextWindow'));
-        winText.SetFont(fontText);
-        winText.SetTextColor(colText);
-        winText.SetTextAlignments(HALIGN_Center, VALIGN_Top);
-        winText.SetTextMargins(0, 0);
-        winText.SetText(colHeader[i]$"|n"$colTxt[i]);
+    numCols=0;
+    if (colTxt[0]!="") numCols++;
+    if (colTxt[1]!="") numCols++;
+    if (colTxt[2]!="") numCols++;
+
+    for (i=0;i<ArrayCount(colTxt);i++){
+        if (colTxt[i]!=""){
+            winText = TextWindow(winAlign.NewChild(Class'TextWindow'));
+            winText.SetFont(fontText);
+            winText.SetTextColor(colText);
+            winText.SetTextAlignments(HALIGN_Center, VALIGN_Top);
+            winText.SetTextMargins(0, 0);
+            winText.SetText(colHeader[i]$"|n"$colTxt[i]);
+            winText.SetWidth(maxTextWidth/numCols);
+        }
     }
-
-    winAlign.SetWidth((maxTextWidth*i)/3);
+    winAlign.SetWidth(maxTextWidth);
 }
 
 function AddDXRCreditsGeneral()

--- a/GUI/DeusEx/Classes/NewGamePlusCreditsWindow.uc
+++ b/GUI/DeusEx/Classes/NewGamePlusCreditsWindow.uc
@@ -64,7 +64,7 @@ function PrintTeeColumns(String colHeader[3], String colTxt[3])
 
     winAlign = AlignWindow(winScroll.NewChild(Class'AlignWindow'));
     winAlign.SetWindowAlignments(HALIGN_Center, VALIGN_Center);
-    winAlign.SetChildVAlignment(VALIGN_Top);
+    winAlign.SetChildVAlignment(VALIGN_Center);
 
     winColumn = HeaderedColumnWindow(winAlign.NewChild(Class'HeaderedColumnWindow'));
     winColumn.SetColumnWidth(maxTextWidth/2);

--- a/GUI/DeusEx/Classes/NewGamePlusCreditsWindow.uc
+++ b/GUI/DeusEx/Classes/NewGamePlusCreditsWindow.uc
@@ -23,6 +23,9 @@ function DoNewGamePlus()
 }
 
 //Draw up to 3 columns across the screen
+//  1 | 2 | 3
+//     or
+//    1 | 2
 function PrintColumns(String colHeader[3], String colTxt[3])
 {
     local AlignWindow winAlign;
@@ -49,6 +52,52 @@ function PrintColumns(String colHeader[3], String colTxt[3])
             winText.SetWidth(maxTextWidth/numCols);
         }
     }
+    winAlign.SetWidth(maxTextWidth);
+}
+
+//Draw 1 tall column and two stacked rows
+//     | 2
+//   1 |---
+//     | 3
+function PrintTeeColumns(String colHeader[3], String colTxt[3])
+{
+    local AlignWindow winAlign;
+    local TileWindow  winTile;
+    local TextWindow  winText;
+
+    winAlign = AlignWindow(winScroll.NewChild(Class'AlignWindow'));
+    winAlign.SetWindowAlignments(HALIGN_Center, VALIGN_Center);
+    winAlign.SetChildVAlignment(VALIGN_Top);
+
+    winText = TextWindow(winAlign.NewChild(Class'TextWindow'));
+    winText.SetFont(fontText);
+    winText.SetTextColor(colText);
+    winText.SetTextAlignments(HALIGN_Center, VALIGN_Top);
+    winText.SetTextMargins(0, 0);
+    winText.SetText(colHeader[0]$"|n"$colTxt[0]);
+    winText.SetWidth(maxTextWidth/2);
+
+    winTile = TileWindow(winAlign.NewChild(Class'TileWindow'));
+    winTile.SetWindowAlignments(HALIGN_Center, VALIGN_Center);
+    winTile.SetWidth(maxTextWidth/2);
+
+    winText = TextWindow(winTile.NewChild(Class'TextWindow'));
+    winText.SetFont(fontText);
+    winText.SetTextColor(colText);
+    winText.SetTextAlignments(HALIGN_Center, VALIGN_Center);
+    winText.SetTextMargins(0, 0);
+    winText.SetText(colHeader[1]$"|n"$colTxt[1]);
+    winText.SetWidth(maxTextWidth/2);
+
+    winText = TextWindow(winTile.NewChild(Class'TextWindow'));
+    winText.SetFont(fontText);
+    winText.SetTextColor(colText);
+    winText.SetTextAlignments(HALIGN_Center, VALIGN_Center);
+    winText.SetTextMargins(0, 0);
+    winText.SetText(colHeader[2]$"|n"$colTxt[2]);
+    winText.SetWidth(maxTextWidth/2);
+
+
     winAlign.SetWidth(maxTextWidth);
 }
 

--- a/Pawns/DeusEx/Classes/DamageProxy.uc
+++ b/Pawns/DeusEx/Classes/DamageProxy.uc
@@ -32,6 +32,11 @@ function TakeDamage(int Damage, Pawn instigatedBy, Vector hitlocation, Vector mo
     }
 }
 
+event Bump( Actor Other )
+{
+    Base.Bump(Other);
+}
+
 function CopyAlliances(ScriptedPawn from)
 {
     Alliance = from.Alliance;
@@ -43,7 +48,7 @@ function Tick(float deltaTime)
     local vector loc;
 
     // do NOT call Super
-    if(Base==None) {
+    if(Base==None || Base.bDeleteMe) {
         Destroy();
         return;
     }
@@ -69,8 +74,6 @@ function PostPostBeginPlay()
 function ZoneChange(ZoneInfo newZone)
 {}
 singular function BaseChange()
-{}
-function Bump(actor Other)
 {}
 function HitWall(vector HitLocation, Actor hitActor)
 {}

--- a/Pawns/DeusEx/Classes/Merchant.uc
+++ b/Pawns/DeusEx/Classes/Merchant.uc
@@ -31,10 +31,8 @@ function EnterConversationState(bool bFirstPerson, optional bool bAvoidState)
     local Conversation con;
     local ConEvent ce;
     local ConEventSpeech ces;
-    local int newHint;
+    local int newHint, i;
     local string hint, details;
-
-    hints = DXRHints(class'DXRHints'.static.Find());
 
     con = ConListItem(ConListItems).con;
 
@@ -45,24 +43,32 @@ function EnterConversationState(bool bFirstPerson, optional bool bAvoidState)
         }
     }
 
-    do {
-        newHint = hints.GetHint();
-        hint = hints.hints[newHint];
-        details = hints.details[newHint];
-    } until (
-        newHint != lastHint &&
-        hint != "Viewers, you could've prevented this with Crowd Control." &&
-        hint != "Don't forget you (the viewer!) can" &&
-        details != "We just shared your death publicly, go retweet it!" &&
-        !(CarcassType == Class'LeMerchantCarcass' && hint == "If you need a Hazmat suit")
-    )
+    hints = DXRHints(class'DXRHints'.static.Find());
 
-    ces = class'DXRActorsBase'.static.GetSpeechEvent(con.eventList, "Hehehehe");
-    ces.conSpeech.speech = "Hehehehe, thank you. Here's a tip: " $ hint @ details;
-    ces = class'DXRActorsBase'.static.GetSpeechEvent(con.eventList, "Come back");
-    ces.conSpeech.speech = "Come back anytime. Here's a tip: " $ hint @ details;
-    ces = class'DXRActorsBase'.static.GetSpeechEvent(con.eventList, "Not enough cash");
-    ces.conSpeech.speech = "Not enough cash, stranger. Here's a tip: " $ hint @ details;
+    if(hints != None) {
+        for(i=0; i<100; i++) {
+            newHint = hints.GetHint();
+            hint = hints.hints[newHint];
+            details = hints.details[newHint];
+            if(
+                newHint != lastHint &&
+                hint != "Viewers, you could've prevented this with Crowd Control." &&
+                hint != "Don't forget you (the viewer!) can" &&
+                details != "We just shared your death publicly, go retweet it!" &&
+                !(CarcassType == Class'LeMerchantCarcass' && hint == "If you need a Hazmat suit")
+            ) break;
+        }
+        if(i>=100) hint = "";
+    }
+
+    if(hint!="") {
+        ces = class'DXRActorsBase'.static.GetSpeechEvent(con.eventList, "Hehehehe");
+        ces.conSpeech.speech = "Hehehehe, thank you. Here's a tip: " $ hint @ details;
+        ces = class'DXRActorsBase'.static.GetSpeechEvent(con.eventList, "Come back");
+        ces.conSpeech.speech = "Come back anytime. Here's a tip: " $ hint @ details;
+        ces = class'DXRActorsBase'.static.GetSpeechEvent(con.eventList, "Not enough cash");
+        ces.conSpeech.speech = "Not enough cash, stranger. Here's a tip: " $ hint @ details;
+    }
 
     lastHint = newHint;
 

--- a/Pawns/DeusEx/Classes/MrH.uc
+++ b/Pawns/DeusEx/Classes/MrH.uc
@@ -217,7 +217,9 @@ state Wandering
         local float   magnitude, dist1, dist2;
         local rotator rot1;
 
-        target = GetFarthestNavPoint(self);
+        if(closestDestPoint != None) {
+            target = GetFarthestNavPoint(self);
+        }
         if(target != None) {
             farthestDestPoint = target;
         }

--- a/compiler_settings.default.json
+++ b/compiler_settings.default.json
@@ -4,7 +4,7 @@
         "out_dir": "C:/Program Files (x86)/Steam/steamapps/common/Deus Ex Rando/",
         "preproc_definitions": {
             "vanilla":1, "singleplayer":1, "fixes":1, "mapfixes":1, "balance":1, "backtracking":1, "injections":1, "flags": 1, "prefix":"", "vanillamaps":1,
-            "DeusExPrefix":"DeusEx", "PlayerPawn":"Human", "flagvarprefix": "", "package": "DeusEx", "injectsprefix": ""
+            "DeusExPrefix":"DeusEx", "PlayerPawn":"Human", "flagvarprefix": "", "package": "DeusEx", "injectsprefix": "", "allfeatures": false
         },
         "mods_paths": [ "../Lay-D-Denton-Project", "./" ],
         "packages": [ "DeusEx" ],
@@ -22,7 +22,7 @@
         "out_dir": "C:/Program Files (x86)/Steam/steamapps/common/Deus Ex HX/",
         "preproc_definitions": {
             "hx":1, "multiplayer":1, "mapfixes":1, "balance":1, "noflags":1, "prefix":"HX",
-            "DeusExPrefix":"HX", "PlayerPawn":"HXPlayerPawn", "flagvarprefix": "config", "package": "HXRandomizer", "injectsprefix": "DXR"
+            "DeusExPrefix":"HX", "PlayerPawn":"HXPlayerPawn", "flagvarprefix": "config", "package": "HXRandomizer", "injectsprefix": "DXR", "allfeatures": false
         },
         "mods_paths": [ "./" ],
         "packages": [ "HXRandomizer" ],
@@ -37,7 +37,7 @@
         "out_dir": "C:/Program Files (x86)/Steam/steamapps/common/Deus Ex GMDX/",
         "preproc_definitions": {
             "gmdx":1, "singeplayer":1, "mapfixes":1, "flags":1, "prefix":"",
-            "DeusExPrefix":"DeusEx", "PlayerPawn":"Human", "flagvarprefix": "", "package": "GMDXRandomizer", "injectsprefix": "DXR"
+            "DeusExPrefix":"DeusEx", "PlayerPawn":"Human", "flagvarprefix": "", "package": "GMDXRandomizer", "injectsprefix": "DXR", "allfeatures": false
         },
         "mods_paths": [ "./" ],
         "packages": [ "GMDXRandomizer" ],
@@ -52,7 +52,7 @@
         "out_dir": "C:/Program Files (x86)/Steam/steamapps/common/Deus Ex Revision/",
         "preproc_definitions": {
             "revision":1, "singeplayer":1, "mapfixes":1, "flags":1, "prefix":"",
-            "DeusExPrefix":"DeusEx", "PlayerPawn":"Human", "flagvarprefix": "", "package": "RevRandomizer", "injectsprefix": "DXR"
+            "DeusExPrefix":"DeusEx", "PlayerPawn":"Human", "flagvarprefix": "", "package": "RevRandomizer", "injectsprefix": "DXR", "allfeatures": false
         },
         "mods_paths": [ "./" ],
         "packages": [ "RevRandomizer" ],
@@ -67,7 +67,7 @@
         "out_dir": "C:/Program Files (x86)/Steam/steamapps/common/Deus Ex VMD/",
         "preproc_definitions": {
             "vmd":1, "vmd175":1, "singeplayer":1, "mapfixes":1, "flags":1, "prefix":"", "vanillamaps":1,
-            "DeusExPrefix":"DeusEx", "PlayerPawn":"Human", "flagvarprefix": "", "package": "VMDRandomizer", "injectsprefix": "DXR"
+            "DeusExPrefix":"DeusEx", "PlayerPawn":"Human", "flagvarprefix": "", "package": "VMDRandomizer", "injectsprefix": "DXR", "allfeatures": false
         },
         "mods_paths": [ "./" ],
         "packages": [ "VMDRandomizer" ],

--- a/notes/notes.txt
+++ b/notes/notes.txt
@@ -173,6 +173,8 @@ http://www.unrealtexture.com/Unreal/Downloads/3DEditing/UnrealEd/Tutorials/unrea
 
 Various UnrealEd information (mostly for the very detailed Lighting information): https://lodev.org/unrealed/
 
+Texture Reference List (rather than squinting at the tiny previews in UEd): https://dxgalaxy.org/docs/reference/textures/
+
 http://dark191.333networks.com/uncodex/
 
 https://www.bunnytrack.net/package-explorer/

--- a/notes/notes.txt
+++ b/notes/notes.txt
@@ -30,21 +30,6 @@ static final function SetGameRenderDevice(string RenderDevicePath)
 -----------------------------
 -----------------------------
 
-check gas grenades ammo
-loadouts score boosts?
-
-allow loadouts to mess with skills? remove the config crap? loadouts give bonus points?
-taking some items/ammo out of a stack but not all when full
-make aquinas router door keypad unhackable maybe?
-
-manually add actors to the safety checks for keys and datacubes, as an easier version of the safe_rules, basically a whitelist of actor names (and/or a quick way to generate safety rules based on actor names?)
-
-check gmdx augs list
-add a note for every mission change?
-What if consuming the VialAmbrosia yourself gave you a full heal or something lol
-check mission 5 jailbreak in all mods
-
-
 Needed this to run UnrealEd http://download.microsoft.com/download/vb50pro/utility/1/win98/EN-US/Msvbvm50.exe
 
 Patched editor https://coding.hanfling.de/launch/#dxstuff
@@ -82,8 +67,6 @@ EditPackages=HX
 EditPackages=HXRandomizer
 
 HX scale difficulty with extra players like diablo, slightly increase enemy randomization and combat difficulty
-can I partially re-enable Paul's conversation in liberty island and remove the part where he gives you a weapon?
-	will need to mark it as played when entering unatco though, pretty sure it can break stuff
 GUI for NG+? can open a window similar to the advanced settings page
 create new "stories", start with a hub area (either hell's kitchen or hong kong, but which hell's kitchen?)
 	class DXRStories extends DXREntranceRando;
@@ -93,11 +76,6 @@ create new "stories", start with a hub area (either hell's kitchen or hong kong,
 	remove all vanilla npcs and dialog and add new ones
 	after beating a hub area, it can take you to the "next" area just by running a different seed, maybe do something to ensure it's based on a different hub area
 	I need to reuse the data in DXREntranceRando, maybe by subclassing it
-dynamically generate patrol routes? will probably need a new state for scriptedpawns to replace patrolling
-randomize item pool by replacing 50% of items?
-with flags binding, maybe I could convert some of them to floats or ints x100
-flashbang grenades?
-	for flashbang grenades, stun duration is hardcoded to sleep for 15 seconds in ScriptedPawn state Stunned Begin, maybe have to call them stun grenades
 
 CleanerBot Tick function could also cleanup Effects, TrashPaper, Fragment...
 
@@ -193,6 +171,8 @@ https://web.archive.org/web/20201023054944/http://wiki.beyondunreal.com/Legacy:C
 
 http://www.unrealtexture.com/Unreal/Downloads/3DEditing/UnrealEd/Tutorials/unrealwiki-offline/unrealscript.html
 
+Various UnrealEd information (mostly for the very detailed Lighting information): https://lodev.org/unrealed/
+
 http://dark191.333networks.com/uncodex/
 
 https://www.bunnytrack.net/package-explorer/
@@ -202,8 +182,6 @@ https://web.archive.org/web/20051025132508/http://mimesis.csc.ncsu.edu/Unreal/Sy
 https://ut99.org/viewtopic.php?t=5985
 
 https://www.dx-revision.com/dxtutorials/constructor/tutorials.htm
-
-charisma setting/skill that disables random dialog options with low charisma?
 
 https://forums.epicgames.com/unreal-tournament-3/unreal-tournament-3-programming-unrealscript/176322-decompile-u-files
 


### PR DESCRIPTION
v3.2 Halloween trailer rough draft: https://youtu.be/oWIXXpKjlBc

# v3.2.0.2 Beta Halloween changes:

- Halloween Entrance Rando game modes now available
- Mr H tweaks to no longer get stuck at M03 Liberty Island
- Mr H now damages decorations and pawns on bump
- Halloween mode M01 UNATCO HQ body is marked as unconscious instead of dead, so it will not become a zombie
- Fixed bug with zombies spawning as you pick up a body
- Reduced Jack O Lantern health
- Fixed Saves modes now allow ATMs
- Zombie timer now based on respawning enemies timer option, you can disable by setting to 0 in Advanced options
- Fixed spiderwebs on skyboxes

# v3.2.0.2 Beta Minor changes:

- Improve Nicolette's spotlight in the media store
- Clean up mission 5 surgery ward equipment locations and add more so items don't overlap.
- End credits now supports multiple columns of text
- More elevator tweaks
- Revision can use randomized music when soundtrack is set to vanilla
- For non-vanilla mods, fixed looted grenades and throwing knives from walls not having randomized stats
- Area51 improved datacube rules for stairwell blast door and reactor lab code datacubes in 15_Area51_Final
- Gas station now has a datacube with Tiffany's portrait (can help in WaltonWare)
- Maggie leaves her apartment after showing the DTS to Max, and a police vault datacube is added to 06_HONGKONG_WANCHAI_STREET 
- More goals and notes for WaltonWare starts

--------------------------

# Previously...

# Major changes since v3.1.1

- New game modes: Halloween Mode, WaltonWare Halloween, and Zombies Horde Mode
  - Limited and Fixed saves (you need a Memory Containment Unit to save, and you must save at a computer)
  - Mr H is immortal but you can hurt him to make him run away for a bit
  - Zombies!
  - You start with Run Silent instead of Speed aug (optional in Advanced settings)
  - You need to loot your Halloween costumes...

# Minor changes since v3.2.0.0 Alpha

- Fixed FOV adjustments for assault shotgun and DTS
- Tweaks with Mr H
- Area 51 gray room Geiger sound is quieter after generators are turned off
- Fixes for goal texts being updated
- Some zombie fixes
- Added a public terminal to Brooklyn Bridge Station to help with fixed saving modes
- Limited saving modes start with 2 memory containment units instead of 1
- NG+ Halloween modes no longer enable respawning enemies (because they already have zombies)
- Never add extra spaces around passwords
- Fixed locations for nanokeys in Paris street/metro, and added a key for the media store
- Added a spotlight in the Paris Media Store when a goal character is inside
- Prevent quick consume from using more than one in a stack
- Elevators now have more consistent movement speeds
- More fixes for various mid-mission start locations in WaltonWare

# Minor changes since v3.1.1

- Slightly increased Payphone collision radius as a lazy fix for badly placed payphones
- Fixes for weapon display on high FOV
- DXRMissions smarter mutual exclusions for fewer retries
- Maintain Paris Chill % across NG+ loops
- Improvements to handling of failed bingo goals
- New option to show or hide messages about bingo progress
- Fixes for more mid-mission starts in WaltonWare
- 03_NYC_AIRFIELDHELIBASE disable camera and turrets after finishing 747
- Fixed issues with upgrading active augs