### PR TITLE
Don't set bingo_duration to 1 in NewBingoBoard()

### DIFF
--- a/DXRModules/DeusEx/Classes/DXRBingoCampaign.uc
+++ b/DXRModules/DeusEx/Classes/DXRBingoCampaign.uc
@@ -190,9 +190,8 @@ function NewBingoBoard()
     foreach AllActors(class'DXREvents', events) break;
     if (events == None) return;
 
-    dxr.flags.settings.starting_map = dxr.dxInfo.missionNumber * 10;
     dxr.flags.bingoBoardRoll = 0;
-    events.CreateBingoBoard();
+    events.CreateBingoBoard(dxr.dxInfo.missionNumber * 10);
     ClearDataVaultImages(player());
 }
 

--- a/DXRModules/DeusEx/Classes/DXRBingoCampaign.uc
+++ b/DXRModules/DeusEx/Classes/DXRBingoCampaign.uc
@@ -75,7 +75,7 @@ function FirstEntry()
 
                 AddBingoEventBlocker('everettsignaldoor', GetBingoMissionFlag(10));
 
-                dxr.flagbase.SetBool('MS_CommandosUnhidden', true,, 12); // keep commandos from spawning prematurely
+                dxr.flagbase.SetBool('MS_CommandosUnhidden', true,, 12); // keep commandos from being unhidden prematurely
                 ft = Spawn(class'#var(prefix)FlagTrigger',, 'everettsignaldoor_bingoblocked');
                 ft.flagName = 'DXRando_CommandosUnhidden';
                 ft.flagValue = true;
@@ -192,7 +192,6 @@ function NewBingoBoard()
 
     dxr.flags.settings.starting_map = dxr.dxInfo.missionNumber * 10;
     dxr.flags.bingoBoardRoll = 0;
-    dxr.flags.bingo_duration = 1;
     events.CreateBingoBoard();
     ClearDataVaultImages(player());
 }

--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -1043,14 +1043,20 @@ simulated function PlayerAnyEntry(#var(PlayerPawn) player)
     }
 }
 
-simulated function CreateBingoBoard()
+simulated function CreateBingoBoard(optional int starting_map)
 {
     local PlayerDataItem data;
+
+    if (starting_map == 0) {
+        starting_map = dxr.flags.settings.starting_map;
+    }
+
     dxr.flags.bingoBoardRoll++;
     dxr.flags.SaveFlags();
     SetGlobalSeed("bingo"$dxr.flags.bingoBoardRoll);
     data = class'PlayerDataItem'.static.GiveItem(player());
-    _CreateBingoBoard(data, dxr.flags.settings.starting_map, dxr.flags.bingo_duration);
+
+    _CreateBingoBoard(data, starting_map, dxr.flags.bingo_duration);
 }
 
 // a nice, convenient function to test some specified goal


### PR DESCRIPTION
Bingo boards in Bingo Machine mode were always for 1 mission, even if `bingo_duration` was set to something else, basically breaking that setting.