### PR TITLE
Scale bingo goals by duration

### DIFF
--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -1129,19 +1129,13 @@ simulated function _CreateBingoBoard(PlayerDataItem data, int starting_map, int 
     starting_mission = class'DXRStartMap'.static.GetStartMapMission(starting_map);
     starting_mission_mask = class'DXRStartMap'.static.GetStartingMissionMask(starting_map);
     maybe_mission_mask = class'DXRStartMap'.static.GetMaybeMissionMask(starting_map);
-    if (bingo_duration!=0){
-        end_mission = starting_mission + bingo_duration - 1; //The same mission is the first mission
 
-        //Missions 7 and 13 don't exist, so don't count them
-        if (starting_mission<7 && end_mission>=7){
-            end_mission+=1;
-        }
-        if (starting_mission<13 && end_mission>=13){
-            end_mission+=1;
-        }
-    } else {
-        end_mission = 15;
-    }
+    if (end_mission <= 0) end_mission = 15;
+    end_mission = class'DXRStartMap'.static.GetLogicalMissionNumber(starting_mission) + bingo_duration - 1;
+    end_mission = Min(end_mission, 13);
+    bingo_duration = end_mission - class'DXRStartMap'.static.GetLogicalMissionNumber(starting_mission) + 1;
+    end_mission = class'DXRStartMap'.static.GetIllogicalMissionNumber(end_mission);
+
     end_mission_mask = class'DXRStartMap'.static.GetEndMissionMask(end_mission);
 
     num_options = 0;
@@ -1247,6 +1241,7 @@ simulated function _CreateBingoBoard(PlayerDataItem data, int starting_map, int 
                 f = float(dxr.flags.bingo_scale)/100.0;
                 f = rngrange(f, 0.8, 1);// 80% to 100%
                 f *= MissionsMaskAvailability(starting_mission, masked_missions) ** 1.5;
+                f *= float(bingo_duration) / 13.0;
                 max = Ceil(float(max) * f);
                 max = self.Max(max, 1);
 

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -159,6 +159,25 @@ function PostFirstEntry()
     }
 }
 
+// Gives the mission number as if M07 and M15 didn't exist
+static function int GetLogicalMissionNumber(int illogical_mission_number)
+{
+    if (illogical_mission_number >= 13)
+        return illogical_mission_number - 2;
+    if (illogical_mission_number >= 7)
+        return illogical_mission_number - 1;
+    return illogical_mission_number;
+}
+
+static function int GetIllogicalMissionNumber(int logical_mission_number)
+{
+    if (logical_mission_number >= 13)
+        return logical_mission_number + 2;
+    if (logical_mission_number >= 7)
+        return logical_mission_number + 1;
+    return logical_mission_number;
+}
+
 static function int GetStartMapMission(int start_map_val)
 {
     local int mission;


### PR DESCRIPTION
Alleviates #975

Bingo goals are scaled by duration / 13. in other words, they're scaled by the playthrough's bingo duration divided by the default (i.e. full) duration.