### PR TITLE
Make it impossible to get around the Airfield elevator teleporter

### DIFF
--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -69,6 +69,7 @@ function PreFirstEntryMapFixes()
     local Actor a;
     local Trigger t;
     local Teleporter tele;
+    local DynamicTeleporter dt;
     local #var(prefix)NanoKey k;
     local #var(prefix)InformationDevices i;
     local #var(prefix)UNATCOTroop unatco;
@@ -250,6 +251,18 @@ function PreFirstEntryMapFixes()
                     tele.SetCollisionSize(tele.CollisionRadius, tele.CollisionHeight + 10);
                 }
             }
+
+            foreach AllActors(class'Teleporter', tele) {
+                if (tele.event != 'BHElevatorEnt') continue;
+
+                tele.event = '';
+                tele.SetCollision(false, false, false);
+                break;
+            }
+            dt = Spawn(class'DynamicTeleporter',,, vectm(2048.0, -2827.0, 56.1));
+            dt.SetCollisionSize(50.0, 40.0);
+            dt.SetDestination("03_NYC_AirfieldHeliBase",, "BHElevatorEnt");
+
             //Add teleporter hint text to Jock
             foreach AllActors(class'#var(prefix)MapExit',exit){break;}
             foreach AllActors(class'#var(prefix)BlackHelicopter',jock){break;}

--- a/DXRModules/DeusEx/Classes/DXREntranceRando.uc
+++ b/DXRModules/DeusEx/Classes/DXREntranceRando.uc
@@ -1162,7 +1162,7 @@ function NavigationPoint AdjustTeleporter(NavigationPoint p)
         }
         else {
             if( dt != None )
-                dt.SetDestination(newMap, '', newTag);
+                dt.SetDestination(newMap,, newTag);
 #ifdef injections
             else if( m != None )
                 m.SetDestination(newMap, '', newTag);

--- a/DXRando/DeusEx/Classes/DynamicTeleporter.uc
+++ b/DXRando/DeusEx/Classes/DynamicTeleporter.uc
@@ -3,7 +3,7 @@ class DynamicTeleporter extends Teleporter;
 var name destName;
 var int yaw;
 
-function SetDestination(string destURL, name dest_actor_name, optional string tag, optional int dest_yaw)
+function SetDestination(string destURL, optional name dest_actor_name, optional string tag, optional int dest_yaw)
 {// TODO: make dest_yaw a required argument, have to add rotations to DXRBacktracking
     URL = destURL $ "#" $ tag;
     destName = dest_actor_name;


### PR DESCRIPTION
Care was used to make sure you enter the teleporter at about the same spot if you go in straight from one door to the other.