### PR TITLE
v3.2.3.1 Beta

### DIFF
--- a/.github/run-tests/action.yml
+++ b/.github/run-tests/action.yml
@@ -7,7 +7,7 @@ runs:
         python-version: '3.8'
         cache: 'pip' # caching pip dependencies
 
-    - run: pip3 install -r installer/requirements.txt 2>&1
+    - run: pip3 install --break-system-packages -r installer/requirements.txt 2>&1
       shell: bash
 
     # check syntax and run tests

--- a/BingoDisplay.py
+++ b/BingoDisplay.py
@@ -255,32 +255,41 @@ def saveLastUsedBingoFile(f):
     # TODO: save last used file and reuse it for getDefaultPath()
 
 def getDefaultPath():
-    checks = [
-        Path.home() / "Documents" / "Deus Ex" / "System",
-        Path("C:\\") / "Program Files (x86)" / "Steam" / "steamapps" / "common" / "Deus Ex" / "Revision" / "System",
-        Path("D:\\") / "Program Files (x86)" / "Steam" / "steamapps" / "common" / "Deus Ex" / "Revision" / "System",
-        Path("C:\\") / "Program Files (x86)" / "Steam" / "steamapps" / "common" / "Deus Ex" / "System",
-        Path("D:\\") / "Program Files (x86)" / "Steam" / "steamapps" / "common" / "Deus Ex" / "System",
-        # Linux
-        Path.home() /'snap'/'steam'/'common'/'.local'/'share'/'Steam'/'steamapps'/'common'/'Deus Ex'/'System',
-        Path.home() /'.steam'/'steam'/'SteamApps'/'common'/'Deus Ex'/'System',
-        Path.home() /'.local'/'share'/'Steam'/'steamapps'/'compatdata'/'6910'/'pfx'/'drive_c'/'users'/'steamuser'/'Documents'/'Deus Ex'/'System',
-        Path.home() /'.local'/'share'/'Steam'/'steamapps'/'common'/'Deus Ex'/'System',
-    ]
+    try:
+        checks = [
+            Path.home() / "Documents" / "Deus Ex" / "System",
+            Path("C:\\") / "Program Files (x86)" / "Steam" / "steamapps" / "common" / "Deus Ex" / "Revision" / "System",
+            Path("D:\\") / "Program Files (x86)" / "Steam" / "steamapps" / "common" / "Deus Ex" / "Revision" / "System",
+            Path("C:\\") / "Program Files (x86)" / "Steam" / "steamapps" / "common" / "Deus Ex" / "System",
+            Path("D:\\") / "Program Files (x86)" / "Steam" / "steamapps" / "common" / "Deus Ex" / "System",
+            # Linux
+            Path.home() /'snap'/'steam'/'common'/'.local'/'share'/'Steam'/'steamapps'/'common'/'Deus Ex'/'System',
+            Path.home() /'.steam'/'steam'/'SteamApps'/'common'/'Deus Ex'/'System',
+            Path.home() /'.local'/'share'/'Steam'/'steamapps'/'compatdata'/'6910'/'pfx'/'drive_c'/'users'/'steamuser'/'Documents'/'Deus Ex'/'System',
+            Path.home() /'.local'/'share'/'Steam'/'steamapps'/'common'/'Deus Ex'/'System',
+        ]
 
-    modified_times = {}
-    for p in checks:
-        f:Path = p / "DXRBingo.ini"
-        if f.exists():
-            modified_times[p] = os.path.getmtime(f)
-    sorted_paths = sorted(modified_times.keys(), key=lambda f: modified_times[f])
+        modified_times = {}
+        for p in checks:
+            try:
+                f:Path = p / "DXRBingo.ini"
+                if f.exists():
+                    modified_times[p] = os.path.getmtime(f)
+            except Exception as e:
+                print(e)
+        sorted_paths = sorted(modified_times.keys(), key=lambda f: modified_times[f])
 
-    if len(sorted_paths) > 0:
-        return sorted_paths[-1]
-    p:Path
-    for p in checks:
-        if p.is_dir():
-            return p
+        if len(sorted_paths) > 0:
+            return sorted_paths[-1]
+        p:Path
+        for p in checks:
+            try:
+                if p.is_dir():
+                    return p
+            except Exception as e:
+                print(e)
+    except Exception as e:
+        print(e)
     return None
 
 def findBingoFile():

--- a/DXRBalance/DeusEx/Classes/WeaponProd.uc
+++ b/DXRBalance/DeusEx/Classes/WeaponProd.uc
@@ -1,0 +1,8 @@
+class DXRWeaponProd injects WeaponProd;
+
+// vanilla range is 80 (same as knife), DTS is 96
+defaultproperties
+{
+    maxRange=88
+    AccurateRange=88
+}

--- a/DXRCore/DeusEx/Classes/DXRInfo.uc
+++ b/DXRCore/DeusEx/Classes/DXRInfo.uc
@@ -188,12 +188,6 @@ function bool IsAprilFools()
     return Level.Month == 4 && Level.Day == 1 && class'MenuChoice_ToggleMemes'.static.IsEnabled(GetDXR().flags);
 }
 
-function bool IsOctoberUnlocked()
-{
-    // Happy Halloween! unlock gamemodes forever and other features
-    return true;
-}
-
 function bool IsOctober()
 {
     // Happy Halloween! This will be used for general halloween things like cosmetic changes and piano song weighting

--- a/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -87,11 +87,9 @@ function BindControls(optional string action)
     EnumOption("Autosave First Entry", autosave.FirstEntry, f.autosave);
     EnumOption("Autosaves-Only (Hardcore)", autosave.Hardcore, f.autosave);
     EnumOption("Extra Safe (1+GB per playthrough)", autosave.ExtraSafe, f.autosave);
-    if(f.IsOctoberUnlocked()) {
-        EnumOption("Limited Saves", autosave.LimitedSaves, f.autosave);
-        EnumOption("Limited Fixed Saves", autosave.FixedSaves, f.autosave);
-        EnumOption("Unlimited Fixed Saves", autosave.UnlimitedFixedSaves, f.autosave);
-    }
+    EnumOption("Limited Saves", autosave.LimitedSaves, f.autosave);
+    EnumOption("Limited Fixed Saves", autosave.FixedSaves, f.autosave);
+    EnumOption("Unlimited Fixed Saves", autosave.UnlimitedFixedSaves, f.autosave);
     EnumOption("Autosaves Disabled", autosave.Disabled, f.autosave);
 #endif
 

--- a/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -37,6 +37,9 @@ function BindControls(optional string action)
 #endif
 
     f = GetFlags();
+    if(writing) {
+        f.InitAdvancedDefaults();
+    }
 
     gamemode_enum = NewMenuItem("Game Mode", "Choose a game mode!");
     for(i=0; i<20; i++) {

--- a/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -90,6 +90,7 @@ function BindControls(optional string action)
     EnumOption("Limited Saves", autosave.LimitedSaves, f.autosave);
     EnumOption("Limited Fixed Saves", autosave.FixedSaves, f.autosave);
     EnumOption("Unlimited Fixed Saves", autosave.UnlimitedFixedSaves, f.autosave);
+    EnumOption("Extreme Limited Fixed Saves", autosave.FixedSavesExtreme, f.autosave);
     EnumOption("Autosaves Disabled", autosave.Disabled, f.autosave);
 #endif
 

--- a/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
@@ -89,11 +89,9 @@ function BindControls(optional string action)
     EnumOption("Show", 1, f.moresettings.splits_overlay);
 
 #ifdef vanilla
-    if (f.IsOctoberUnlocked()){
-        NewMenuItem("Clothes Looting", "Should clothes need to be looted first, or start with all of them?");
-        EnumOption("Full Closet", 0, f.clothes_looting);
-        EnumOption("Looting Required", 1, f.clothes_looting);
-    }
+    NewMenuItem("Clothes Looting", "Should clothes need to be looted first, or start with all of them?");
+    EnumOption("Full Closet", 0, f.clothes_looting);
+    EnumOption("Looting Required", 1, f.clothes_looting);
 #endif
 
     NewGroup("Bingo");

--- a/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
@@ -242,6 +242,9 @@ function BindControls(optional string action)
     NewMenuItem("Enemy Shuffling %", "Shuffle enemies around the map.");
     Slider(f.settings.enemiesshuffled, 0, 100);
 
+    NewMenuItem("Enemy Weapons Variety %", "Should enemies be using weapons that normally exist in the map?");
+    Slider(f.moresettings.enemies_weapons, 0, 100);
+
     NewMenuItem("Non-Human Chance %", "Reduce the chance of new enemies being non-humans.");
     Slider(f.settings.enemies_nonhumans, 0, 100);
 

--- a/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -4,13 +4,13 @@ simulated static function CurrentVersion(optional out int major, optional out in
 {
     major=3;
     minor=2;
-    patch=2;
-    build=2;//build can't be higher than 99
+    patch=3;
+    build=0;//build can't be higher than 99
 }
 
 simulated static function bool VersionIsStable()
 {
-    return true;
+    return false;
 }
 
 simulated static function string VersionString(optional bool full)
@@ -18,7 +18,7 @@ simulated static function string VersionString(optional bool full)
     local int major,minor,patch,build;
     local string status;
 
-    status = "";
+    status = "Alpha";
 
     if(status!="") {
         status = " " $ status;

--- a/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -5,7 +5,7 @@ simulated static function CurrentVersion(optional out int major, optional out in
     major=3;
     minor=2;
     patch=3;
-    build=0;//build can't be higher than 99
+    build=1;//build can't be higher than 99
 }
 
 simulated static function bool VersionIsStable()
@@ -18,7 +18,7 @@ simulated static function string VersionString(optional bool full)
     local int major,minor,patch,build;
     local string status;
 
-    status = "Alpha";
+    status = "Beta";
 
     if(status!="") {
         status = " " $ status;

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
@@ -42,6 +42,8 @@ function PreFirstEntryMapFixes()
     local #var(prefix)HumanCivilian hc;
     local #var(prefix)OrdersTrigger ot;
     local #var(prefix)FlagTrigger ft;
+    local #var(prefix)ComputerPublic compublic;
+    local bool VanillaMaps;
 #ifdef injections
     local #var(prefix)Newspaper np;
     local class<#var(prefix)Newspaper> npClass;
@@ -52,6 +54,8 @@ function PreFirstEntryMapFixes()
     local class<DXRInformationDevices> npClass;
     npClass = class'DXRInformationDevices';
 #endif
+
+    VanillaMaps = class'DXRMapVariants'.static.IsVanillaMaps(player());
 
     switch(dxr.localURL) {
     case "01_NYC_UNATCOISLAND":
@@ -146,6 +150,17 @@ function PreFirstEntryMapFixes()
 
         //To change it so Manderley will brief you if you talked to Sam and Jaime (instead of actually getting equipment from Sam)
         SetTimer(1.0, True);
+
+        if (VanillaMaps) {
+            foreach AllActors(class'#var(prefix)ComputerPublic', compublic) {
+                compublic.bCollideWorld = false;
+                compublic.SetLocation(vectm(741.36, 1609.34, 298.0));
+                compublic.SetRotation(rotm(0, -16384, 0, GetRotationOffset(class'#var(prefix)ComputerPublic')));
+                compublic.TextPackage = "#var(package)";
+                compublic.BulletinTag = '01_BulletinMenu';
+                break;
+            }
+        }
 
         //Spawn some placeholders for new item locations
         Spawn(class'PlaceholderItem',,, vectm(363.284149, 344.847, 50.32)); //Womens bathroom counter

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -82,6 +82,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)OrdersTrigger ot;
     local AlarmUnit au;
     local vector loc;
+    local #var(prefix)ComputerPublic compublic;
 
     local bool VanillaMaps;
 
@@ -390,6 +391,17 @@ function PreFirstEntryMapFixes()
         foreach AllActors(class'#var(prefix)OrdersTrigger',ot){
             if (ot.ordersTag=='CarterAtWindow'){
                 ot.Orders='RunningTo';
+                break;
+            }
+        }
+
+        if (VanillaMaps) {
+            foreach AllActors(class'#var(prefix)ComputerPublic', compublic) {
+                compublic.bCollideWorld = false;
+                compublic.SetLocation(vectm(741.36, 1609.34, 298.0));
+                compublic.SetRotation(rotm(0, -16384, 0, GetRotationOffset(class'#var(prefix)ComputerPublic')));
+                compublic.TextPackage = "#var(package)";
+                compublic.BulletinTag = '03_BulletinMenu';
                 break;
             }
         }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -56,6 +56,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)HumanCivilian hc;
     local Teleporter tel;
     local DynamicTeleporter dtel;
+    local #var(prefix)ComputerPublic compublic;
     local #var(prefix)LaserTrigger lt;
     local #var(prefix)Datacube dc;
 
@@ -284,6 +285,17 @@ function PreFirstEntryMapFixes()
             key.Description = "MedLab Closet Key Code";
             if(dxr.flags.settings.keysrando > 0)
                 GlowUp(key);
+        }
+
+        if (VanillaMaps) {
+            class'#var(prefix)ComputerPublic'.default.bCollideWorld = false;
+            compublic = #var(prefix)ComputerPublic(Spawnm(
+                class'#var(prefix)ComputerPublic',,,
+                vect(741.36, 1609.34, 298.00),
+                rot(0, -16384, 0)
+            ));
+            compublic.TextPackage = "#var(package)";
+            compublic.BulletinTag = '04_BulletinMenuUnatco';
         }
 
         //Spawn some placeholders for new item locations

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -42,6 +42,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)Terrorist miguel;
     local #var(prefix)Keypad3 kp;
     local #var(prefix)Cigarettes cigs;
+    local #var(prefix)ComputerPublic compublic;
 
     local DXREnemies dxre;
     local int i;
@@ -169,6 +170,13 @@ function PreFirstEntryMapFixes()
                 k.Description = "MedLab Closet Key Code";
                 if(dxr.flags.settings.keysrando > 0)
                     GlowUp(k);
+            }
+
+            foreach AllActors(class'#var(prefix)ComputerPublic', compublic) {
+                compublic.bCollideWorld = false;
+                compublic.SetLocation(vectm(741.36, 1609.34, 298.0));
+                compublic.SetRotation(rotm(0, -16384, 0, GetRotationOffset(class'#var(prefix)ComputerPublic')));
+                break;
             }
 
             //Spawn some placeholders for new item locations

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM09.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM09.uc
@@ -89,6 +89,8 @@ function PreFirstEntryMapFixes()
             rg=Spawn(class'#var(prefix)RatGenerator',,, vectm(-738,-1412,-474));//Near sewer grate
             rg.MaxCount=1;
 
+            SetAllLampsState(false, true, false); // the lamps in zhao's empty room
+
             //Add some new locations for containers and items
             Spawn(class'PlaceholderContainer',,, vectm(-3143,274,305)); //Front of ship
             Spawn(class'PlaceholderContainer',,, vectm(-3109,-73,305)); //Front of ship

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
@@ -778,6 +778,11 @@ function AnyEntryMapFixes()
         SetTimer(1, True);
 
         break;
+
+    case "14_OCEANLAB_LAB":
+        GetConversation('DL_Simons1').AddFlagRef('WaltonSimons_Dead', false);
+        GetConversation('DL_Simons2').AddFlagRef('WaltonSimons_Dead', false);
+        break;
     }
 }
 

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -2206,15 +2206,15 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
         case "PaulDenton_Dead":
             return "Let Paul Denton die (or kill him yourself) during the ambush on the hotel";
         case "JordanShea_Dead":
-            return "Kill Jordan Shea, the bartender at the Underworld bar in New York";
+            return "Kill Jordan Shea, the bartender at the Underworld Tavern in New York";
         case "SandraRenton_Dead":
             msg = "Kill Sandra Renton (or let her die).  ";
             if (mission<=2){
-                msg=msg$"  She can be found in an alley next to the Underworld bar in New York";
+                msg=msg$"  She can be found in an alley next to the Underworld Tavern in New York";
             } else if (mission<=4){
                 msg=msg$"  She can be found inside the hotel";
             } else if (mission<=8){
-                msg=msg$"  She can be found in the Underworld bar";
+                msg=msg$"  She can be found in the Underworld Tavern";
             } else if (mission<=12){
                 msg=msg$"  She can be found outside the gas station";
             }
@@ -2269,7 +2269,7 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
         case "JoeGreene_Dead":
             msg= "Kill Joe Greene, the reporter poking around in New York.  ";
             if (mission<=4){
-                msg=msg$"He can be found in the Underworld bar.";
+                msg=msg$"He can be found in the Underworld Tavern.";
             }else if (mission<=8){
                 msg=msg$"He can be found somewhere in New York after you return from Hong Kong.";
             }
@@ -2323,7 +2323,7 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
         case "DL_Flooded_Played":
             return "Swim outside of the Ocean Lab on the ocean floor and enter the flooded section through the hole blasted in the underside of the structure.  There is a flickering light above the hole you need to enter.";
         case "JockSecondStory":
-            return "Buy two beers from Jordan Shea and give them to Jock in the Underworld bar.";
+            return "Buy two beers from Jordan Shea and give them to Jock in the Underworld Tavern.";
         case "M07ChenSecondGive_Played":
             return "After the triad meeting in the temple, meet the leaders in the Lucky Money and receive all the gifted bottles of wine from each Dragon Head.";
         case "DeBeersDead":
@@ -2707,17 +2707,17 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             if (mission<=1){
                 msg=msg$"There is a machine in Alex's office as well as the break room.";
             } else if (mission<=2){
-                msg=msg$"There is a machine in the Underworld bar in Hell's Kitchen.";
+                msg=msg$"There is a machine in the Underworld Tavern in Hell's Kitchen.";
             } else if (mission<=3){
                 msg=msg$"There is a machine in Alex's office and the break room of UNATCO HQ, two machines in the LaGuardia helibase break room, and one in the Airfield barracks.";
             } else if (mission<=4){
-                msg=msg$"There is a machine in Alex's office and the break room of UNATCO HQ, as well as one in the Underworld bar in Hell's Kitchen.";
+                msg=msg$"There is a machine in Alex's office and the break room of UNATCO HQ, as well as one in the Underworld Tavern in Hell's Kitchen.";
             } else if (mission<=5){
                 msg=msg$"There is a machine in Alex's office and the break room of UNATCO HQ.";
             } else if (mission<=6){
                 msg=msg$"There is a machine in the MJ12 Helibase, one in the MJ12 Lab barracks, one in the Old China Hand, and one in the Lucky Money.";
             } else if (mission<=8){
-                msg=msg$"There is a machine in the Underworld bar in Hell's Kitchen.";
+                msg=msg$"There is a machine in the Underworld Tavern in Hell's Kitchen.";
             } else if (mission<=12){
                 msg=msg$"There is a machine in the Comms building in Vandenberg.";
             } else if (mission<=15){
@@ -3137,7 +3137,7 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
         case "InterviewLocals":
             return "Interview some of the locals around Hell's Kitchen to find out more information about the NSF generator.";
         case "MeetSandraRenton_Played":
-            return "Rescue Sandra Renton from Johnny, the pimp who has her cornered in the alley beside the Underworld bar.";
+            return "Rescue Sandra Renton from Johnny, the pimp who has her cornered in the alley beside the Underworld Tavern.";
         default:
             return "Unable to find help text for event '"$event$"'|nReport this to the developers!";
     }

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -2447,7 +2447,7 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
         case "LeoToTheBar":
             return "Bring the body of Leo Gold (The terrorist commander from Liberty Island) to any bar in the game (New York, Hong Kong, Paris) and set him down.  You can also bring him to the bottom of the Ocean Lab, since it is under many BARs of pressure.";
         case "KnowYourEnemy":
-            return "Read enough 'Know Your Enemy' articles on the public computer in the UNATCO break room.";
+            return "Read enough \"Know Your Enemy\" bulletins on the public computer in the UNATCO break room.";
         case "09_NYC_DOCKYARD--796967769":
             return "Find Jenny's number (867-5309) somewhere in the outer area of the Brooklyn Naval Yards on a datacube.";
         case "JacobsShadow":
@@ -3275,7 +3275,7 @@ defaultproperties
 #ifndef hx
     bingo_options(99)=(event="LeoToTheBar",desc="Bring the terrorist commander to a bar",max=1,missions=17686)
 #endif
-    bingo_options(100)=(event="KnowYourEnemy",desc="Read %s Know Your Enemy bulletins",desc_singular="Read 1 Know Your Enemy bulletin",max=6,missions=10)
+    bingo_options(100)=(event="KnowYourEnemy",desc="Read %s Know Your Enemy bulletins",desc_singular="Read 1 Know Your Enemy bulletin",max=6,missions=26)
     bingo_options(101)=(event="09_NYC_DOCKYARD--796967769",desc="Learn Jenny's phone number",max=1,missions=512)
     bingo_options(102)=(event="JacobsShadow",desc="Read %s parts of Jacob's Shadow",desc_singular="Read 1 part of Jacob's Shadow",max=4,missions=38492)
     bingo_options(103)=(event="ManWhoWasThursday",desc="Read %s parts of The Man Who Was Thursday",desc_singular="Read 1 part of The Man Who Was Thursday",max=4,missions=54300)

--- a/DXRModules/DeusEx/Classes/DXRFashion.uc
+++ b/DXRModules/DeusEx/Classes/DXRFashion.uc
@@ -181,12 +181,10 @@ function AddDXRCredits(CreditsWindow cw)
 {
     local DXRFashionManager f;
 
-    if (IsOctoberUnlocked()) {
-        f=class'DXRFashionManager'.static.GiveItem(player());
+    f=class'DXRFashionManager'.static.GiveItem(player());
 
-        cw.PrintHeader("Fashion");
-        cw.PrintText("Number of Clothes in Closet:"@f.numClothes);
-        cw.PrintText("Number of Outfit Changes:"@f.GetNumOutfitChanges(player()));
-        cw.PrintLn();
-    }
+    cw.PrintHeader("Fashion");
+    cw.PrintText("Number of Clothes in Closet:"@f.numClothes);
+    cw.PrintText("Number of Outfit Changes:"@f.GetNumOutfitChanges(player()));
+    cw.PrintLn();
 }

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -808,12 +808,16 @@ simulated function bool FixInventory(#var(PlayerPawn) p)
         for(x = item.invPosX; x < item.invPosX + item.invSlotsX; x++) {
             for(y = item.invPosY; y < item.invPosY + item.invSlotsY; y++) {
                 if(slots[x*8 + y] > 0) {
-                    err("inventory overlap at (" $ x $ ", " $ y $ ") " $ item);
+                    warning("inventory overlap at (" $ x $ ", " $ y $ ") " $ item);
                     good = false;
                 }
                 slots[x*8 + y]++;
             }
         }
+    }
+
+    if(!good && class'MenuChoice_FixGlitches'.default.enabled) {
+        err("inventory overlap");
     }
 
     return good;

--- a/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -59,17 +59,8 @@ simulated function PlayerAnyEntry(#var(PlayerPawn) p)
     l("starting map is set to "$settings.starting_map);
 }
 
-function InitDefaults()
+function InitAdvancedDefaults()
 {
-    InitVersion();
-    if(!#defined(hx)) {
-        seed = 0;
-        NewPlaythroughId();
-        if( dxr != None) {
-            RollSeed();
-        }
-        crowdcontrol = 0;
-    }
     bingo_duration=0;
     bingo_scale=100;
     newgameplus_loops = 0;
@@ -81,6 +72,20 @@ function InitDefaults()
     newgameplus_num_removed_weapons = 1;
 
     clothes_looting=0;
+}
+
+function InitDefaults()
+{
+    InitVersion();
+    if(!#defined(hx)) {
+        seed = 0;
+        NewPlaythroughId();
+        if( dxr != None) {
+            RollSeed();
+        }
+        crowdcontrol = 0;
+    }
+    InitAdvancedDefaults();
 
 #ifdef hx
     difficulty = 1;

--- a/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -12,6 +12,7 @@ const RandoMedium = 9;
 const WaltonWareHardcore = 10;
 const WaltonWarex3 = 11;
 const ZeroRandoPlus = 12;
+const OneItemMode = 13;
 const HordeZombies = 1020;
 const WaltonWareHalloweenEntranceRando = 1029;
 const HalloweenEntranceRando = 1030;
@@ -703,11 +704,11 @@ function string DifficultyName(int diff)
 function int GameModeIdForSlot(int slot)
 {// allow us to reorder in the menu, similar to DXRLoadouts::GetIdForSlot
     if(slot--==0) return 0;
-    if(IsOctoberUnlocked() && slot--==0) return HalloweenMode;
+    if(slot--==0) return HalloweenMode;
     if(slot--==0) return EntranceRando;
-    if(IsOctoberUnlocked() && slot--==0) return HalloweenEntranceRando;
-    if(IsOctoberUnlocked() && slot--==0) return WaltonWareHalloween;
-    if(IsOctoberUnlocked() && slot--==0) return WaltonWareHalloweenEntranceRando;
+    if(slot--==0) return HalloweenEntranceRando;
+    if(slot--==0) return WaltonWareHalloween;
+    if(slot--==0) return WaltonWareHalloweenEntranceRando;
     if(slot--==0) return WaltonWare;
     if(slot--==0) return WaltonWareEntranceRando;
     if(!VersionIsStable()) {
@@ -720,8 +721,9 @@ function int GameModeIdForSlot(int slot)
     if(slot--==0) return RandoMedium;
     if(slot--==0) return SpeedrunMode;
     if(slot--==0) return SeriousSam;
-    if(IsOctoberUnlocked() && slot--==0) return HordeZombies;
+    if(slot--==0) return HordeZombies;
     if(slot--==0) return HordeMode;
+    if(slot--==0) return OneItemMode;
     return 999999;
 }
 
@@ -738,8 +740,7 @@ function string GameModeName(int gamemode)
     case HordeMode:
         return "Horde Mode";
     case HordeZombies:
-        if(IsOctoberUnlocked()) return "Zombies Horde Mode";// maybe a full-time replacement for original horde mode?
-        break;
+        return "Zombies Horde Mode";// maybe a full-time replacement for original horde mode?
 #endif
     case RandoLite:
         return "Randomizer Lite";
@@ -754,8 +755,7 @@ function string GameModeName(int gamemode)
     case SpeedrunMode:
         return "Speedrun Mode";
     case WaltonWareHalloween:
-        if(IsOctoberUnlocked()) return "WaltonWare Halloween";
-        break;
+        return "WaltonWare Halloween";
     case WaltonWare:
         return "WaltonWare";
 #ifdef injections
@@ -769,8 +769,9 @@ function string GameModeName(int gamemode)
     case WaltonWarex3:
         return "WaltonWare x3";
     case HalloweenMode:
-        if(IsOctoberUnlocked()) return "Halloween Mode";// maybe needs a better name
-        break;
+        return "Halloween Mode";// maybe needs a better name
+    case OneItemMode:
+        return "One Item Mode";
     }
     //EnumOption("Kill Bob Page (Alpha)", 3, f.gamemode);
     //EnumOption("How About Some Soy Food?", 6, f.gamemode);
@@ -821,6 +822,11 @@ function bool IsWaltonWareHardcore()
 function bool IsHalloweenMode()
 {
     return gamemode == HalloweenMode || gamemode == HordeZombies || gamemode == WaltonWareHalloween || gamemode == HalloweenEntranceRando || gamemode == WaltonWareHalloweenEntranceRando;
+}
+
+function bool IsOneItemMode()
+{
+    return gamemode == OneItemMode;
 }
 
 simulated function AddDXRCredits(CreditsWindow cw)

--- a/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -177,6 +177,7 @@ function CheckConfig()
     more_difficulty_settings[i].grenadeswap = 100;
     more_difficulty_settings[i].newgameplus_curve_scalar = -1;// disable NG+ for faster testing, gamemode can override
     more_difficulty_settings[i].camera_mode = 0;
+    more_difficulty_settings[i].enemies_weapons = 100;
     more_difficulty_settings[i].splits_overlay = 0;
     i++;
 #endif
@@ -251,6 +252,7 @@ function CheckConfig()
     more_difficulty_settings[i].grenadeswap = 100;
     more_difficulty_settings[i].newgameplus_curve_scalar = 100;
     more_difficulty_settings[i].camera_mode = 0;
+    more_difficulty_settings[i].enemies_weapons = 100;
     more_difficulty_settings[i].splits_overlay = 0;
     i++;
 
@@ -324,6 +326,7 @@ function CheckConfig()
     more_difficulty_settings[i].grenadeswap = 100;
     more_difficulty_settings[i].newgameplus_curve_scalar = 100;
     more_difficulty_settings[i].camera_mode = 0;
+    more_difficulty_settings[i].enemies_weapons = 100;
     more_difficulty_settings[i].splits_overlay = 0;
     i++;
 
@@ -397,6 +400,7 @@ function CheckConfig()
     more_difficulty_settings[i].grenadeswap = 100;
     more_difficulty_settings[i].newgameplus_curve_scalar = 100;
     more_difficulty_settings[i].camera_mode = 0;
+    more_difficulty_settings[i].enemies_weapons = 100;
     more_difficulty_settings[i].splits_overlay = 0;
     i++;
 
@@ -470,6 +474,7 @@ function CheckConfig()
     more_difficulty_settings[i].grenadeswap = 100;
     more_difficulty_settings[i].newgameplus_curve_scalar = 100;
     more_difficulty_settings[i].camera_mode = 0;
+    more_difficulty_settings[i].enemies_weapons = 100;
     more_difficulty_settings[i].splits_overlay = 0;
     i++;
 
@@ -505,6 +510,8 @@ function FlagsSettings SetDifficulty(int new_difficulty)
         settings.startinglocations = 0;
         settings.goals = 0;
         settings.dancingpercent = 0;
+        settings.enemiesrandomized *= 0.8;
+        moresettings.enemies_weapons *= 0.8;
     }
     else if(IsReducedRando()) {
         settings.doorsmode = 0;
@@ -516,6 +523,7 @@ function FlagsSettings SetDifficulty(int new_difficulty)
         settings.deviceshackable = 0;
         settings.infodevices = 0;
         settings.enemiesrandomized = 0;
+        moresettings.enemies_weapons = 0;
         settings.hiddenenemiesrandomized = 0;
         settings.enemiesshuffled = 0;
         settings.enemies_nonhumans = 0;

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -82,6 +82,7 @@ struct MoreFlagsSettings{
     var int newgameplus_curve_scalar;
     var int empty_medbots;
     var int camera_mode;
+    var int enemies_weapons;
 
     var int splits_overlay;// keep this at the end for automated tests
 };
@@ -353,6 +354,7 @@ simulated function string BindFlags(int mode, optional string str)
     if(!FlagInt('Rando_enemystats', settings.enemystats, mode, str) && mode==Reading) {
         settings.enemystats = settings.enemiesrandomized * 2;
     }
+    FlagInt('Rando_enemies_weapons', moresettings.enemies_weapons, mode, str);
     FlagInt('Rando_hiddenenemiesrandomized', settings.hiddenenemiesrandomized, mode, str);
     FlagInt('Rando_enemiesshuffled', settings.enemiesshuffled, mode, str);
     FlagInt('Rando_infodevices', settings.infodevices, mode, str);
@@ -604,6 +606,8 @@ simulated function string flagNameToHumanName(name flagname){
             return "Splits Overlay";
         case 'Rando_clothes_looting':
             return "Clothes Looting";
+        case 'Rando_enemies_weapons':
+            return "Enemy weapons rando";
         default:
             err("flagNameToHumanName: " $ flagname $ " missing human readable name");
             return flagname $ "(ADD HUMAN READABLE NAME!)"; //Showing the raw flag name will stand out more
@@ -680,6 +684,7 @@ simulated function string flagValToHumanVal(name flagname, int val){
         case 'Rando_grenadeswap':
         case 'Rando_newgameplus_curve_scalar':
         case 'Rando_bot_weapons':
+        case 'Rando_enemies_weapons':
             return val$"%";
 
         case 'Rando_enemyrespawn':

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -423,10 +423,7 @@ simulated function string BindFlags(int mode, optional string str)
     FlagInt('Rando_camera_mode', moresettings.camera_mode, mode, str);
     FlagInt('Rando_splits_overlay', moresettings.splits_overlay, mode, str);
 
-    //Keep this option hidden in the credits until October
-    if (mode!=Credits || IsOctoberUnlocked()){
-        FlagInt('Rando_clothes_looting',clothes_looting,mode,str);
-    }
+    FlagInt('Rando_clothes_looting',clothes_looting,mode,str);
 
     return str;
 }

--- a/DXRModules/DeusEx/Classes/DXRHalloween.uc
+++ b/DXRModules/DeusEx/Classes/DXRHalloween.uc
@@ -404,6 +404,8 @@ function MakeCosmetics()
     }
 
     SetSeed("MakeJackOLanterns");
+    ConsoleCommand("set DXRJackOLantern bBlockActors " $ (!dxr.flags.IsSpeedrunMode()));
+    ConsoleCommand("set DXRJackOLantern bBlockPlayers " $ (!dxr.flags.IsSpeedrunMode()));
     if(IsHalloween()) num = len/30;
     else num = len/30 * Level.Day/40;// divided by 40 instead of 31 to make it weaker
     for(i=0; i<num; i++) {
@@ -486,6 +488,7 @@ function SpawnJackOLantern(vector loc)
 
     r.Yaw = Rotator(wall1.norm).Yaw;
     jacko = spawn(class'DXRJackOLantern',,, wall1.loc, r);
+    if(jacko == None) return;
     jacko.DrawScale *= size;
     jacko.SetCollisionSize(jacko.CollisionRadius*size,jacko.CollisionHeight*size);
 
@@ -540,6 +543,7 @@ function SpawnSpiderweb(vector loc)
         }
         break;
     }
+    if(target == None) return;
 
     rot.roll = rng(65536);
 
@@ -551,6 +555,7 @@ function SpawnSpiderweb(vector loc)
     }
     web = Spawn(webClass,,, loc, rot);
     web.DrawScale = size;
+    if(Mover(target)!=None) web.SetBase(target);
 }
 
 function bool GetSpiderwebLocation(out vector loc, out rotator rot, float size)

--- a/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -636,6 +636,7 @@ function class<Inventory> _GetRandomUtilityItem()
         if( _randomitems[i].type == None ) continue;
         if( chance( _randomitems[i].chance, r ) ) iclass = _randomitems[i].type;
     }
+    chance_remaining(r);
     return iclass;
 }
 

--- a/DXRModules/DeusEx/Classes/DXRReduceItems.uc
+++ b/DXRModules/DeusEx/Classes/DXRReduceItems.uc
@@ -126,7 +126,8 @@ function OneItemMode()
 {
     local Inventory item, nextItem, items[1024];
     local #var(prefix)Containers d;
-    local class<Inventory> contents[1024], newclass;
+    local class<Actor> contents[1024];
+    local class<Inventory> newclass;
     local #var(DeusExPrefix)Carcass carc;
     local int num, numcontents, i, slot;
     local vector loc;
@@ -150,9 +151,11 @@ function OneItemMode()
     }
 
     if(num<=1) return;
-    slot = rng(num+numcontents);
-    if(slot<num) newclass = items[slot].class;
-    else newclass = contents[slot-num];
+    while(newclass==None) {
+        slot = rng(num+numcontents);
+        if(slot<num) newclass = items[slot].class;
+        else newclass = class<Inventory>(contents[slot-num]);
+    }
 
     for(i=0; i<num; i++) {
         if(i==slot) continue;
@@ -378,7 +381,6 @@ function bool _ReduceSpawnInContainer(#var(prefix)Containers d, class<Inventory>
 function ReduceSpawnsInContainers(class<Inventory> classname, float percent)
 {
     local #var(prefix)Containers d;
-    local class<Inventory> contents;
 
     SetSeed( "ReduceSpawnsInContainers " $ classname.Name );
 

--- a/DXRModules/DeusEx/Classes/DXRReduceItems.uc
+++ b/DXRModules/DeusEx/Classes/DXRReduceItems.uc
@@ -102,6 +102,7 @@ function PostFirstEntry()
         && dxr.flags.settings.biocells==100
         && dxr.flags.settings.medkits==100
     ) {
+        if(dxr.flags.IsOneItemMode()) OneItemMode();
         return;
     }
 
@@ -117,6 +118,75 @@ function PostFirstEntry()
 
     SetAllMaxCopies(scale);
     SetTimer(1.0, true);
+
+    if(dxr.flags.IsOneItemMode()) OneItemMode();
+}
+
+function OneItemMode()
+{
+    local Inventory item, nextItem, items[1024];
+    local #var(prefix)Containers d;
+    local class<Inventory> contents[1024], newclass;
+    local #var(DeusExPrefix)Carcass carc;
+    local int num, numcontents, i, slot;
+    local vector loc;
+    local rotator rot;
+    local EPhysics phys;
+    local Actor base;
+
+    foreach AllActors(class'Inventory', item) {
+        if(item.bIsSecretGoal) continue;
+        if(Pawn(item.Owner) != None) continue;
+        if(item.bDeleteMe) continue;
+        if(#var(prefix)NanoKey(item) != None) continue;
+        items[num++] = item;
+    }
+
+    foreach AllActors(class'#var(prefix)Containers', d) {
+        if (#var(PlayerPawn)(d.base)!=None) continue;
+        if(d.Contents!=None) contents[numcontents++] = d.Contents;
+        if(d.Content2!=None) contents[numcontents++] = d.Content2;
+        if(d.Content3!=None) contents[numcontents++] = d.Content3;
+    }
+
+    if(num<=1) return;
+    slot = rng(num+numcontents);
+    if(slot<num) newclass = items[slot].class;
+    else newclass = contents[slot-num];
+
+    for(i=0; i<num; i++) {
+        if(i==slot) continue;
+        item = items[i];
+        loc = item.Location;
+        loc.Z -= item.CollisionHeight;
+        rot = item.Rotation;
+        phys = item.physics;
+        base = item.Base;
+        carc = #var(DeusExPrefix)Carcass(item.Owner);
+        if(carc != None) carc.DeleteInventory(item);
+        item.Destroy();
+
+        loc.Z += newclass.default.CollisionHeight;
+
+        item = Spawn(newclass,,, loc, rot);
+        if(item==None) continue;
+        item.SetPhysics(phys);
+        item.SetBase(base);
+
+        if(carc!=None) {
+            item.BecomeItem();
+            carc.AddInventory(item);
+            item.GotoState('Idle2');
+        }
+    }
+
+    foreach AllActors(class'#var(prefix)Containers', d) {
+        if (#var(PlayerPawn)(d.base)!=None) continue;
+        if(d.Contents==None && d.Content2==None && d.Content3==None) continue;
+        d.Contents = newclass;
+        d.Content2 = None;
+        d.Content3 = None;
+    }
 }
 
 function ReduceItem(Inventory a)

--- a/DXRModules/DeusEx/Classes/DXRReplaceActors.uc
+++ b/DXRModules/DeusEx/Classes/DXRReplaceActors.uc
@@ -16,6 +16,9 @@ function ReplaceActors()
         else if( #var(prefix)AllianceTrigger(a) != None ) {
             ReplaceAllianceTrigger(#var(prefix)AllianceTrigger(a));
         }
+        else if( #var(prefix)OrdersTrigger(a) != None ) {
+            ReplaceOrdersTrigger(#var(prefix)OrdersTrigger(a));
+        }
         else if( #var(prefix)ShakeTrigger(a) != None ) {
             ReplaceShakeTrigger(#var(prefix)ShakeTrigger(a));
         }
@@ -297,6 +300,20 @@ function ReplaceAllianceTrigger(#var(prefix)AllianceTrigger a)
         n.Alliances[i].AllianceLevel = a.Alliances[i].AllianceLevel;
         n.Alliances[i].bPermanent = a.Alliances[i].bPermanent;
     }
+
+    ReplaceTrigger(a, n);
+    a.Destroy();
+}
+
+function ReplaceOrdersTrigger(#var(prefix)OrdersTrigger a)
+{
+    local DXROrdersTrigger n;
+    n = DXROrdersTrigger(SpawnReplacement(a, class'DXROrdersTrigger'));
+    if(n == None)
+        return;
+
+    n.Orders = a.Orders;
+    n.ordersTag = a.ordersTag;
 
     ReplaceTrigger(a, n);
     a.Destroy();

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -991,9 +991,8 @@ static function bool BingoGoalImpossible(string bingo_event, int start_map, int 
         {
         case "MaggieCanFly":
             return start_map >= 66; // can technically be done still by carrying her body out of VersaLife but it's not really sensible to have as a goal at this point
-        // // this goal can actually be done with the way these starts currently work, but would normally be impossible
-        // case "M06JCHasDate":
-        //     return start_map > 65;
+        case "M06JCHasDate":
+            return start_map > 65;
         }
         break;
 

--- a/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminalATM.uc
+++ b/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminalATM.uc
@@ -38,12 +38,12 @@ function ConfigurationChanged()
 
 function CreateKnownAccountsWindow()
 {
-    if( class'MenuChoice_PasswordAutofill'.default.value < 1 ) return;
+    if( class'MenuChoice_PasswordAutofill'.static.GetSetting() < 1 ) return;
 
     winKnownShadow = ShadowWindow(NewChild(Class'ShadowWindow'));
 
     winKnownAccounts = ComputerScreenKnownAccounts(NewChild(Class'ComputerScreenKnownAccounts'));
-    if( class'MenuChoice_PasswordAutofill'.default.value == 2 )
+    if( class'MenuChoice_PasswordAutofill'.static.GetSetting() == 2 )
         winKnownAccounts.bShowPasswords = true;
     winKnownAccounts.SetNetworkTerminal(Self);
     winKnownAccounts.SetCompOwner(compOwner);

--- a/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminalPersonal.uc
+++ b/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminalPersonal.uc
@@ -34,12 +34,12 @@ function ConfigurationChanged()
 
 function CreateKnownAccountsWindow()
 {
-    if( class'MenuChoice_PasswordAutofill'.default.value < 1 ) return;
+    if( class'MenuChoice_PasswordAutofill'.static.GetSetting() < 1 ) return;
 
     winKnownShadow = ShadowWindow(NewChild(Class'ShadowWindow'));
 
     winKnownAccounts = ComputerScreenKnownAccounts(NewChild(Class'ComputerScreenKnownAccounts'));
-    if( class'MenuChoice_PasswordAutofill'.default.value == 2 )
+    if( class'MenuChoice_PasswordAutofill'.static.GetSetting() == 2 )
         winKnownAccounts.bShowPasswords = true;
     winKnownAccounts.SetNetworkTerminal(Self);
     winKnownAccounts.SetCompOwner(compOwner);

--- a/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminalSecurity.uc
+++ b/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminalSecurity.uc
@@ -34,12 +34,12 @@ function ConfigurationChanged()
 
 function CreateKnownAccountsWindow()
 {
-    if( class'MenuChoice_PasswordAutofill'.default.value < 1 ) return;
+    if( class'MenuChoice_PasswordAutofill'.static.GetSetting() < 1 ) return;
 
     winKnownShadow = ShadowWindow(NewChild(Class'ShadowWindow'));
 
     winKnownAccounts = ComputerScreenKnownAccounts(NewChild(Class'ComputerScreenKnownAccounts'));
-    if( class'MenuChoice_PasswordAutofill'.default.value == 2 )
+    if( class'MenuChoice_PasswordAutofill'.static.GetSetting() == 2 )
         winKnownAccounts.bShowPasswords = true;
     winKnownAccounts.SetNetworkTerminal(Self);
     winKnownAccounts.SetCompOwner(compOwner);

--- a/DXRVanilla/DeusEx/Classes/DXRNetworkTerminal.uc
+++ b/DXRVanilla/DeusEx/Classes/DXRNetworkTerminal.uc
@@ -104,12 +104,12 @@ function CloseScreen(String action)
 
 function CreateKnownAccountsWindow()
 {
-    if( class'MenuChoice_PasswordAutofill'.default.value < 1 ) return;
+    if( class'MenuChoice_PasswordAutofill'.static.GetSetting() < 1 ) return;
 
     winKnownShadow = ShadowWindow(NewChild(Class'ShadowWindow'));
 
     winKnownAccounts = ComputerScreenKnownAccounts(NewChild(Class'ComputerScreenKnownAccounts'));
-    if( class'MenuChoice_PasswordAutofill'.default.value == 2 )
+    if( class'MenuChoice_PasswordAutofill'.static.GetSetting() == 2 )
         winKnownAccounts.bShowPasswords = true;
     winKnownAccounts.SetNetworkTerminal(Self);
     winKnownAccounts.SetCompOwner(compOwner);

--- a/DXRando/DeusEx/Classes/DXRandoText.uc
+++ b/DXRando/DeusEx/Classes/DXRandoText.uc
@@ -24,3 +24,19 @@ class DXRandoText extends object abstract;
 #exec DEUSEXTEXT IMPORT FILE=Text\10_HostelBulletin02.txt
 
 #exec DEUSEXTEXT IMPORT FILE=Text\04_Datacube03.txt
+
+// UNATCO public terminals
+#exec DEUSEXTEXT IMPORT FILE=Text\01_BulletinMenu.txt
+#exec DEUSEXTEXT IMPORT FILE=Text\03_BulletinMenu.txt
+#exec DEUSEXTEXT IMPORT FILE=Text\04_BulletinMenuUnatco.txt
+
+#exec DEUSEXTEXT IMPORT FILE=Text\01_Bulletin01.txt
+#exec DEUSEXTEXT IMPORT FILE=Text\01_Bulletin02.txt
+#exec DEUSEXTEXT IMPORT FILE=Text\01_Bulletin05.txt
+#exec DEUSEXTEXT IMPORT FILE=Text\01_Bulletin06.txt
+#exec DEUSEXTEXT IMPORT FILE=Text\01_Bulletin07.txt
+#exec DEUSEXTEXT IMPORT FILE=Text\01_Bulletin08.txt
+#exec DEUSEXTEXT IMPORT FILE=Text\03_Bulletin01.txt
+#exec DEUSEXTEXT IMPORT FILE=Text\03_Bulletin02.txt
+#exec DEUSEXTEXT IMPORT FILE=Text\03_Bulletin03.txt
+#exec DEUSEXTEXT IMPORT FILE=Text\03_Bulletin04.txt

--- a/DXRando/DeusEx/Classes/InformationDevices.uc
+++ b/DXRando/DeusEx/Classes/InformationDevices.uc
@@ -342,6 +342,14 @@ final function bool GlowOff()
     }
 }
 
+function BaseChange()
+{
+    Super.BaseChange();
+    if(LevelInfo(Base)!=None || Brush(Base)!=None) {
+        SetCollision(true,false,false);
+    }
+}
+
 defaultproperties
 {
     bInvincible=True

--- a/DXRando/DeusEx/Classes/Keypad.uc
+++ b/DXRando/DeusEx/Classes/Keypad.uc
@@ -28,7 +28,7 @@ simulated function ActivateKeypadWindow(DeusExPlayer Hacker, bool bHacked)
 function bool GetInstantSuccess(DeusExPlayer Hacker, bool bHacked)
 {
    if( bHacked ) return true;
-   if( class'MenuChoice_PasswordAutofill'.default.value == 2 && bCodeKnown ) return true;
+   if( class'MenuChoice_PasswordAutofill'.static.GetSetting() == 2 && bCodeKnown ) return true;
    return false;
 }
 

--- a/DXRando/DeusEx/Classes/MemConUnit.uc
+++ b/DXRando/DeusEx/Classes/MemConUnit.uc
@@ -7,20 +7,21 @@ function BeginPlay()
     MultiSkins[1] = Texture(DynamicLoadObject("Extras.Matrix_A00", class'Texture'));
 }
 
+#ifdef injections
 function PostPostBeginPlay()
 {
-    local DXRFlags m;
+    local DXRAutosave m;
     Super.PostPostBeginPlay();
 
-    m = DXRFlags(class'DXRFlags'.static.Find());
+    m = DXRAutosave(class'DXRAutosave'.static.Find());
 
-    if (m==None) return; //There should always be a DXRFlags, but better safe than sorry
+    if (m==None) return;
 
-    if (m.autosave==7){ //Fixed Saves
+    if (m.IsFixedSaves()){
         Description=default.Description $ "|n|nYou must have an ATM, personal computer, public terminal, or security computer highlighted in order to save your game.";
     }
 }
-
+#endif
 
 defaultproperties
 {

--- a/DXRando/DeusEx/Classes/OrdersTrigger.uc
+++ b/DXRando/DeusEx/Classes/OrdersTrigger.uc
@@ -1,0 +1,45 @@
+class DXROrdersTrigger injects #var(prefix)OrdersTrigger;
+
+#ifdef hx
+function StartPatrolling()
+#else
+function bool StartPatrolling()
+#endif
+{
+    local ScriptedPawn P;
+    local name newTag;
+
+#ifdef hx
+    if(Event == '') return;
+#else
+    if(Event == '') return True;
+#endif
+
+    newtag = StringToName(Event $ "_clone");
+
+    // find the target NPC to start on the patrol route
+    foreach AllActors (class'ScriptedPawn', P) {
+        if( P.Tag != Event && P.Tag != newtag ) continue;
+
+        if(Orders=='Idle' && Robot(P)==None) {
+            P.HealthTorso = 0;
+            P.Health = 0;
+            P.TakeDamage(1, P, P.Location, vect(0,0,0), 'Shot');
+        }
+        else
+            P.SetOrders(Orders, ordersTag, True);
+    }
+
+#ifndef hx
+    return True;
+#endif
+}
+
+#ifndef hx
+function Name StringToName(string s)
+{
+    local DeusExPlayer player;
+    player = DeusExPlayer(GetPlayerPawn());
+    return player.rootWindow.StringToName(s);
+}
+#endif

--- a/DXRando/DeusEx/Text/01_Bulletin01.txt
+++ b/DXRando/DeusEx/Text/01_Bulletin01.txt
@@ -1,0 +1,12 @@
+<DC=255,255,255>
+<P><B>Terrorism -- Crime or Conscience?</B>
+<P>
+<P>The question must be asked: is the global rise of terrorism a haphazard response to a decimated economy or is there a pattern?  Does UNATCO face coordinated ideological opposition?
+<P>
+<P>Some groups -- Silhouette in France, for instance -- have declared a "Meme War," or "war of meanings" in their terminology.  They spread email and pamphlets that lampoon the U.N.'s proposal for a one-world democracy, a tedious exercise in rudimentary propaganda.  With sophistries and doublespeak, they portray "freedom" as "obedience," "democracy" as "tyranny," and UNATCO as the perpetrator of terrorism -- an idea as shocking as it is reprehensible.
+<P>
+<P>Other organizations, such as the self-proclaimed revolutionary National Seccessionist Forces (NSF) in the U.S., claim allegiance to the Meme War, but are in fact no better than common criminals.  They desire territory and wealth at the expense of society at large.  Their "civil war" is merely a smokescreen for criminal activity.
+<P>
+<P>Any population can be quickly turned against such "revolutionaries" simply by educating them about the U.N.'s policies and goals.
+<P>
+<P>-- Joseph Manderley, Director, UNATCO

--- a/DXRando/DeusEx/Text/01_Bulletin02.txt
+++ b/DXRando/DeusEx/Text/01_Bulletin02.txt
@@ -1,0 +1,10 @@
+<DC=255,255,255>
+<P><B>Terrorism -- Threat Profiling</B>
+<P>
+<P>Symbolic attacks -- the Statue of Liberty bombing, the desecration of the Soviet War Memorial in Berlin, the department-store shooting-sprees on Orchard Road in Singapore -- are the recourse of the weak.  They serve only to call attention to a group or cause that is of no more than marginal interest to the public.
+<P>
+<P>But what distinguishes true terrorist activity is its gradual escalation towards genuine acts of war.  Fringe groups now have access to technology that allows direct assaults on governments, including the classic trio of nuclear, biological, or chemical weaponry (NBC).  But aside from direct assaults on a nation and its people, indirect attacks can cause considerable collateral damage -- rogue software can disrupt financial markets, communications, and military operations, while encryption programs allow terrorists to coordinate smuggling operations in secret right over the Net!  Drugs, guns, illegal immigrants, and even heavy equipment such as armored vehicles and cruise missiles are routinely traded across borders, aided and abetted by such software.
+<P>
+<P>UNATCO -- the first organization with the technology, manpower, and authority to cope with such threats -- is an idea that is long overdue.
+<P>
+<P>-- Joseph Manderley, Director, UNATCO

--- a/DXRando/DeusEx/Text/01_Bulletin05.txt
+++ b/DXRando/DeusEx/Text/01_Bulletin05.txt
@@ -1,0 +1,8 @@
+<DC=255,255,255>
+<P><B>Know Your Enemy -- NSF</B>
+<P>
+<P>The National Secessionist Forces (NSF) remain a very real and increasingly widespread terrorist threat.  Ten years ago, in response to the Sporting Weapons Act of 2042, splinter groups from nearly every state militia refused to surrender their rifles, grenades, land mines, and other "collectibles" prohibited by the Act.  Unified under the charismatic leadership of Leon Woods, these isolated fanatics eventually formed the NSF with Woods assuming the rank of General. Their intended goal: the "liberation" of Washington, Montana, Oregon, and Northern California.
+<P>
+<P>While Woods died during his infamous "last stand" in 2045, his war machine continues what can only be termed an occupation of the United States, aided by an encrypted network designed by dissident computer scientists from San Francisco and Seattle.  Currently, the UNATCO Cryptography Division has had minimal success in cracking their communications, requiring more direct intelligence gathering techniques to be utilized.
+<P>
+<P>The U.N. has declared war on the NSF.

--- a/DXRando/DeusEx/Text/01_Bulletin06.txt
+++ b/DXRando/DeusEx/Text/01_Bulletin06.txt
@@ -1,0 +1,8 @@
+<DC=255,255,255>
+<P><B>Know Your Enemy -- Silhouette</B>
+<P>
+<P>Famous for inserting 20th-century style commercials into the Net broadcast of the World Cup in 2050, Silhouette favors "feats of spectacle" over violence.
+<P>
+<P>"Printed circuits, part of this nutritious breakfast," the announcer told children in one of the World Cup commercials.  "You ain't mech 'til you eat mech.  [A mech boy chews a memory chip.]  Boys who eat organics get stomped by their posthuman classmates.  [Mech boys in UNATCO helmets and metal boots take turns kicking another boy.]"
+<P>
+<P>Despite their numerous pranks, these intellectuals, artists, and labor organizers pose a serious threat.  They are well-armed and have been linked to the murders of numerous European politicians and journalists.  They will not hesitate to use lethal force.

--- a/DXRando/DeusEx/Text/01_Bulletin07.txt
+++ b/DXRando/DeusEx/Text/01_Bulletin07.txt
@@ -1,0 +1,6 @@
+<DC=255,255,255>
+<P><B>Know Your Enemy -- The Triads</B>
+<P>
+<P>UNATCO surveillance of Hong Kong is currently a high priority given the renewed threat of Chinese organized crime in the form of the Triads.  Despite being a model of prosperity and technological leadership for decades, Hong Kong persists as a haven for organized crime.  The Triads, namely the Luminous Path and Red Arrow, vie for control of the ten-trillion credit shipping business, much of which supplies greater Asia with pirated technology, illegal drugs, and weapons.
+<P>
+<P>Most disturbing of all, the Triads preach an ethic of technopiracy that has found enthusiastic support among small shopkeepers and businessmen who often aid the gangsters and buy their bootlegged software.  Gullible and greedy, this army of middlemen remain insensitive to how their violations of intellectual property and copyright laws damage the global information economy.

--- a/DXRando/DeusEx/Text/01_Bulletin08.txt
+++ b/DXRando/DeusEx/Text/01_Bulletin08.txt
@@ -1,0 +1,6 @@
+<DC=255,255,255>
+<P><B>Know Your Enemy -- Other Threats </B>
+<P>
+<P>UNATCO operatives have identified over 1250 terrorist organizations active in the world today, some too small to currently present a serious threat, but all eager to see one or more governments topple.
+<P>
+<P>Groups such as the Templars (Europe) and "X-51" (Western U.S.) will be dealt with in subsequent volumes of "Know Your Enemy."

--- a/DXRando/DeusEx/Text/01_BulletinMenu.txt
+++ b/DXRando/DeusEx/Text/01_BulletinMenu.txt
@@ -1,0 +1,5 @@
+<COMMENT>UNATCO HQ</COMMENT>
+<FILE=01_Bulletin01,Terrorism -- Crime or Conscience?>
+<FILE=01_Bulletin02,Terrorism -- Threat Profiling>
+<FILE=01_Bulletin05,Know Your Enemy -- NSF>
+<FILE=01_Bulletin06,Know Your Enemy -- Silhouette>

--- a/DXRando/DeusEx/Text/03_Bulletin01.txt
+++ b/DXRando/DeusEx/Text/03_Bulletin01.txt
@@ -1,0 +1,6 @@
+<DC=255,255,255>
+<P><B>Know Your Enemy -- Templars</B>
+<P>
+<P>There is some debate as to whether the Templars should be considered a "terrorist" organization because they do not employ the typical tools of terrorism.  But make no mistake, the Templars are just as dangerous as any other group that might use guns and bombs to intimidate the free citizens of a country -- only the Templars wield blackmail and extortion as their weapons.  Supposedly the direct descendent of a so-called "secret society" with its roots in the medieval Crusades, the present-day Templars are mainly concerned with increasing their own bank accounts in elaborately illegal financial manipulations that have left entire markets collapsed in their wake. 
+<P>
+<P>The Templars are currently classified as inactive after being successfully diminished by a combined UNATCO/Interpol raid on their Paris headquarters in 2051; however, several key Templar figures are still at large and may attempt to reform the organization under a new designation.

--- a/DXRando/DeusEx/Text/03_Bulletin02.txt
+++ b/DXRando/DeusEx/Text/03_Bulletin02.txt
@@ -1,0 +1,6 @@
+<DC=255,255,255>
+<P><B>Know Your Enemy -- X-51</B>
+<P>
+<P>Little is known about "X-51" aside from their involvement in all manner of illegal research, much of it proscribed by worldwide concordes over the last fifty years.  Computer profiling shows a high likelihood that X-51 was responsible for the SoCal disaster that submerged much of southern California, though the exact nature of the experiment that led to the tragedy is still unknown.  Little other information is available on the overall objective of X-51, if any exists.
+<P>
+<P>X-51 is believed to be led by Gary Savage, a scientist previously employed by the United States government for a variety of black projects until he disappeared under mysterious circumstances several years ago.  All agents are advised to be vigilant for any indications as to the whereabouts of Savage or other members of X-51, and report them immediately to their operator or immediate superior.

--- a/DXRando/DeusEx/Text/03_Bulletin03.txt
+++ b/DXRando/DeusEx/Text/03_Bulletin03.txt
@@ -1,0 +1,8 @@
+<DC=255,255,255>
+<P><B>Stopping Terror -- A New Perspective on Freedom</B>
+<P>
+<P>When one maniac can wipe out a city of twenty million with a microbe developed in his basement, a new approach to law enforcement becomes necessary.  Every citizen of the world must be placed under surveillance.  That means sky-cams at every intersection, computer-mediated analysis of every phone call, e-mail, and snail-mail, and a purely electronic economy in which every transaction is recorded and data-mined for suspicious activity.
+<P>
+<P>We are close to achieving this goal.  Some would say that human liberty has been compromised, but the reality is just the opposite.  As surveillance expands, people become free from danger, free to walk alone at night, free to work in a safe place, and free to buy any legal product or service without the threat of fraud.  One day every man and woman will quietly earn credits, purchase items for quiet homes on quiet streets, have cook-outs with neighbors and strangers alike, and sleep with doors and windows wide open.  If that isn't the tranquil dream of every free civilization throughout history, what is?
+<P>
+<P>-- Anna Navarre, Agent, UNATCO

--- a/DXRando/DeusEx/Text/03_Bulletin04.txt
+++ b/DXRando/DeusEx/Text/03_Bulletin04.txt
@@ -1,0 +1,10 @@
+<DC=255,255,255>
+<P><B>Terrorism -- War Without Fronts</B>
+<P>
+<P>How do we fight an underground threat, one with no defined territory, base, or -- often -- known leader?  We look to military history.
+<P>
+<P>The casebook example of how to manage civil unrest is the Hamlet Evaluation System (HES) developed by the United States military during its occupation of South Vietnam in the 20th Century.  Since population centers in that country contained both Communist rebels and loyal citizens, the towns were ranked on a scale from 1 to 5, five being the safest.  The monthly reports of local commanders, useful in Vietnam for maintaining contour maps of ideology concentration, have provided many components of the UNATCO Sector Field Report.
+<P>
+<P>The modern UDU (UNATCO Deployed Unit) has been modeled on the CAP (Combined Action Platoon) deployed in Vietnam, a 15-man rifle squad responsible for a single hamlet.  CAP-protected villages typically earned a 2.95 HET score, compared to a 1.6 average in the same region.  CAP units performed in many mission roles, but they primarily worked with indigenous police to strengthen ideological ties.  Like CAP units, UNATCO teams are primarily concerned with building safe communities.
+<P>
+<P>-- Joseph Manderley, Director, UNATCO

--- a/DXRando/DeusEx/Text/03_BulletinMenu.txt
+++ b/DXRando/DeusEx/Text/03_BulletinMenu.txt
@@ -1,0 +1,4 @@
+<COMMENT>UNATCO HQ</COMMENT>
+<FILE=03_Bulletin03,Stopping Terror>
+<FILE=01_Bulletin07,Know Your Enemy -- The Triads>
+<FILE=01_Bulletin08,Know Your Enemy -- Other Threats>

--- a/DXRando/DeusEx/Text/04_BulletinMenuUnatco.txt
+++ b/DXRando/DeusEx/Text/04_BulletinMenuUnatco.txt
@@ -1,0 +1,4 @@
+<COMMENT>UNATCO HQ</COMMENT>
+<FILE=03_Bulletin04,Terrorism -- War Without Fronts>
+<FILE=03_Bulletin01,Know Your Enemy -- Templars>
+<FILE=03_Bulletin02,Know Your Enemy -- X-51>

--- a/GUI/DeusEx/Classes/FrobDisplayWindow.uc
+++ b/GUI/DeusEx/Classes/FrobDisplayWindow.uc
@@ -52,13 +52,13 @@ event StyleChanged()
 
 function bool GetAutoCodes()
 {
-    return class'MenuChoice_PasswordAutofill'.default.value == 2;
+    return class'MenuChoice_PasswordAutofill'.static.GetSetting() == 2;
 
 }
 
 function bool GetKnownCodes()
 {
-    return class'MenuChoice_PasswordAutofill'.default.value >= 1;
+    return class'MenuChoice_PasswordAutofill'.static.GetSetting() >= 1;
 }
 
 function bool GetShowKeys()

--- a/GUI/DeusEx/Classes/MenuChoice_LootActionMisc.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_LootActionMisc.uc
@@ -4,7 +4,7 @@ class MenuChoice_LootActionMisc extends MenuChoice_LootAction;
 defaultproperties
 {
     HelpText="Should rebreathers, tech goggles, binoculars and flares be included in the list of Junk items that get dropped when looting a body?"
-    actionText="Miscellaneous"
+    actionText="Miscellaneous Items"
 
     itemClasses(0)=class'Rebreather'
     itemClasses(1)=class'TechGoggles'

--- a/GUI/DeusEx/Classes/MenuChoice_PasswordAutofill.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_PasswordAutofill.uc
@@ -11,13 +11,26 @@ function SaveSetting()
     ChangeStyle();
 }
 
+static function int GetSetting()
+{
+    local DXRando dxr;
+    if(default.value == 3) {
+        dxr = class'DXRando'.default.dxr;
+        if(dxr==None) return 2;
+        if(dxr.flags.IsZeroRandoPure()) return 0;
+        return 2;
+    }
+    return default.value;
+}
+
 defaultproperties
 {
-    value=2;
-    defaultvalue=2
+    value=3
+    defaultvalue=3
     HelpText="Help with finding randomized passwords from your notes."
     actionText="Password Assistance"
     enumText(0)="No Assistance"
     enumText(1)="Mark Known Passwords"
     enumText(2)="Autofill Passwords"
+    enumText(3)="According to Game Mode"
 }

--- a/installer/Install/__init__.py
+++ b/installer/Install/__init__.py
@@ -263,19 +263,25 @@ def GetDocumentsDir(system:Path) -> Path:
 
 
 def getDefaultPath():
-    checks = [
-        Path("C:\\") / "Program Files (x86)" / "Steam" / "steamapps" / "common" / "Deus Ex" / "System",
-        Path("D:\\") / "Program Files (x86)" / "Steam" / "steamapps" / "common" / "Deus Ex" / "System",
-        Path.home() /'snap'/'steam'/'common'/'.local'/'share'/'Steam'/'steamapps'/'common'/'Deus Ex'/'System',
-        Path.home() /'.steam'/'steam'/'SteamApps'/'common'/'Deus Ex'/'System',
-        Path.home() /'.steam'/'steam'/'steamapps'/'common'/'Deus Ex'/'System', # not sure if this ever happens but the one above with different capitalization had me suspicious
-        Path.home() /'.local'/'share'/'Steam'/'steamapps'/'common'/'Deus Ex'/'System',
-    ]
-    p:Path
-    for p in checks:
-        f:Path = p / "DeusEx.exe"
-        if f.exists():
-            return p
+    try:
+        checks = [
+            Path("C:\\") / "Program Files (x86)" / "Steam" / "steamapps" / "common" / "Deus Ex" / "System",
+            Path("D:\\") / "Program Files (x86)" / "Steam" / "steamapps" / "common" / "Deus Ex" / "System",
+            Path.home() /'snap'/'steam'/'common'/'.local'/'share'/'Steam'/'steamapps'/'common'/'Deus Ex'/'System',
+            Path.home() /'.steam'/'steam'/'SteamApps'/'common'/'Deus Ex'/'System',
+            Path.home() /'.steam'/'steam'/'steamapps'/'common'/'Deus Ex'/'System', # not sure if this ever happens but the one above with different capitalization had me suspicious
+            Path.home() /'.local'/'share'/'Steam'/'steamapps'/'common'/'Deus Ex'/'System',
+        ]
+        p:Path
+        for p in checks:
+            try:
+                f:Path = p / "DeusEx.exe"
+                if f.exists():
+                    return p
+            except Exception as e:
+                info(e)
+    except Exception as e:
+        info(e)
     return None
 
 


### PR DESCRIPTION
- OrdersTrigger now affects clones, and when disabling non-robots it kills them instead of making them t-pose
- Added our new dumbest game mode
- Don't play Walton infolinks if he's dead
- Fixed collision for datacubes, and in speedrun mode also for jack-o-lanterns
- Slightly buffed prod range (from 80 like knife, to 88, DTS is 96)
- Separate option for enemies weapons variety % (issue #729)
- Added the missing UNATCO public computer terminal to M04 and redistributed the articles between them
- Extreme Limited Fixed Saves, uses 2 MCUs per save
- Fixed installer and BingoViewer crash when searching paths
- Autofill passwords default disabled in Zero Rando (non-plus)
- Removed annoying messages about inventory overlap when glitches are enabled
- Fixed certain advanced settings not always being properly reset when navigating the new game screens and changing game modes