### PR TITLE
Immediately mark the OverhearLebedev_Played bingo goal as failed when you talk to Lebedev

### DIFF
--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -513,6 +513,7 @@ function SetWatchFlags() {
         break;
     case "03_NYC_747":
         RewatchFlag('747Ambrosia');
+        WatchFlag('MeetLebedev_Played');
         WatchFlag('PlayerKilledLebedev');
         WatchFlag('AnnaKilledLebedev');
 
@@ -2069,69 +2070,23 @@ static function int GetBingoFailedEvents(string eventname, out string failed[5])
 
     // keep in mind that a goal can only be marked as failed if it isn't already marked as completed
     switch (eventname) {
-        case "JuanLebedev_Dead":
-            failed[num_failed++] = "LebedevLived";
+        
+        case "SubHostageFemale_Dead":
+        case "SubHostageMale_Unconscious":
+        case "SubHostageFemale_Dead":
+        case "SubHostageMale_Unconscious":
+            failed[num_failed++] = "SubwayHostagesSaved";
             return num_failed;
-        case "Aimee_Dead":
-        case "LeMerchant_Dead":
-            failed[num_failed++] = "AimeeLeMerchantLived";
-            return num_failed;
-        case "MaggieChow_Dead":
-            failed[num_failed++] = "MaggieLived";
+        case "AlleyBum_Dead":
+        case "AlleyBum_Unconscious":
+            failed[num_failed++] = "AlleyBumRescued";
             return num_failed;
         case "FordSchick_Dead":
             failed[num_failed++] = "FordSchickRescued";
             return num_failed;
-        case "AlleyBum_Dead":
-            failed[num_failed++] = "AlleyBumRescued";
+        case "GeneratorBlown":
+            failed[num_failed++] = "JockSecondStory";
             return num_failed;
-        case "Camille_Dead":
-            failed[num_failed++] = "CamilleConvosDone";
-            return num_failed;
-        case "Miguel_Dead":
-            failed[num_failed++] = "Terrorist_peeptime";
-            failed[num_failed++] = "Terrorist_ClassDead";
-            failed[num_failed++] = "Terrorist_ClassUnconscious";
-            failed[num_failed++] = "nsfwander";
-            failed[num_failed++] = "MiguelLeaving";
-            return num_failed;
-        case "Josh_Dead":
-            failed[num_failed++] = "JoshFed";
-            return num_failed;
-        case "Billy_Dead":
-            failed[num_failed++] = "M02BillyDone";
-            return num_failed;
-        case "Canal_Bartender_Dead":
-            failed[num_failed++] = "Canal_Bartender_Question4";
-            return num_failed;
-        case "ClubBartender_Dead":
-            failed[num_failed++] = "M06BartenderQuestion3";
-            return num_failed;
-        case "Joshua_Dead":
-            failed[num_failed++] = "JoshuaInterrupted_Played";
-            return num_failed;
-        case "Mamasan_Dead":
-        case "Date1_Dead":
-            failed[num_failed++] = "M06JCHasDate";
-            return num_failed;
-
-        case "KnowsAboutNanoSword":
-            failed[num_failed++] = "M06JCHasDate";
-            // fallthrough
-        case "ClubMercedes_Dead":
-        case "ClubTessa_Dead":
-            failed[num_failed++] = "ClubEntryPaid";
-            return num_failed;
-
-        // omg these hostage names
-        case "SubHostageFemale_Dead":
-        case "SubHostageMale_Dead":
-            failed[num_failed++] = "SubwayHostagesSaved";
-            return num_failed;
-        case "JoJoFine_Dead":
-            failed[num_failed++] = "GaveRentonGun";
-            return num_failed;
-
         case "SandraRenton_Dead":
             failed[num_failed++] = "FamilySquabbleWrapUpGilbertDead_Played";
             return num_failed;
@@ -2140,41 +2095,41 @@ static function int GetBingoFailedEvents(string eventname, out string failed[5])
                 failed[num_failed++] = "FamilySquabbleWrapUpGilbertDead_Played";
             }
             failed[num_failed++] = "GaveRentonGun";
-            // fallthrough
+        // fallthrough
         case "FemaleHostage_Dead":
         case "MaleHostage_Dead":
             failed[num_failed++] = "HotelHostagesSaved";
             return num_failed;
-
-        case "hostage_female_Dead":
-        case "hostage_Dead":
-            failed[num_failed++] = "SilhouetteHostagesAllRescued";
+        case "Josh_Dead":
+            failed[num_failed++] = "JoshFed";
             return num_failed;
-        case "M06Junkie_Dead":
-            failed[num_failed++] = "M06PaidJunkie";
-            return num_failed;
-        case "MarketBum1_Dead": // the guy who sells you the Versalife map and camo, isn't in the market, and looks nothing like a bum
-            failed[num_failed++] = "M06BoughtVersaLife";
-            return num_failed;
-        case "Supervisor01_Dead":
-            failed[num_failed++] = "Supervisor_Paid";
-            return num_failed;
-        case "Joshua_Dead":
-            failed[num_failed++] = "JoshuaInterrupted_Played";
+        case "Billy_Dead":
+            failed[num_failed++] = "M02BillyDone";
             return num_failed;
         case "Don_Dead":
+        case "Don_Unconscious":
         case "Lenny_Dead":
+        case "Lenny_Unconscious":
             failed[num_failed++] = "GiveZyme";
             return num_failed;
-        case "Renault_Dead":
-            failed[num_failed++] = "SoldRenaultZyme";
-            failed[num_failed++] = "MeetRenault_Played";
+        case "MeetLebedev_Played":
+            failed[num_failed++] = "OverhearLebedev_Played";
             return num_failed;
-        case "TimBaker_Dead":
-            failed[num_failed++] = "MeetTimBaker_Played";
+        case "JuanLebedev_Dead":
+            failed[num_failed++] = "LebedevLived";
             return num_failed;
-        case "drbernard_Dead":
-            failed[num_failed++] = "MeetDrBernard_Played";
+        case "JoJoFine_Dead":
+            failed[num_failed++] = "GaveRentonGun";
+            return num_failed;
+        case "NSFSignalSent":
+            failed[num_failed++] = "M04PlayerLikesUNATCO_Played";
+            return num_failed;
+        case "Miguel_Dead":
+            failed[num_failed++] = "Terrorist_peeptime";
+            failed[num_failed++] = "Terrorist_ClassDead";
+            failed[num_failed++] = "Terrorist_ClassUnconscious";
+            failed[num_failed++] = "nsfwander";
+            failed[num_failed++] = "MiguelLeaving";
             return num_failed;
         case "JaimeLeftBehind":
             failed[num_failed++] = "M07MeetJaime_Played";
@@ -2182,11 +2137,58 @@ static function int GetBingoFailedEvents(string eventname, out string failed[5])
         case "JaimeRecruited":
             failed[num_failed++] = "KnowsGuntherKillphrase";
             return num_failed;
-        case "NSFSignalSent":
-            failed[num_failed++] = "M04PlayerLikesUNATCO_Played";
+        case "M06Junkie_Dead":
+            failed[num_failed++] = "M06PaidJunkie";
             return num_failed;
-        case "GeneratorBlown":
-            failed[num_failed++] = "JockSecondStory";
+        case "MarketBum1_Dead": // the guy who sells you the Versalife map and camo, isn't in the market, and looks nothing like a bum
+            failed[num_failed++] = "M06BoughtVersaLife";
+            return num_failed;
+        case "Canal_Bartender_Dead":
+            failed[num_failed++] = "Canal_Bartender_Question4";
+            return num_failed;
+        case "ClubBartender_Dead":
+            failed[num_failed++] = "M06BartenderQuestion3";
+            return num_failed;
+        case "MaggieChow_Dead":
+            failed[num_failed++] = "MaggieLived";
+            return num_failed;
+        case "Mamasan_Dead":
+        case "Date1_Dead":
+            failed[num_failed++] = "M06JCHasDate";
+            return num_failed;
+        case "KnowsAboutNanoSword":
+            failed[num_failed++] = "M06JCHasDate";
+            // fallthrough
+        case "ClubMercedes_Dead":
+        case "ClubTessa_Dead":
+            failed[num_failed++] = "ClubEntryPaid";
+            return num_failed;
+        case "Supervisor01_Dead":
+            failed[num_failed++] = "Supervisor_Paid";
+            return num_failed;
+        case "Aimee_Dead":
+        case "LeMerchant_Dead":
+            failed[num_failed++] = "AimeeLeMerchantLived";
+            return num_failed;
+        case "hostage_female_Dead":
+        case "hostage_Dead":
+            failed[num_failed++] = "SilhouetteHostagesAllRescued";
+            return num_failed;
+        case "Renault_Dead":
+            failed[num_failed++] = "SoldRenaultZyme";
+            failed[num_failed++] = "MeetRenault_Played";
+            return num_failed;
+        case "Joshua_Dead":
+            failed[num_failed++] = "JoshuaInterrupted_Played";
+            return num_failed;
+        case "Camille_Dead":
+            failed[num_failed++] = "CamilleConvosDone";
+            return num_failed;
+        case "drbernard_Dead":
+            failed[num_failed++] = "MeetDrBernard_Played";
+            return num_failed;
+        case "TimBaker_Dead":
+            failed[num_failed++] = "MeetTimBaker_Played";
             return num_failed;
     }
 


### PR DESCRIPTION
This also rearranges the `GetBingoFailedEvents()` cases in chronological order. The actually new bit there starts at line 2115.