### PR TITLE
Play the mini crossbow's unique sound instead of 'StealthPistolFire'

### DIFF
--- a/DXRando/DeusEx/Classes/DXRWeaponMiniCrossbow.uc
+++ b/DXRando/DeusEx/Classes/DXRWeaponMiniCrossbow.uc
@@ -1,0 +1,7 @@
+class DXRWeaponMiniCrossbow injects WeaponMiniCrossbow;
+
+simulated function PlayFiringSound()
+{
+    // play the mini crossbow's unique sound instead of 'StealthPistolFire'
+    PlaySimSound( FireSound, SLOT_None, TransientSoundVolume, 2048 );
+}


### PR DESCRIPTION
This removes the check for `bHasSilencer` that `PlayFiringSound()` normally does, which causes it to play 'StealthPistolFire' instead.