### PR TITLE
v3.3.2.2 Alpha

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -31,7 +31,7 @@ jobs:
           path: installer/dist/BingoViewer.exe
 
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -67,7 +67,7 @@ jobs:
           overwrite: true
 
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
         RELEASE_TAG: testing
     defaults:

--- a/DXRBalance/DeusEx/Classes/BalancePlayer.uc
+++ b/DXRBalance/DeusEx/Classes/BalancePlayer.uc
@@ -29,9 +29,13 @@ function TakeDamage(int Damage, Pawn instigatedBy, Vector hitlocation, Vector mo
 
 function PlayTakeHitSound(int Damage, name damageType, int Mult)
 {
-    if(damageType == 'Fell') {
-        if(Damage <= 0) PlaySound(HitSound1, SLOT_Pain, FMax(Mult * TransientSoundVolume * 0.5, Mult * 1.0));
-        else PlaySound(HitSound2, SLOT_Pain, FMax(Mult * TransientSoundVolume, Mult * 2.0));
+    if ( Level.TimeSeconds - LastPainSound < 0.25 )
+        return;
+
+    if(damageType == 'Fell' && Damage <= 0) {
+        if(flagbase.GetBool('LDDPJCIsFemale')) PlaySound(Sound'FemaleLand', SLOT_Pain, FMax(Mult * TransientSoundVolume, Mult * 2.0));
+        else PlaySound(Sound'MaleLand', SLOT_Pain, FMax(Mult * TransientSoundVolume, Mult * 2.0));
+        LastPainSound = Level.TimeSeconds;
     }
     else {
         Super.PlayTakeHitSound(Damage, damageType, Mult);

--- a/DXRBalance/DeusEx/Classes/BalancePlayer.uc
+++ b/DXRBalance/DeusEx/Classes/BalancePlayer.uc
@@ -27,6 +27,17 @@ function TakeDamage(int Damage, Pawn instigatedBy, Vector hitlocation, Vector mo
     Super.TakeDamage(Damage, instigatedBy, hitlocation, momentum, damageType);
 }
 
+function PlayTakeHitSound(int Damage, name damageType, int Mult)
+{
+    if(damageType == 'Fell') {
+        if(Damage <= 0) PlaySound(HitSound1, SLOT_Pain, FMax(Mult * TransientSoundVolume * 0.5, Mult * 1.0));
+        else PlaySound(HitSound2, SLOT_Pain, FMax(Mult * TransientSoundVolume, Mult * 2.0));
+    }
+    else {
+        Super.PlayTakeHitSound(Damage, damageType, Mult);
+    }
+}
+
 function RandomizeAugStates()
 {
     local Augmentation aug;

--- a/DXRBalance/DeusEx/Classes/BalancePlayer.uc
+++ b/DXRBalance/DeusEx/Classes/BalancePlayer.uc
@@ -1,7 +1,5 @@
 class BalancePlayer injects Human;
 
-var travel bool bZeroRando, bReducedRando, bCrowdControl;
-
 function TakeDamage(int Damage, Pawn instigatedBy, Vector hitlocation, Vector momentum, name damageType)
 {
     local float augLevel;
@@ -97,7 +95,7 @@ function float AdjustCritSpots(float Damage, name damageType, vector hitLocation
         // narrow the head region
         if ((Abs(offset.x) < headOffsetY) || (Abs(offset.y) < headOffsetY))
         {
-            if(!bZeroRando) {
+            if(!class'DXRFlags'.default.bZeroRandoPure) {
                 // do 1.7x damage instead of the 2x damage in DeusExPlayer.uc::TakeDamage()
                 return Damage * 0.85;
             }
@@ -116,7 +114,7 @@ function float AdjustCritSpots(float Damage, name damageType, vector hitLocation
         {
             // left arm
         }
-        else if(!bZeroRando)
+        else if(!class'DXRFlags'.default.bZeroRandoPure)
         {
             // and finally, the torso! do 1.4x damage instead of the 2x damage in DeusExPlayer.uc::TakeDamage()
             return Damage * 0.7;
@@ -310,7 +308,7 @@ function float GetDamageMultiplier()
 {
     local DataStorage datastorage;
 
-    if (!bCrowdControl) return 0;
+    if (!class'DXRFlags'.default.bCrowdControl) return 0;
 
     datastorage = class'DataStorage'.static.GetObjFromPlayer(self);
     return float(datastorage.GetConfigKey('cc_damageMult'));
@@ -320,7 +318,7 @@ function bool WineBulletsActive()
 {
     local DataStorage datastorage;
 
-    if (!bCrowdControl) return False;
+    if (!class'DXRFlags'.default.bCrowdControl) return False;
 
     datastorage = class'DataStorage'.static.GetObjFromPlayer(self);
     return bool(datastorage.GetConfigKey('cc_WineBullets'));

--- a/DXRBalance/DeusEx/Classes/BuffTechGoggles.uc
+++ b/DXRBalance/DeusEx/Classes/BuffTechGoggles.uc
@@ -11,8 +11,10 @@ function static float CalcDistance(AugVision aug)
 function static string CalcDescription(AugVision aug)
 {
     local string desc;
-    desc = default.Description $ "|n|nSee-through walls distance: ";
-    desc = desc $ int(CalcDistance(aug)/16.0) $ " ft";
+    desc = default.Description;
+    if(!class'DXRFlags'.default.bZeroRandoPure) {
+        desc = desc $ "|n|nSee-through walls distance: " $ int(CalcDistance(aug)/16.0) $ " ft";
+    }
     return desc;
 }
 
@@ -20,6 +22,11 @@ function PostBeginPlay()
 {
     local AugVision aug;
     Super.PostBeginPlay();
+
+    if(class'DXRFlags'.default.bZeroRandoPure) {
+        Charge = class'TechGogglesInjBase'.default.Charge;
+        return;
+    }
 
     foreach AllActors(class'AugVision', aug) {
         Description = CalcDescription(aug);
@@ -34,6 +41,11 @@ function UpdateHUDDisplay(DeusExPlayer Player)
     local AugVision aug;
     local AugmentationDisplayWindow augDisplay;
     local float dist;
+
+    if(class'DXRFlags'.default.bZeroRandoPure) {
+        Super.UpdateHUDDisplay(Player);
+        return;
+    }
 
     aug = AugVision(Player.AugmentationSystem.FindAugmentation(class'AugVision'));
     dist = CalcDistance(aug);
@@ -59,6 +71,11 @@ function ChargedPickupEnd(DeusExPlayer Player)
 {
     local AugVision aug;
     local AugmentationDisplayWindow augDisplay;
+
+    if(class'DXRFlags'.default.bZeroRandoPure) {
+        Super.ChargedPickupEnd(Player);
+        return;
+    }
 
     augDisplay = DeusExRootWindow(Player.rootWindow).hud.augDisplay;
     if (--augDisplay.activeCount <= 0) {

--- a/DXRBalance/DeusEx/Classes/Chair1.uc
+++ b/DXRBalance/DeusEx/Classes/Chair1.uc
@@ -7,6 +7,7 @@ function BeginPlay()
         PrePivot = class'Chair1InjBase'.default.PrePivot;
         sitPoint[0] = class'Chair1InjBase'.default.sitPoint[0];
     }
+    Super.BeginPlay();
 }
 
 defaultproperties

--- a/DXRBalance/DeusEx/Classes/Chair1.uc
+++ b/DXRBalance/DeusEx/Classes/Chair1.uc
@@ -1,5 +1,14 @@
 class DXRChair1 injects Chair1;
 
+function BeginPlay()
+{
+    if(class'DXRFlags'.default.bZeroRandoPure) {
+        SetCollisionSize(CollisionRadius, class'Chair1InjBase'.default.CollisionHeight);
+        PrePivot = class'Chair1InjBase'.default.PrePivot;
+        sitPoint[0] = class'Chair1InjBase'.default.sitPoint[0];
+    }
+}
+
 defaultproperties
 {
     CollisionHeight=16

--- a/DXRBalance/DeusEx/Classes/HKChair.uc
+++ b/DXRBalance/DeusEx/Classes/HKChair.uc
@@ -7,6 +7,7 @@ function BeginPlay()
         PrePivot = class'HKChairInjBase'.default.PrePivot;
         sitPoint[0] = class'HKChairInjBase'.default.sitPoint[0];
     }
+    Super.BeginPlay();
 }
 
 defaultproperties

--- a/DXRBalance/DeusEx/Classes/HKChair.uc
+++ b/DXRBalance/DeusEx/Classes/HKChair.uc
@@ -1,5 +1,14 @@
 class DXRHKChair injects HKChair;
 
+function BeginPlay()
+{
+    if(class'DXRFlags'.default.bZeroRandoPure) {
+        SetCollisionSize(CollisionRadius, class'HKChairInjBase'.default.CollisionHeight);
+        PrePivot = class'HKChairInjBase'.default.PrePivot;
+        sitPoint[0] = class'HKChairInjBase'.default.sitPoint[0];
+    }
+}
+
 defaultproperties
 {
     CollisionHeight=16

--- a/DXRBalance/DeusEx/Classes/OfficeChair.uc
+++ b/DXRBalance/DeusEx/Classes/OfficeChair.uc
@@ -7,6 +7,7 @@ function BeginPlay()
         PrePivot = class'OfficeChairInjBase'.default.PrePivot;
         sitPoint[0] = class'OfficeChairInjBase'.default.sitPoint[0];
     }
+    Super.BeginPlay();
 }
 
 defaultproperties

--- a/DXRBalance/DeusEx/Classes/OfficeChair.uc
+++ b/DXRBalance/DeusEx/Classes/OfficeChair.uc
@@ -1,5 +1,14 @@
 class DXROfficeChair injects OfficeChair;
 
+function BeginPlay()
+{
+    if(class'DXRFlags'.default.bZeroRandoPure) {
+        SetCollisionSize(CollisionRadius, class'OfficeChairInjBase'.default.CollisionHeight);
+        PrePivot = class'OfficeChairInjBase'.default.PrePivot;
+        sitPoint[0] = class'OfficeChairInjBase'.default.sitPoint[0];
+    }
+}
+
 defaultproperties
 {
     CollisionHeight=15.549999

--- a/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -4,6 +4,7 @@ var string MaxRandoBtnTitle, MaxRandoBtnMessage;
 var string AdvancedBtnTitle, AdvancedBtnMessage;
 var string ExtremeBtnTitle, ExtremeBtnMessage;
 var string ImpossibleBtnTitle, ImpossibleBtnMessage;
+var string SplitsBtnTitle, SplitsBtnMessage;
 
 var int gamemode_enum, autosave_enum;
 
@@ -11,7 +12,7 @@ enum ERandoMessageBoxModes
 {
     RMB_MaxRando,
     RMB_Advanced,
-    RMB_Difficulty,// choosing Extreme or Impossible
+    RMB_NewGame,// choosing Extreme or Impossible, or starting with splits with a different flagshash
 };
 var ERandoMessageBoxModes nextScreenNum;
 
@@ -207,12 +208,16 @@ function HandleNewGameButton()
     local DXRFlags f;
     f = GetFlags();
 
-    if(dxr.rando_beaten == 0 && f.DifficultyName(f.difficulty) ~= "Extreme") {
-        nextScreenNum=RMB_Difficulty;
+    if(!class'HUDSpeedrunSplits'.static.CheckFlags(f)) {
+        nextScreenNum=RMB_NewGame;
+        root.MessageBox(SplitsBtnTitle,SplitsBtnMessage,0,False,Self);
+    }
+    else if(dxr.rando_beaten == 0 && f.DifficultyName(f.difficulty) ~= "Extreme") {
+        nextScreenNum=RMB_NewGame;
         root.MessageBox(ExtremeBtnTitle,ExtremeBtnMessage,0,False,Self);
     }
     else if(dxr.rando_beaten == 0 && f.DifficultyName(f.difficulty) ~= "Impossible") {
-        nextScreenNum=RMB_Difficulty;
+        nextScreenNum=RMB_NewGame;
         root.MessageBox(ImpossibleBtnTitle,ImpossibleBtnMessage,0,False,Self);
     }
     else {
@@ -283,7 +288,7 @@ event bool BoxOptionSelected(Window button, int buttonNumber)
                 DoAdvancedButtonConfirm();
             }
             return true;
-        case RMB_Difficulty:
+        case RMB_NewGame:
             if (buttonNumber==0){
                 DoNewGameScreen();
             }
@@ -334,4 +339,6 @@ defaultproperties
     ExtremeBtnMessage="It appears you're new to DX Randomizer.  Extreme difficulty means fewer items, less ammo, more enemies, higher skill costs, fewer medbots, and many other challenges.  Are you sure?"
     ImpossibleBtnTitle="Impossible Difficulty?"
     ImpossibleBtnMessage="It appears you're new to DX Randomizer.  Impossible difficulty means fewer items, less ammo, more enemies, higher skill costs, fewer medbots, and many other challenges.  Are you sure?"
+    SplitsBtnTitle="Mismatched Splits!"
+    SplitsBtnMessage="It appears that your DXRSplits.ini file is for different settings than this.  Are you sure you want to continue?"
 }

--- a/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
@@ -356,7 +356,7 @@ function BindControls(optional string action)
 
     NewGroup("Augmentations");
 
-    NewMenuItem("Speed Aug Level", "Start the game with the Speed Enhancement augmentation.");
+    NewMenuItem("Starting Aug Level", "What level your starting augs should start at." $ BR $ "Default loadout starts with the Speed Enhancement augmentation.");
     Slider(f.settings.speedlevel, 0, 4);
 
     NewMenuItem("Aug Cans Randomized %", "The chance for aug cannisters to have their contents changed.");

--- a/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
@@ -2,6 +2,14 @@ class DXRMenuSetupRando extends DXRMenuBase;
 
 var float combatDifficulty;
 
+var string SplitsBtnTitle, SplitsBtnMessage;
+
+enum ERandoMessageBoxModes
+{
+    RMB_NewGame,// starting with splits with a different flagshash
+};
+var ERandoMessageBoxModes nextScreenNum;
+
 event InitWindow()
 {
     Super.InitWindow();
@@ -381,7 +389,7 @@ function BindControls(optional string action)
     NewMenuItem("Weapons Removed", "Number of weapons removed per loop.");
     Slider(f.newgameplus_num_removed_weapons, 0, 18);
 
-    if( action == "NEXT" ) _InvokeNewGameScreen(combatDifficulty);
+    if( action == "NEXT" ) HandleNewGameButton();
     if( action == "RANDOMIZE" ) RandomizeOptions();
 }
 
@@ -407,6 +415,40 @@ function SetDifficulty(float newDifficulty)
     combatDifficulty = newDifficulty;
 }
 
+function HandleNewGameButton()
+{
+    local DXRFlags f;
+    f = GetFlags();
+
+    if(!class'HUDSpeedrunSplits'.static.CheckFlags(f)) {
+        nextScreenNum=RMB_NewGame;
+        root.MessageBox(SplitsBtnTitle,SplitsBtnMessage,0,False,Self);
+    }
+    else {
+        DoNewGameScreen();
+    }
+}
+
+function DoNewGameScreen()
+{
+    _InvokeNewGameScreen(combatDifficulty);
+}
+
+event bool BoxOptionSelected(Window button, int buttonNumber)
+{
+    root.PopWindow();
+
+    switch (nextScreenNum){
+        case RMB_NewGame:
+            if (buttonNumber==0){
+                DoNewGameScreen();
+            }
+            return true;
+    }
+
+    return Super.BoxOptionSelected(button,buttonNumber);
+}
+
 defaultproperties
 {
     num_rows=13
@@ -422,5 +464,6 @@ defaultproperties
     actionButtons(0)=(Align=HALIGN_Left,Action=AB_Cancel,Text="|&Back")
     actionButtons(1)=(Align=HALIGN_Right,Action=AB_Other,Text="|&Next",Key="NEXT")
     actionButtons(2)=(Align=HALIGN_Right,Action=AB_Other,Text="|&Randomize",Key="RANDOMIZE")
-
+    SplitsBtnTitle="Mismatched Splits!"
+    SplitsBtnMessage="It appears that your DXRSplits.ini file is for different settings than this.  Are you sure you want to continue?"
 }

--- a/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
@@ -30,6 +30,9 @@ function BindControls(optional string action)
         iDifficulty = int(combatDifficulty * 100.0);
         Slider(iDifficulty, 0, 10000);
         combatDifficulty = float(iDifficulty) / 100.0;
+    #ifndef hx
+        f.settings.CombatDifficulty = combatDifficulty;
+    #endif
     }
 
     //Make sure the starting map values match those in DXRStartMap

--- a/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -5,7 +5,7 @@ simulated static function CurrentVersion(optional out int major, optional out in
     major=3;
     minor=3;
     patch=2;
-    build=1;//build can't be higher than 99
+    build=2;//build can't be higher than 99
 }
 
 simulated static function bool VersionIsStable()

--- a/DXRCore/DeusEx/Classes/DXRando.uc
+++ b/DXRCore/DeusEx/Classes/DXRando.uc
@@ -78,11 +78,16 @@ function SetdxInfo(DeusExLevelInfo i)
     // must do this before the mission script is loaded, so we can't wait for finding the player and loading modules
     class'DXRBacktracking'.static.LevelInit(Self);
 
+    // to test many seeds quickly:
+    // - set the preproc var playersonly, manually enable cheats, use legend to skip to the level you want, quicksave
+    // - change the preproc var to supercut, load your save over and over again to get a new seed each time
 #ifdef playersonly
     Level.bPlayersOnly = true;
+    Level.LevelAction = LEVACT_None;
 #elseif supercut
     Level.bPlayersOnly = false;
 #endif
+
     CrcInit();
     ClearModules();
     LoadFlagsModule();
@@ -108,7 +113,9 @@ function DXRInit()
 #ifdef supercut
     Player.bCheatsEnabled = true;
     Player.Invisible(true);
-    Player.GotoState('Paralyzed');
+    Player.ReducedDamageType = 'All';
+    //Player.GotoState('Paralyzed');// keeps the camera still for recording video
+    Player.GotoState('CheatFlying');
 #endif
 
 #ifdef revision

--- a/DXRFixes/DeusEx/Classes/LaserEmitter.uc
+++ b/DXRFixes/DeusEx/Classes/LaserEmitter.uc
@@ -8,24 +8,31 @@ function CalcTrace(float deltaTime)
     local actor target;
     local int i, texFlags;
     local name texName, texGroup;
+    local bool vanilla;
 
     StartTrace = Location;
     EndTrace = Location + 5000 * vector(Rotation);
     HitActor = None;
+
+    vanilla = class'DXRFlags'.default.bZeroRandoPure;
 
     // trace the path of the reflected beam and draw points at each hit
     for (i=0; i<ArrayCount(spot); i++)
     {
         foreach TraceTexture(class'Actor', target, texName, texGroup, texFlags, HitLocation, HitNormal, EndTrace, StartTrace)
         {
-            if (   !target.bBlockActors
-                || (DeusExProjectile(target) != None && !DeusExProjectile(target).bStuck)
-            ) {
-                // do nothing - keep on tracing
-            }
-            else if ((target == Level) || target.IsA('Mover'))
+            if ((target == Level) || target.IsA('Mover'))
             {
                 break;
+            }
+            else if (   !target.bBlockActors
+                || (DeusExProjectile(target) != None && !DeusExProjectile(target).bStuck)
+            ) {
+                // do nothing - keep on tracing (except in Zero Rando Pure)
+                if(vanilla && DeathMarker(target)==None && target.DrawType != DT_None && !target.bHidden) {
+                    HitActor = target;
+                    break;
+                }
             }
             else
             {

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -420,6 +420,20 @@ function PreFirstEntryMapFixes()
             anna.AgitationDecayRate = 0;
         }
 
+        //A crate in the water near the dock to let you climb out of the water (there's no ladder)
+        a = Spawnm(class'#var(prefix)CrateUnbreakableMed',,,vect(-515,-3810,210));
+        a.bIsSecretGoal = true; //Don't shuffle
+
+        //Crates blocking the entrance to the empty Castle Clinton
+        a = Spawnm(class'#var(prefix)CrateUnbreakableLarge',,,vect(1070,1175,400));
+        a.bIsSecretGoal = true; //Don't shuffle
+        a = Spawnm(class'#var(prefix)CrateUnbreakableLarge',,,vect(1070,1075,400));
+        a.bIsSecretGoal = true; //Don't shuffle
+        a = Spawnm(class'#var(prefix)CrateUnbreakableLarge',,,vect(1070,975,400));
+        a.bIsSecretGoal = true; //Don't shuffle
+        a = Spawnm(class'#var(prefix)CrateUnbreakableLarge',,,vect(1070,875,400));
+        a.bIsSecretGoal = true; //Don't shuffle
+
         break;
 
     case "04_NYC_BAR":
@@ -517,6 +531,9 @@ function AnyEntryMapFixes()
     local bool VanillaMaps;
     local Mover door;
     local ConEventSpeech ces;
+    local #var(prefix)ScriptedPawn sp;
+    local #var(prefix)BlackHelicopter jock;
+    local bool raidStarted;
 
     RevisionMaps = class'DXRMapVariants'.static.IsRevisionMaps(player());
     VanillaMaps = class'DXRMapVariants'.static.IsVanillaMaps(player());
@@ -530,6 +547,32 @@ function AnyEntryMapFixes()
 
     switch (dxr.localURL)
     {
+    case "04_NYC_BATTERYPARK":
+        raidStarted = dxr.flagbase.GetBool('M04RaidBegan');
+
+        foreach AllActors(class'#var(prefix)ScriptedPawn',sp){
+            switch(sp.Alliance){
+                case 'UNATCO':
+                case 'gunther':
+                case 'bots':
+                    if (raidStarted){
+                        sp.EnterWorld();
+                    } else {
+                        sp.LeaveWorld();
+                    }
+                    break;
+            }
+        }
+
+        foreach AllActors(class'#var(prefix)BlackHelicopter',jock){
+            if (raidStarted){
+                jock.EnterWorld();
+            } else {
+                jock.LeaveWorld();
+            }
+        }
+
+        break;
     case "04_NYC_NSFHQ":
         // allow Paul dialog to repeat, especially if you try to send the signal without aligning the dishes
         GetConversation('DL_PaulGoodJob').bDisplayOnce = false;

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -466,16 +466,20 @@ function BalanceJailbreak()
 
         switch(rng(4)) {
         case 1:// crate past the desk
-            Spawn(iclass,,, vectm(-1838.230225, 1250.242676, -110.399773));
+            nextItem = Spawn(iclass,,, vectm(-1838.230225, 1250.242676, -110.399773));
+            l("spawned freebie weapon crate past the desk " $ iclass @ nextItem);
             break;
         case 2:// desk
-            Spawn(iclass,,, vectm(-2105.412598, 1232.926758, -134.400101));
+            nextItem = Spawn(iclass,,, vectm(-2105.412598, 1232.926758, -134.400101));
+            l("spawned freebie weapon desk " $ iclass @ nextItem);
             break;
         case 3:// locked jail cell with medbot
-            Spawn(iclass,,, vectm(-3020.846924, 910.062134, -201.399750));
+            nextItem = Spawn(iclass,,, vectm(-3020.846924, 910.062134, -201.399750));
+            l("spawned freebie weapon locked jail cell with medbot " $ iclass @ nextItem);
             break;
         default:// unlocked jail cell
-            Spawn(iclass,,, vectm(-2688.502686, 1424.474731, -158.099915));
+            nextItem = Spawn(iclass,,, vectm(-2688.502686, 1424.474731, -158.099915));
+            l("spawned freebie weapon unlocked jail cell " $ iclass @ nextItem);
             break;
         }
     }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -454,7 +454,7 @@ function BalanceJailbreak()
 
     //Freebie Weapon
     //Don't try to move this to DXRMissions
-    //When it's there, it won'tapply with goal rando disabled
+    //When it's there, it won't apply with goal rando disabled
     if(dxr.flags.settings.swapitems > 0 || dxr.flags.loadout != 0) {
         e = DXREnemies(dxr.FindModule(class'DXREnemies'));
         if( e != None ) {

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -335,8 +335,14 @@ function BalanceJailbreak()
     local #var(PlayerPawn) p;
     local vector itemLocations[50];
     local DXRMissions missions;
-    local string PaulLocation;
+    local string EquipLocation;
     local #var(prefix)DataLinkTrigger dlt;
+    local string freebieLocNames[4];
+    local vector freebieLocs[4];
+    local DynamicLight dl;
+    local bool VanillaMaps;
+
+    VanillaMaps = class'DXRMapVariants'.static.IsVanillaMaps(player());
 
     SetSeed("BalanceJailbreak");
 
@@ -348,16 +354,16 @@ function BalanceJailbreak()
         if(DeusExWeapon(p.inHand) != None)
             DeusExWeapon(p.inHand).LaserOff();
 
-        PaulLocation = "Surgery Ward";
+        EquipLocation = "Armory";
         missions = DXRMissions(dxr.FindModule(class'DXRMissions'));
         for(i=0;missions!=None && i<missions.num_goals;i++) {
-            if(missions.GetSpoiler(i).goalName == "Paul") {
-                PaulLocation = missions.GetSpoiler(i).goalLocation;
+            if(missions.GetSpoiler(i).goalName == "Equipment") {
+                EquipLocation = missions.GetSpoiler(i).goalLocation;
             }
         }
         num=0;
-        l("BalanceJailbreak PaulLocation == " $ PaulLocation);
-        if(PaulLocation == "Surgery Ward" || PaulLocation == "Greasel Pit")
+        l("BalanceJailbreak EquipLocation == " $ EquipLocation);
+        if(EquipLocation == "Armory")
             foreach AllActors(class'SpawnPoint', SP, 'player_inv')
                 //Adjust item spawnpoints in armoury - specifically, move things off the top shelf
                 switch(sp.Name){
@@ -384,7 +390,7 @@ function BalanceJailbreak()
                         break;
                 }
 
-        else {
+        else { //EquipLocation == "Surgery Ward"
             // put the items in the surgery ward
             itemLocations[num++] = vectm(2160,-585,-203);// paul's bed
             itemLocations[num++] = vectm(2160,-505,-203);// paul's bed
@@ -446,6 +452,9 @@ function BalanceJailbreak()
         }
     }
 
+    //Freebie Weapon
+    //Don't try to move this to DXRMissions
+    //When it's there, it won'tapply with goal rando disabled
     if(dxr.flags.settings.swapitems > 0 || dxr.flags.loadout != 0) {
         e = DXREnemies(dxr.FindModule(class'DXREnemies'));
         if( e != None ) {
@@ -464,24 +473,38 @@ function BalanceJailbreak()
             iclass = loadout.get_starting_item();
         }
 
-        switch(rng(4)) {
-        case 1:// crate past the desk
-            nextItem = Spawn(iclass,,, vectm(-1838.230225, 1250.242676, -110.399773));
-            l("spawned freebie weapon crate past the desk " $ iclass @ nextItem);
-            break;
-        case 2:// desk
-            nextItem = Spawn(iclass,,, vectm(-2105.412598, 1232.926758, -134.400101));
-            l("spawned freebie weapon desk " $ iclass @ nextItem);
-            break;
-        case 3:// locked jail cell with medbot
-            nextItem = Spawn(iclass,,, vectm(-3020.846924, 910.062134, -201.399750));
-            l("spawned freebie weapon locked jail cell with medbot " $ iclass @ nextItem);
-            break;
-        default:// unlocked jail cell
-            nextItem = Spawn(iclass,,, vectm(-2688.502686, 1424.474731, -158.099915));
-            l("spawned freebie weapon unlocked jail cell " $ iclass @ nextItem);
-            break;
+        freebieLocNames[0]="Unlocked Jail Cell";
+        freebieLocNames[1]="Crate past the Desk";
+        freebieLocNames[2]="Desk";
+        freebieLocNames[3]="Locked Jail Cell";
+
+        //Define the locations by mod
+        if (VanillaMaps){
+            freebieLocs[0]=vectm(-2688.502686, 1424.474731, -158.099915); //Unlocked Jail Cell
+            freebieLocs[1]=vectm(-1838.230225, 1250.242676, -110.399773); //Crate past the desk
+            freebieLocs[2]=vectm(-2105.412598, 1232.926758, -134.400101); //Desk
+            freebieLocs[3]=vectm(-3020.846924, 910.062134, -201.399750);  //Locked Jail Cell
+        } else { //Revision
+            freebieLocs[0]=vectm(-2690,1420,-190); //Unlocked Jail Cell
+            freebieLocs[1]=vectm(-1893,1184,-110); //Crate past the desk
+            freebieLocs[2]=vectm(-2190,1075,-130); //Desk
+            freebieLocs[3]=vectm(-3024,910,-190);  //Locked Jail Cell
         }
+
+        if (ArrayCount(freebieLocs) != ArrayCount(freebieLocNames)){
+            err("DXRFixupM05 Freebie Weapon - freebieLocs and freebieLocNames sizes don't match!" @ ArrayCount(freebieLocs) @ ArrayCount(freebieLocNames));
+        }
+
+        i=rng(ArrayCount(freebieLocs));
+        nextItem = Spawn(iclass,,, freebieLocs[i]);
+        l("spawned freebie weapon" @ freebieLocNames[i] @ iclass @ nextItem);
+
+        //Give the weapon a light so that it stands out a bit more
+        //The light will disappear when you grab the item
+        dl = Spawn(class'DynamicLight',,,nextItem.Location+vect(0,0,6));
+        dl.LightRadius=6;
+        dl.SetBase(nextItem);
+
     }
 }
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -27,6 +27,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)NicoletteDuclare nico;
     local #var(prefix)NanoKey k;
     local DXRMoverSequenceTrigger elevatortrig;
+    local #var(prefix)OrdersTrigger ot;
     local Actor a;
 
     VanillaMaps = class'DXRMapVariants'.static.IsVanillaMaps(player());
@@ -201,6 +202,11 @@ function PreFirstEntryMapFixes()
         foreach AllActors(class'#var(prefix)JaimeReyes', j) {
             RemoveFears(j);
         }
+
+        ot = Spawn(class'OrdersTrigger',, 'NicoLeaving');
+        ot.Orders = 'Leaving';
+        ot.Event = '#var(prefix)NicoletteDuClare';
+        ot.SetCollision(false, false, false);
 
         break;
 
@@ -384,6 +390,7 @@ function AnyEntryMapFixes()
     local ConEventSetFlag cesf;
     local ConEventAddSkillPoints ceasp;
     local ConEventTransferObject ceto;
+    local ConEventTrigger cet;
     local bool VanillaMaps;
 
     VanillaMaps = class'DXRMapVariants'.static.IsVanillaMaps(player());
@@ -440,6 +447,16 @@ function AnyEntryMapFixes()
             c.bInvokeSight = false;
             c.bInvokeRadius = false;
         }
+
+        c = GetConversation('JockReady');
+        if (c != None) {
+            cet = new(c) class'ConEventTrigger';
+            cet.eventType = ET_Trigger;
+            cet.triggerTag = 'NicoLeaving';
+            cet.nextEvent = c.eventList;
+            c.eventList = cet;
+        }
+
         break;
     case "11_PARIS_UNDERGROUND":
         //Add a flag change to Toby's conversation so it sets MS_PlayerTeleported to false if you choose the "take me with you" option
@@ -502,7 +519,6 @@ function AnyEntryMapFixes()
 function PostFirstEntryMapFixes()
 {
     local #var(prefix)WIB wib;
-    local #var(prefix)NicoletteDuclare nico;
     local #var(prefix)NanoKey k;
     local #var(PlayerPawn) p;
 
@@ -510,13 +526,6 @@ function PostFirstEntryMapFixes()
 
     switch(dxr.localURL) {
     case "10_PARIS_METRO":
-        if (dxr.flags.settings.starting_map >= 109) {
-            foreach AllActors(class'#var(prefix)NicoletteDuclare', nico, 'DXRMissions') {
-                nico.LeaveWorld();
-                break;
-            }
-        }
-
         k = None;
         if (class'DXRMapVariants'.static.IsVanillaMaps(p)) {
             k = Spawn(class'#var(prefix)NanoKey',,, vectm(2513.0, 2439.0, 458.0));

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -203,7 +203,7 @@ function PreFirstEntryMapFixes()
             RemoveFears(j);
         }
 
-        ot = Spawn(class'OrdersTrigger',, 'NicoLeaving');
+        ot = Spawn(class'#var(prefix)OrdersTrigger',, 'NicoLeaving');
         ot.Orders = 'Leaving';
         ot.Event = '#var(prefix)NicoletteDuClare';
         ot.SetCollision(false, false, false);

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
@@ -554,6 +554,11 @@ function PreFirstEntryMapFixes()
             SetOutsideGuyReactions(sp);
         }
 
+        ot = Spawn(class'OrdersTrigger',, 'TiffanyLeaving');
+        ot.Orders = 'Leaving';
+        ot.Event = '#var(prefix)TiffanySavage';
+        ot.SetCollision(false, false, false);
+
         if (VanillaMaps){
             class'PlaceholderEnemy'.static.Create(self,vectm(635,488,-930));
             class'PlaceholderEnemy'.static.Create(self,vectm(1351,582,-930),,'Shitting');
@@ -861,6 +866,9 @@ function AnyEntryMapFixes()
     local NanoKey key;
     local #var(prefix)HowardStrong hs;
     local bool prevMapsDone;
+    local Conversation con;
+    local ConEvent ce;
+    local ConEventTrigger cet;
 
     if(dxr.flagbase.GetBool('schematic_downloaded') && !dxr.flagbase.GetBool('DL_downloaded_Played')) {
         dxr.flagbase.SetBool('DL_downloaded_Played', true);
@@ -882,6 +890,19 @@ function AnyEntryMapFixes()
                 key.Timer();// make sure to fix the ItemName in vanilla
             }
         }
+
+        con = GetConversation('M12JockFinal2');
+        for (ce = con.eventList; ce != None; ce = ce.nextEvent) {
+            if (ConEventCheckFlag(ce) != None && ConEventCheckFlag(ce).setLabel == "Dead") {
+                cet = new(con) class'ConEventTrigger';
+                cet.eventType = ET_Trigger;
+                cet.triggerTag = 'TiffanyLeaving';
+                cet.nextEvent = ce.nextEvent;
+                ce.nextEvent = cet;
+                break;
+            }
+        }
+
         break;
 
     case "14_VANDENBERG_SUB":

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
@@ -554,7 +554,7 @@ function PreFirstEntryMapFixes()
             SetOutsideGuyReactions(sp);
         }
 
-        ot = Spawn(class'OrdersTrigger',, 'TiffanyLeaving');
+        ot = Spawn(class'#var(prefix)OrdersTrigger',, 'TiffanyLeaving');
         ot.Orders = 'Leaving';
         ot.Event = '#var(prefix)TiffanySavage';
         ot.SetCollision(false, false, false);

--- a/DXRMissions/DeusEx/Classes/DXRMissionsM05.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsM05.uc
@@ -3,7 +3,7 @@ class DXRMissionsM05 extends DXRMissions;
 
 function int InitGoals(int mission, string map)
 {
-    local int goal, loc, loc2;
+    local int goal, loc, pArm,pSurg,pPit,pRobot,  eArm,eSurg;
 
     switch(map) {
     case "05_NYC_UNATCOMJ12LAB":
@@ -12,23 +12,37 @@ function int InitGoals(int mission, string map)
         AddGoalActor(goal, 2, 'DataLinkTrigger6', PHYS_None);
         AddGoalActor(goal, 3, 'SecurityCamera0', PHYS_None);
 
-        loc = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Armory", NORMAL_GOAL, vect(-8548.773438, 1074.370850, -20.860909), rot(0, 0, 0));
-        AddActorLocation(loc, 3, vect(-8162.683594, 1194.161621, 276.902924), rot(-6000, 36000, 0));
-        AddMapMarker(class'Image05_NYC_MJ12Lab',33,289,"P","Paul", loc,"Paul can be located on the second floor of the armory.  If Paul is in this location, your equipment will be located in the surgery ward.");
+        pArm = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Armory", NORMAL_GOAL, vect(-8548.773438, 1074.370850, -20.860909), rot(0, 0, 0));
+        AddActorLocation(pArm, 3, vect(-8162.683594, 1194.161621, 276.902924), rot(-6000, 36000, 0));
+        AddMapMarker(class'Image05_NYC_MJ12Lab',33,289,"P","Paul", pArm,"Paul can be located on the second floor of the armory.  If Paul is in this location, your equipment will be located in the surgery ward.");
 
-        loc = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Surgery Ward", NORMAL_GOAL | VANILLA_GOAL, vect(2281.708008, -617.352478, -224.400238), rot(0,35984,0));
-        AddActorLocation(loc, 1, vect(2177.405273, -552.487671, -200.899811), rot(0, 16944, 0));
-        AddActorLocation(loc, 2, vect(2177.405273, -552.487671, -200.899811), rot(0, 16944, 0)); //DataLinkTrigger should be centered on his carcass rather than his living location
-        AddActorLocation(loc, 3, vect(1891.301514, -289.854248, -64.997406), rot(-3000, 58200, 0));
-        AddMapMarker(class'Image05_NYC_MJ12Lab',379,96,"P","Paul", loc,"Paul can be located in the surgery ward.  This is the vanilla location.  If Paul is in this location, your equipment will be located in the armory.");
+        pSurg = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Surgery Ward", NORMAL_GOAL | VANILLA_GOAL, vect(2281.708008, -617.352478, -224.400238), rot(0,35984,0));
+        AddActorLocation(pSurg, 1, vect(2177.405273, -552.487671, -200.899811), rot(0, 16944, 0));
+        AddActorLocation(pSurg, 2, vect(2177.405273, -552.487671, -200.899811), rot(0, 16944, 0)); //DataLinkTrigger should be centered on his carcass rather than his living location
+        AddActorLocation(pSurg, 3, vect(1891.301514, -289.854248, -64.997406), rot(-3000, 58200, 0));
+        AddMapMarker(class'Image05_NYC_MJ12Lab',379,96,"P","Paul", pSurg,"Paul can be located in the surgery ward.  This is the vanilla location.  If Paul is in this location, your equipment will be located in the armory.");
 
-        loc = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Greasel Pit", NORMAL_GOAL, vect(456,3947,-604), rot(0, 8048, 0));
-        AddActorLocation(loc, 3, vect(745.180481, 4150.960449, -477.601196), rot(-3100, 39700, 0));
-        AddMapMarker(class'Image05_NYC_MJ12Lab',325,226,"P","Paul", loc,"Paul can be located in the greasel pit accessed through the vent on the back wall of the nanotech lab.  If Paul is in this location, your equipment will be located in the armory.");
+        pPit = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Greasel Pit", NORMAL_GOAL, vect(456,3947,-604), rot(0, 8048, 0));
+        AddActorLocation(pPit, 3, vect(745.180481, 4150.960449, -477.601196), rot(-3100, 39700, 0));
+        AddMapMarker(class'Image05_NYC_MJ12Lab',325,226,"P","Paul", pPit,"Paul can be located in the greasel pit accessed through the vent on the back wall of the nanotech lab.  If Paul is in this location, your equipment will be located in the armory.");
 
-        loc = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Robotics Bay Office", NORMAL_GOAL, vect(-4297,1083,210), rot(0, 16392, 0));
-        AddActorLocation(loc, 3, vect(-4289.660645, 1397.180054, 307.937073), rot(-2000, -16384, 0));
-        AddMapMarker(class'Image05_NYC_MJ12Lab',171,286,"P","Paul", loc,"Paul can be located in the office on the third floor of the robotics bay.  If Paul is in this location, your equipment will be located in the surgery ward.");
+        pRobot = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Robotics Bay Office", NORMAL_GOAL, vect(-4297,1083,210), rot(0, 16392, 0));
+        AddActorLocation(pRobot, 3, vect(-4289.660645, 1397.180054, 307.937073), rot(-2000, -16384, 0));
+        AddMapMarker(class'Image05_NYC_MJ12Lab',171,286,"P","Paul", pRobot,"Paul can be located in the office on the third floor of the robotics bay.  If Paul is in this location, your equipment will be located in the surgery ward.");
+
+        //This is just the concept of the location of your equipment.  BalanceJailbreak in DXRFixup will actually place the items
+        AddGoal("05_NYC_UNATCOMJ12LAB", "Equipment", GOAL_TYPE2, '', PHYS_None);
+
+        eArm = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Armory", GOAL_TYPE2 | VANILLA_GOAL, vect(-8477.731445,1244.474854,-199.900879), rot(0, 0, 0));
+        AddMapMarker(class'Image05_NYC_MJ12Lab',46,299,"E","Equipment", eArm,"Your equipment can be located in the armory.  This is the vanilla location.  If your equipment is in this location, Paul is in either the surgery ward or the greasel pit.");
+
+        eSurg = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Surgery Ward", GOAL_TYPE2, vect(1670.443237,-702.527649,-179.660095), rot(0,0,0));
+        AddMapMarker(class'Image05_NYC_MJ12Lab',362,95,"E","Equipment", eSurg,"Your equipment can be located in the surgery ward.  If your equipment is in this location, Paul is in either the armory or the robotics bay office.");
+
+        AddMutualExclusion(eArm, pArm);
+        AddMutualExclusion(eArm, pRobot);
+        AddMutualExclusion(eSurg, pSurg);
+        AddMutualExclusion(eSurg, pPit);
 
         AddGoal("05_NYC_UNATCOMJ12LAB", "Paul Security Monitor", GOAL_TYPE4, 'ComputerSecurity4', PHYS_None); //Making this a goal actor so it gets dignified, but it will always be in the original location
         loc = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Command Center", GOAL_TYPE4, vect(-1072.5594,20.1928,-101.3019), rot(0, 16312, 0));
@@ -71,7 +85,7 @@ function int InitGoals(int mission, string map)
 
 function int InitGoalsRev(int mission, string map)
 {
-    local int goal, loc, loc2;
+    local int goal, loc, pArm,pSurg,pPit,pRobot,  eArm,eSurg;
 
     switch(map) {
     case "05_NYC_UNATCOMJ12LAB":
@@ -80,19 +94,29 @@ function int InitGoalsRev(int mission, string map)
         AddGoalActor(goal, 2, 'DataLinkTrigger6', PHYS_None);
         AddGoalActor(goal, 3, 'SecurityCamera0', PHYS_None);
 
-        loc = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Armory", NORMAL_GOAL, vect(-8548.773438, 1074.370850, -20.860909), rot(0, 0, 0));
-        AddActorLocation(loc, 3, vect(-8162.683594, 1194.161621, 276.902924), rot(-6000, 36000, 0));
+        pArm = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Armory", NORMAL_GOAL, vect(-8548.773438, 1074.370850, -20.860909), rot(0, 0, 0));
+        AddActorLocation(pArm, 3, vect(-8162.683594, 1194.161621, 276.902924), rot(-6000, 36000, 0));
 
-        loc = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Surgery Ward", NORMAL_GOAL | VANILLA_GOAL, vect(2281.708008, -617.352478, -224.400238), rot(0,35984,0));
-        AddActorLocation(loc, 1, vect(2177.405273, -552.487671, -200.899811), rot(0, 16944, 0));
-        AddActorLocation(loc, 2, vect(2177.405273, -552.487671, -200.899811), rot(0, 16944, 0)); //DataLinkTrigger should be centered on his carcass rather than his living location
-        AddActorLocation(loc, 3, vect(1891.301514, -289.854248, -64.997406), rot(-3000, 58200, 0));
+        pSurg = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Surgery Ward", NORMAL_GOAL | VANILLA_GOAL, vect(2281.708008, -617.352478, -224.400238), rot(0,35984,0));
+        AddActorLocation(pSurg, 1, vect(2177.405273, -552.487671, -200.899811), rot(0, 16944, 0));
+        AddActorLocation(pSurg, 2, vect(2177.405273, -552.487671, -200.899811), rot(0, 16944, 0)); //DataLinkTrigger should be centered on his carcass rather than his living location
+        AddActorLocation(pSurg, 3, vect(1891.301514, -289.854248, -64.997406), rot(-3000, 58200, 0));
 
-        loc = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Greasel Pit", NORMAL_GOAL, vect(456,3947,-604), rot(0, 8048, 0));
-        AddActorLocation(loc, 3, vect(745.180481, 4150.960449, -477.601196), rot(-3100, 39700, 0));
+        pPit = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Greasel Pit", NORMAL_GOAL, vect(456,3947,-604), rot(0, 8048, 0));
+        AddActorLocation(pPit, 3, vect(745.180481, 4150.960449, -477.601196), rot(-3100, 39700, 0));
 
-        loc = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Robotics Bay Office", NORMAL_GOAL, vect(-4297,1083,210), rot(0, 16392, 0));
-        AddActorLocation(loc, 3, vect(-4289.660645, 1397.180054, 307.937073), rot(-2000, -16384, 0));
+        pRobot = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Robotics Bay Office", NORMAL_GOAL, vect(-4297,1083,210), rot(0, 16392, 0));
+        AddActorLocation(pRobot, 3, vect(-4289.660645, 1397.180054, 307.937073), rot(-2000, -16384, 0));
+
+        //This is just the concept of the location of your equipment.  BalanceJailbreak in DXRFixup will actually place the items
+        AddGoal("05_NYC_UNATCOMJ12LAB", "Equipment", GOAL_TYPE2, '', PHYS_None);
+        eArm = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Armory", GOAL_TYPE2 | VANILLA_GOAL, vect(-8477.731445,1244.474854,-199.900879), rot(0, 0, 0));
+        eSurg = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Surgery Ward", GOAL_TYPE2, vect(1670.443237,-702.527649,-179.660095), rot(0,0,0));
+
+        AddMutualExclusion(eArm, pArm);
+        AddMutualExclusion(eArm, pRobot);
+        AddMutualExclusion(eSurg, pSurg);
+        AddMutualExclusion(eSurg, pPit);
 
         AddGoal("05_NYC_UNATCOMJ12LAB", "Paul Security Monitor", GOAL_TYPE4, 'ComputerSecurity4', PHYS_None); //Making this a goal actor so it gets dignified, but it will always be in the original location
         loc = AddGoalLocation("05_NYC_UNATCOMJ12LAB", "Command Center", GOAL_TYPE4, vect(-1044.9645,529.963,46.6981), rot(0, 65520, 0));

--- a/DXRModules/DeusEx/Classes/DXRAugmentations.uc
+++ b/DXRModules/DeusEx/Classes/DXRAugmentations.uc
@@ -221,6 +221,15 @@ function static AddRandomAugs(DXRando dxr, DeusExPlayer p, int num)
     }
 }
 
+function static class<Augmentation> GetRandomAug(DXRando dxr)
+{
+    local int numAugs;
+    local int banned[50];
+
+    _DefaultAugsMask(dxr, banned, numAugs);
+    return PickRandomAug(dxr, banned, numAugs);
+}
+
 function static bool AugCanBeUpgraded(Augmentation anAug)
 {
     return anAug.bHasIt && anAug.CurrentLevel < anAug.MaxLevel;
@@ -295,10 +304,6 @@ function static RandomizeAugCannister(DXRando dxr, #var(prefix)AugmentationCanni
             a.ItemName = a.default.ItemName $": "$ augs[0].default.AugmentationName;
         else if(augs[1] != None)
             a.ItemName = a.default.ItemName $": "$ augs[1].default.AugmentationName;
-    }
-
-    if( (a.AddAugs[0] == '#var(prefix)AugSpeed' || a.AddAugs[1] == '#var(prefix)AugSpeed') && !dxr.flags.IsReducedRando() ) {
-        dxr.flags.player().ClientMessage("Speed Enhancement is in this area.",, true);
     }
 }
 

--- a/DXRModules/DeusEx/Classes/DXRBingoCampaign.uc
+++ b/DXRModules/DeusEx/Classes/DXRBingoCampaign.uc
@@ -208,9 +208,10 @@ function AnyEntry()
 
 function bool IsLateStart(int mission)
 {
+    if(#bool(neverlate)) return false;
     if(mission==7) mission=6;
     if(mission==13) mission=12;
-    return dxr.flags.settings.starting_map > mission * 10 + 5;
+    return dxr.flags.settings.starting_map >= mission * 10 + 5;
 }
 
 function HandleSpecialPerson(string bindname, string thisGoal, optional string nextGoal) {
@@ -221,7 +222,7 @@ function HandleSpecialPerson(string bindname, string thisGoal, optional string n
     if (IsBoardGoal(thisGoal)) return;
 
     data = class'PlayerDataItem'.static.GiveItem(player());
-    oldSeed = SetGlobalSeed(dxr.dxInfo.MissionNumber $ " HandleSpecialPerson " $ bindname);
+    oldSeed = SetGlobalSeed(dxr.dxInfo.MissionNumber @ "HandleSpecialPerson" @ bindname);
 
     if (chance_single(50)) {
         foreach AllActors(class'ScriptedPawn', pawn) {

--- a/DXRModules/DeusEx/Classes/DXRBingoCampaign.uc
+++ b/DXRModules/DeusEx/Classes/DXRBingoCampaign.uc
@@ -304,6 +304,10 @@ function NewBingoBoard()
         }
     }
 
+    if(data.IsBanned("JordanShea_Dead") && data.IsBanned("JoeGreene_Dead")) {
+        data.BanGoal("SnitchDowd", 999); // a bit weird because you actually only need one of them to be alive
+    }
+
     // create new board
     dxr.flags.bingoBoardRoll = 0;
     events.CreateBingoBoard(dxr.dxInfo.missionNumber * 10);

--- a/DXRModules/DeusEx/Classes/DXRBrightness.uc
+++ b/DXRModules/DeusEx/Classes/DXRBrightness.uc
@@ -1,7 +1,7 @@
 class DXRBrightness expands DXRActorsBase transient;
 
 //This struct (and it's corresponding array) won't be actively used anymore
-//To be removed in a future release
+//TODO: To be removed in a future release
 struct ZoneBrightnessData
 {
     var name zonename;
@@ -36,14 +36,14 @@ function AnyEntry()
 {
     Super.AnyEntry();
 
-    MigrateSavedData(); //To be removed when the ZoneBrightnessData is stripped out
+    MigrateSavedData(); //TODO: To be removed when the ZoneBrightnessData is stripped out
     //UpdateStoredData(); //If more is added to DXRStoredZoneInfo or DXRStoredLightFog
 
     IncreaseBrightness(GetSavedBrightnessBoost());
     ApplyFog(class'MenuChoice_Fog'.default.enabled);
 }
 
-//To be removed when the ZoneBrightnessData is stripped out
+//TODO: To be removed when the ZoneBrightnessData is stripped out
 function MigrateSavedData()
 {
     local DXRStoredZoneInfo szi;
@@ -183,7 +183,7 @@ static function AdjustBrightness(DeusExPlayer a, int brightness)
     }
 }
 
-//To be removed when the ZoneBrightnessData is stripped out
+//TODO: To be removed when the ZoneBrightnessData is stripped out
 function ZoneBrightnessData GetDefaultZoneBrightness(ZoneInfo z)
 {
     local ZoneBrightnessData zb;
@@ -195,7 +195,7 @@ function ZoneBrightnessData GetDefaultZoneBrightness(ZoneInfo z)
     return zb;
 }
 
-//DO NOT USE - To be removed when the ZoneBrightnessData is stripped out
+//DO NOT USE - TODO: To be removed when the ZoneBrightnessData is stripped out
 function SaveDefaultZoneBrightness(ZoneInfo z)
 {
     local int i;

--- a/DXRModules/DeusEx/Classes/DXREnemiesShuffle.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemiesShuffle.uc
@@ -66,8 +66,8 @@ function bool CanSwap(ScriptedPawn a, ScriptedPawn b) {
     local vector loc; // out param
     local float extraWidth, extraHeight;
 
-    spaceA = #var(prefix)Robot(a) == None || #var(prefix)SpiderBot2(a) != None;
-    spaceB = #var(prefix)Robot(b) == None || #var(prefix)SpiderBot2(b) != None;
+    spaceA = #var(prefix)SecurityBot2(a) == None && #var(prefix)MilitaryBot(a) == None && #var(prefix)SpiderBot(a) == None;
+    spaceB = #var(prefix)SecurityBot2(b) == None && #var(prefix)MilitaryBot(b) == None && #var(prefix)SpiderBot(b) == None;
     if(spaceA && spaceB) return true;
 
     colA = a.bBlockActors;
@@ -76,7 +76,7 @@ function bool CanSwap(ScriptedPawn a, ScriptedPawn b) {
     b.SetCollision(b.bCollideActors, false, b.bBlockPlayers);
 
     extraWidth = class'#var(PlayerPawn)'.default.CollisionRadius * 2.1;
-    extraHeight = class'#var(PlayerPawn)'.default.CollisionHeight * 1.1;
+    extraHeight = 1;
 
     loc = b.Location;
     if(!spaceA) spaceA = CheckFreeSpace(loc, a.CollisionRadius + extraWidth, a.CollisionHeight + extraHeight);

--- a/DXRModules/DeusEx/Classes/DXREnemiesShuffle.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemiesShuffle.uc
@@ -60,6 +60,38 @@ function bool ShouldSwap(ScriptedPawn a, ScriptedPawn b) {
     return a.GetAllianceType( b.Alliance ) == ALLIANCE_Friendly && b.GetAllianceType( a.Alliance ) == ALLIANCE_Friendly;
 }
 
+function bool CanSwap(ScriptedPawn a, ScriptedPawn b) {
+    local bool colA, colB; // original collision
+    local bool spaceA, spaceB;
+    local vector loc; // out param
+    local float extraWidth, extraHeight;
+
+    spaceA = #var(prefix)Robot(a) == None || #var(prefix)SpiderBot2(a) != None;
+    spaceB = #var(prefix)Robot(b) == None || #var(prefix)SpiderBot2(b) != None;
+    if(spaceA && spaceB) return true;
+
+    colA = a.bBlockActors;
+    colB = b.bBlockActors;
+    a.SetCollision(a.bCollideActors, false, a.bBlockPlayers);
+    b.SetCollision(b.bCollideActors, false, b.bBlockPlayers);
+
+    extraWidth = class'#var(PlayerPawn)'.default.CollisionRadius * 2.1;
+    extraHeight = class'#var(PlayerPawn)'.default.CollisionHeight * 1.1;
+
+    loc = b.Location;
+    if(!spaceA) spaceA = CheckFreeSpace(loc, a.CollisionRadius + extraWidth, a.CollisionHeight + extraHeight);
+    //if(!spaceA) DebugMarkKeyPosition(loc, a);
+
+    loc = a.Location;
+    if(!spaceB) spaceB = CheckFreeSpace(loc, b.CollisionRadius + extraWidth, b.CollisionHeight + extraHeight);
+    //if(!spaceB) DebugMarkKeyPosition(loc, b);
+
+    a.SetCollision(a.bCollideActors, colA, a.bBlockPlayers);
+    b.SetCollision(b.bCollideActors, colB, b.bBlockPlayers);
+
+    return spaceA && spaceB;
+}
+
 function bool CanSit(ScriptedPawn sp)
 {
     if (#var(prefix)MJ12Commando(sp) != None) return False;
@@ -140,6 +172,11 @@ function SwapScriptedPawns(int percent, bool enemies)
         }
 
         if( ! ShouldSwap(temp[i], temp[slot]) ) {
+            continue;
+        }
+
+        if( ! CanSwap(temp[i], temp[slot]) ) {
+            l("SwapScriptedPawns not enough space to swap "$i@ActorToString(temp[i])$" with "$slot@ActorToString(temp[slot]));
             continue;
         }
 

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -3694,4 +3694,5 @@ defaultproperties
     mutually_exclusive(63)=(e1="LebedevLived",e2="AnnaNavarre_DeadM4")
     mutually_exclusive(64)=(e1="LebedevLived",e2="AnnaNavarre_DeadM5")
     mutually_exclusive(65)=(e1="LebedevLived",e2="AnnaKillswitch")
+    mutually_exclusive(66)=(e1="LebedevLived",e2="JuanLebedev_Unconscious")
 }

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -839,7 +839,7 @@ function SetWatchFlags() {
         break;
     case "06_HONGKONG_MJ12LAB":
         foreach AllActors(class'ZoneInfo',zone){
-            if (zone.bFogZone){
+            if (class'DXRStoredZoneInfo'.static.IsFogZone(zone)){
                 zone.ZonePlayerEvent = 'HongKongGrays';
                 break;
             }

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -934,6 +934,8 @@ function FixBeamLaserTriggers()
     local #var(prefix)BeamTrigger bt;
     local #var(prefix)LaserTrigger lt;
 
+    if(dxr.flags.IsZeroRandoPure()) return;
+
     foreach AllActors(class'#var(prefix)BeamTrigger',bt){
         bt.TriggerType=TT_AnyProximity;
     }

--- a/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -58,10 +58,8 @@ simulated function PlayerAnyEntry(#var(PlayerPawn) p)
     l("starting map is set to "$settings.starting_map);
 }
 
-simulated function AnyEntry()
+simulated function SetGlobals()
 {
-    Super.AnyEntry();
-
     default.bZeroRandoPure = IsZeroRandoPure();
     default.bReducedRando = IsReducedRando();
     default.bCrowdControl = (crowdcontrol!=0);

--- a/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -30,6 +30,9 @@ var FlagsSettings difficulty_settings[5];
 var MoreFlagsSettings more_difficulty_settings[5];
 #endif
 
+// only access these in defaults, mostly for balance change checks
+var bool bZeroRandoPure, bReducedRando, bCrowdControl;
+
 simulated function PlayerAnyEntry(#var(PlayerPawn) p)
 {
 #ifdef injections
@@ -37,11 +40,6 @@ simulated function PlayerAnyEntry(#var(PlayerPawn) p)
 #endif
 
     Super.PlayerAnyEntry(p);
-#ifdef injections||revision
-    p.bZeroRando = IsZeroRandoPure();
-    p.bReducedRando = IsReducedRando();
-    p.bCrowdControl = (crowdcontrol!=0);
-#endif
 
     if(!VersionIsStable() || #bool(debug))
         p.bCheatsEnabled = true;
@@ -58,6 +56,15 @@ simulated function PlayerAnyEntry(#var(PlayerPawn) p)
     }
 
     l("starting map is set to "$settings.starting_map);
+}
+
+simulated function AnyEntry()
+{
+    Super.AnyEntry();
+
+    default.bZeroRandoPure = IsZeroRandoPure();
+    default.bReducedRando = IsReducedRando();
+    default.bCrowdControl = (crowdcontrol!=0);
 }
 
 function InitAdvancedDefaults()

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -291,6 +291,9 @@ simulated function LoadFlags()
     }
 
     BindFlags(Reading);
+#ifndef hx
+    settings.CombatDifficulty = p.CombatDifficulty;
+#endif
 
     if(stored_version < flagsversion ) {
         info("upgraded flags from "$stored_version$" to "$flagsversion);

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -117,6 +117,7 @@ function FlagsSettings SetDifficulty(int new_difficulty);
 simulated function ExecMaxRando();
 function string DifficultyName(int diff);
 function string GameModeName(int gamemode);
+simulated function SetGlobals();
 
 simulated function _PreTravel()
 {
@@ -266,6 +267,7 @@ simulated function LoadFlags()
     }
 #ifdef noflags
     LoadNoFlags();
+    SetGlobals();
     return;
 #endif
 
@@ -298,6 +300,7 @@ simulated function LoadFlags()
         SaveFlags();
     }
 
+    SetGlobals();
     LogFlags("LoadFlags");
     if( p != None )
         DisplayRandoInfoMessage(p, p.CombatDifficulty);

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -248,7 +248,7 @@ simulated function DisplayRandoInfoMessage(#var(PlayerPawn) p, float CombatDiffi
 
     info(str);
     info(str2);
-    if(p != None){
+    if(p != None && !DXRFlags(self).IsZeroRandoPure()){
         p.ClientMessage(str);
         p.ClientMessage(str2);
     }

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -1078,14 +1078,12 @@ simulated function LogFlags(string prefix)
 
 simulated function string StringifyFlags(int mode)
 {
-        local float CombatDifficulty;
-        local #var(PlayerPawn) p;
+    local float CombatDifficulty;
+    local #var(PlayerPawn) p;
 #ifdef hx
     CombatDifficulty = HXGameInfo(Level.Game).CombatDifficulty;
 #else
-    p = player();
-    if( p != None )
-        CombatDifficulty = p.CombatDifficulty;
+    CombatDifficulty = settings.CombatDifficulty;
 #endif
     return BindFlags(mode, "difficulty: " $ TrimTrailingZeros(CombatDifficulty));
 }

--- a/DXRModules/DeusEx/Classes/DXRGrenades.uc
+++ b/DXRModules/DeusEx/Classes/DXRGrenades.uc
@@ -131,8 +131,6 @@ function FirstEntry()
 simulated function AddDXRCredits(CreditsWindow cw)
 {
     local int i;
-    local DXREnemies e;
-    local class<DeusExWeapon> w;
     if(dxr.flags.IsZeroRando()) return;
     cw.PrintHeader( "Grenade Types" );
     for (i=0;i<ArrayCount(randomgrens);i++){

--- a/DXRModules/DeusEx/Classes/DXRHints.uc
+++ b/DXRModules/DeusEx/Classes/DXRHints.uc
@@ -252,8 +252,13 @@ simulated function InitHints()
         }
 
         if(#defined(injections)) {
-            AddHint("The flashlight (F12) no longer consumes energy when used.", "Go wild with it!");
-            AddHint("The flashlight (F12) can be used to attract the attention of guards.", "It doesn't cost any energy!");
+            if(!dxr.flags.IsHalloweenMode()) {
+                AddHint("The flashlight (F12) no longer consumes energy when used.", "Go wild with it!");
+                AddHint("The flashlight (F12) can be used to attract the attention of guards.", "It doesn't cost any energy!");
+            } else {
+                AddHint("The flashlight (F12) consumes energy in Halloween Mode!", "Don't waste your energy!");
+                AddHint("The flashlight (F12) can be upgraded in Halloween Mode!", "Level 2 is brighter and doesn't cost energy!");
+            }
             AddHint("Alcohol and medkits will heal your legs first", "if they are completely broken.");
             AddHint("You can carry 5 fire extinguishers in 1 inventory slot.", "They are very useful for stealthily killing multiple enemies.");
             AddHint("Ever tried to extinguish a fire with a toilet?", "How about a urinal or a shower?");

--- a/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -46,7 +46,7 @@ function CheckConfig()
     local string temp;
     local int i, s;
     local class<Actor> a;
-    if( ConfigOlderThan(2,6,2,4) ) {
+    if( ConfigOlderThan(3,3,2,2) ) {
         mult_items_per_level = 1;
 
         for(i=0; i < ArrayCount(loadouts_order); i++) {
@@ -135,9 +135,9 @@ function CheckConfig()
         item_sets[8].player_message = "No Swords";
         item_sets[8].bans = "WeaponSword,WeaponNanoSword";
 
-        item_sets[9].name = "No Overpowered Weapons";
-        item_sets[9].player_message = "No Overpowered Weapons";
-        item_sets[9].bans = "WeaponSword,WeaponNanoSword,WeaponPistol,WeaponStealthPistol,WeaponGEPGun,WeaponPepperGun";
+        item_sets[9].name = "No Overused Weapons";
+        item_sets[9].player_message = "No Overused Weapons";
+        item_sets[9].bans = "WeaponNanoSword,WeaponPistol,WeaponStealthPistol,WeaponGEPGun";
 
         item_sets[10].name = "By the Book";
         item_sets[10].player_message = "By the Book";
@@ -154,6 +154,12 @@ function CheckConfig()
         item_sets[11].item_spawns =
             "WeaponLAW,75,WeaponLAM,100,WeaponEMPGrenade,75,WeaponGasGrenade,75," $
             "WeaponNanoVirusGrenade,75,#var(package).WeaponRubberBaton,20,AmmoRocket,100,AmmoRocketWP,100,Ammo20mm,100";
+
+        // loadout for random starting aug
+        item_sets[12].name = "Random Starting Aug";
+        item_sets[12].starting_augs = "AugRandom";
+
+        // loadout for borderlands weapons? or gamemode?
 
         i=0;
 
@@ -301,6 +307,11 @@ function AddAug(int s, string type)
 
     for(i=0; i < ArrayCount(__item_sets[s].starting_augs); i++) {
         if( __item_sets[s].starting_augs[i] == None ) {
+            if(type=="AugRandom") {
+                SetGlobalSeed("DXRLoadouts AugRandom " $ i);
+                __item_sets[s].starting_augs[i] = class'DXRAugmentations'.static.GetRandomAug(dxr);
+                return;
+            }
             if(dxr.flags.IsHalloweenMode() && type=="AugSpeed" && dxr.flags.settings.speedlevel == 0) {
                 type = "AugStealth";// this is Halloween!
             }

--- a/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -159,8 +159,6 @@ function CheckConfig()
         item_sets[12].name = "Random Starting Aug";
         item_sets[12].starting_augs = "AugRandom";
 
-        // loadout for borderlands weapons? or gamemode?
-
         i=0;
 
         randomitems[i].type = "Medkit";

--- a/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -120,6 +120,12 @@ function PreFirstEntry()
         }
         break;
 
+    case "12_VANDENBERG_GAS":
+        if (!dxr.flags.IsEntranceRando() && dxr.flags.settings.starting_map > 129) {
+            dxr.flagbase.SetBool('DL_JockTiffanyDead_Played', true,, 15);
+        }
+        break;
+
     case "14_VANDENBERG_SUB":
         if (dxr.flags.settings.starting_map == 141 || dxr.flags.settings.starting_map == 142) {
             foreach AllActors(class'#var(DeusExPrefix)Mover', dxMover, 'Elevator1') {
@@ -167,6 +173,7 @@ function PreFirstEntry()
 function PostFirstEntry()
 {
     local AllianceTrigger at;
+    local #var(prefix)NicoletteDuclare nico;
 
     if(IsStartMap()) {
         PostFirstEntryStartMapFixes(player(), dxr.flagbase, dxr.flags.settings.starting_map);
@@ -178,6 +185,14 @@ function PostFirstEntry()
             foreach AllActors(class'AllianceTrigger', at, 'surrender') {
                 at.Trigger(None, None);
                 break;
+            }
+        }
+        break;
+    case "10_PARIS_METRO":
+    case "10_PARIS_CLUB":
+        if (dxr.flags.settings.starting_map >= 109) {
+            foreach AllActors(class'#var(prefix)NicoletteDuclare', nico) {
+                nico.LeaveWorld();
             }
         }
         break;

--- a/DXRModules/DeusEx/Classes/DXRWeaponMods.uc
+++ b/DXRModules/DeusEx/Classes/DXRWeaponMods.uc
@@ -144,8 +144,6 @@ function FirstEntry()
 simulated function AddDXRCredits(CreditsWindow cw)
 {
     local int i;
-    local DXREnemies e;
-    local class<DeusExWeapon> w;
     if(dxr.flags.IsZeroRando()) return;
     cw.PrintHeader( "Weapon Mods" );
 

--- a/DXRModules/DeusEx/Classes/DXRWeaponMods.uc
+++ b/DXRModules/DeusEx/Classes/DXRWeaponMods.uc
@@ -141,6 +141,24 @@ function FirstEntry()
     }
 }
 
+simulated function AddDXRCredits(CreditsWindow cw)
+{
+    local int i;
+    local DXREnemies e;
+    local class<DeusExWeapon> w;
+    if(dxr.flags.IsZeroRando()) return;
+    cw.PrintHeader( "Weapon Mods" );
+
+    //Should this try to strip the "Weapon Modification (xyz)" name to just "xyz"?
+    for (i=0;i<ArrayCount(randommods);i++){
+        cw.PrintText( randommods[i].Type.default.ItemName $ " : " $ FloatToString(randommods[i].chance, 1) $ "%" );
+    }
+
+    cw.PrintLn();
+    cw.PrintLn();
+}
+
+
 defaultproperties
 {
     min_rate_adjust=0.3

--- a/DXRNonVanilla/DeusEx/Classes/RevRandoPlayer.uc
+++ b/DXRNonVanilla/DeusEx/Classes/RevRandoPlayer.uc
@@ -1,7 +1,6 @@
 #compileif revision
 class RevRandoPlayer extends RevJCDentonMale;
 
-var travel bool bZeroRando, bReducedRando, bCrowdControl;
 var laserEmitter aimLaser;
 var bool bDoomMode;
 var bool bOnLadder;
@@ -58,7 +57,7 @@ function bool WineBulletsActive()
 {
     local DataStorage datastorage;
 
-    if (!bCrowdControl) return False;
+    if (!class'DXRFlags'.default.bCrowdControl) return False;
 
     datastorage = class'DataStorage'.static.GetObjFromPlayer(self);
     return bool(datastorage.GetConfigKey('cc_WineBullets'));
@@ -186,7 +185,7 @@ function float GetDamageMultiplier()
 {
     local DataStorage datastorage;
 
-    if (!bCrowdControl) return 0;
+    if (!class'DXRFlags'.default.bCrowdControl) return 0;
 
     datastorage = class'DataStorage'.static.GetObjFromPlayer(self);
     return float(datastorage.GetConfigKey('cc_damageMult'));
@@ -225,7 +224,7 @@ function float AdjustCritSpots(float Damage, name damageType, vector hitLocation
         // narrow the head region
         if ((Abs(offset.x) < headOffsetY) || (Abs(offset.y) < headOffsetY))
         {
-            if(!bZeroRando) {
+            if(!class'DXRFlags'.default.bZeroRandoPure) {
                 // do 1.7x damage instead of the 2x damage in DeusExPlayer.uc::TakeDamage()
                 return Damage * 0.85;
             }
@@ -244,7 +243,7 @@ function float AdjustCritSpots(float Damage, name damageType, vector hitLocation
         {
             // left arm
         }
-        else if(!bZeroRando)
+        else if(!class'DXRFlags'.default.bZeroRandoPure)
         {
             // and finally, the torso! do 1.4x damage instead of the 2x damage in DeusExPlayer.uc::TakeDamage()
             return Damage * 0.7;
@@ -414,7 +413,7 @@ function int HealPlayer(int baseHealPoints, optional Bool bUseMedicineSkill, opt
     local bool fixLegs;
 
     //Alcohol fixes broken legs, as long as it isn't zero rando
-    if (source=="Forty" || source=="Liquor" || source=="Wine") fixLegs=!bZeroRando;
+    if (source=="Forty" || source=="Liquor" || source=="Wine") fixLegs = ! class'DXRFlags'.default.bZeroRandoPure;
 
     adjustedHealAmount = _HealPlayer(baseHealPoints, bUseMedicineSkill, fixLegs);
 

--- a/DXRVanilla/DeusEx/Classes/DataLinkPlay.uc
+++ b/DXRVanilla/DeusEx/Classes/DataLinkPlay.uc
@@ -10,7 +10,7 @@ function bool bIsFastMode()
     local DXRando dxr;
 
     if(!HaveQueued()) return false;
-    if(Human(player).bZeroRando) return false;
+    if(class'DXRFlags'.default.bReducedRando) return false;
     dxr = Human(player).GetDXR();
     if(dxr != None && dxr.dxInfo.missionNumber == 0) {
         return false;

--- a/DXRVanilla/DeusEx/Classes/HealingItem.uc
+++ b/DXRVanilla/DeusEx/Classes/HealingItem.uc
@@ -18,7 +18,7 @@ function DoHeal(Human player)
     if (player == None) return;
 
     player.drugEffectTimer += drugEffect;
-    balance = ! player.bZeroRando;
+    balance = ! class'DXRFlags'.default.bZeroRandoPure;
 
     if( health > 0 ) {
         i = player._HealPlayer(health, false, balance);// balance bool used for heal legs

--- a/DXRVanilla/DeusEx/Classes/Mission04.uc
+++ b/DXRVanilla/DeusEx/Classes/Mission04.uc
@@ -6,10 +6,10 @@ function Timer()
     local string map;
 
     if (
-        dxr.flags.IsBingoCampaignMode() &&
-        Player.IsInState('Dying') &&
-        class'DXRBingoCampaign'.static.IsBingoEnd(4, dxr.flags.bingo_duration) &&
-        !dxr.flagbase.GetBool(class'DXRBingoCampaign'.static.GetBingoMissionFlag(4))
+        dxr.flags.IsBingoCampaignMode()
+        && Player.IsInState('Dying')
+        && class'DXRBingoCampaign'.static.IsBingoEnd(4, dxr.flags.bingo_duration)
+        && !dxr.flagbase.GetBool(class'DXRBingoCampaign'.static.GetBingoMissionFlag(4))
     ) {
         return;
     }

--- a/DXRVanilla/DeusEx/Classes/Mission04.uc
+++ b/DXRVanilla/DeusEx/Classes/Mission04.uc
@@ -5,7 +5,12 @@ function Timer()
     local DXRMapVariants mapvariants;
     local string map;
 
-    if (dxr.flags.IsBingoCampaignMode() && Player.IsInState('Dying') && !dxr.flagbase.GetBool(class'DXRBingoCampaign'.static.GetBingoMissionFlag(4))) {
+    if (
+        dxr.flags.IsBingoCampaignMode() &&
+        Player.IsInState('Dying') &&
+        class'DXRBingoCampaign'.static.IsBingoEnd(4, dxr.flags.bingo_duration) &&
+        !dxr.flagbase.GetBool(class'DXRBingoCampaign'.static.GetBingoMissionFlag(4))
+    ) {
         return;
     }
 

--- a/DXRVanilla/DeusEx/Classes/Weapon.uc
+++ b/DXRVanilla/DeusEx/Classes/Weapon.uc
@@ -389,8 +389,7 @@ simulated function bool UpdateInfo(Object winObject)
     if (P == None)
         return False;
 
-    if(Human(P) != None)
-        bZeroRando = Human(P).bZeroRando;
+    bZeroRando = class'DXRFlags'.default.bZeroRandoPure;
 
     winInfo = PersonaInventoryInfoWindow(winObject);
     if (winInfo == None)

--- a/DXRando/DeusEx/Classes/DXRHoverHint.uc
+++ b/DXRando/DeusEx/Classes/DXRHoverHint.uc
@@ -66,7 +66,14 @@ function SetBaseActor(Actor base)
 
     //The tick logic is primarily for handling EnterWorld/LeaveWorld,
     //so only activate for things that can do that.
-    if (ScriptedPawn(baseActor)!=None || Vehicles(baseActor)!=None){
+    if (#var(prefix)ScriptedPawn(baseActor)!=None || #var(prefix)Vehicles(baseActor)!=None){
+        //Initialize bInWorld before ticking, in case the base actor changes state before their first tick
+        if (#var(prefix)ScriptedPawn(baseActor)!=None){
+            bInWorld = ScriptedPawn(baseActor).bInWorld;
+        }
+        if (#var(prefix)Vehicles(baseActor)!=None){
+            bInWorld = #var(prefix)Vehicles(baseActor).bInWorld;
+        }
         Enable('Tick');
     }
 }
@@ -78,13 +85,13 @@ function bool ShouldDisplay(float dist)
     }
 
     if (baseActor!=None){
-        if (ScriptedPawn(baseActor)!=None){
-            if ((ScriptedPawn(baseActor).bInWorld==False)){
+        if (#var(prefix)ScriptedPawn(baseActor)!=None){
+            if ((#var(prefix)ScriptedPawn(baseActor).bInWorld==False)){
                 return False;
             }
         }
-        if (Vehicles(baseActor)!=None){
-            if ((Vehicles(baseActor).bInWorld==False)){
+        if (#var(prefix)Vehicles(baseActor)!=None){
+            if ((#var(prefix)Vehicles(baseActor).bInWorld==False)){
                 return False;
             }
         }

--- a/DXRando/DeusEx/Classes/DXRStoredLightFog.uc
+++ b/DXRando/DeusEx/Classes/DXRStoredLightFog.uc
@@ -1,0 +1,33 @@
+class DXRStoredLightFog extends Info;
+
+var int VersionNum; //To theoretically help with upgrades if more information is added in this class
+
+var byte VolumeBrightness;
+var byte VolumeFog;
+var byte VolumeRadius;
+
+
+static function DXRStoredLightFog Init(Light l)
+{
+    local int i;
+    local DXRStoredLightFog slf;
+
+    //Only store information for lights that generate fog
+    if (l.VolumeFog==0 && l.VolumeRadius==0) return None;
+
+    slf = l.Spawn(class'DXRStoredLightFog',,,l.Location);
+
+    slf.SetOwner(l);
+
+    slf.VolumeBrightness = l.VolumeBrightness;
+    slf.VolumeFog = l.VolumeFog;
+    slf.VolumeRadius = l.VolumeRadius;
+
+    return slf;
+}
+
+defaultproperties
+{
+    VersionNum=1
+    bAlwaysRelevant=True
+}

--- a/DXRando/DeusEx/Classes/DXRStoredZoneInfo.uc
+++ b/DXRando/DeusEx/Classes/DXRStoredZoneInfo.uc
@@ -1,0 +1,145 @@
+//Class to store original ZoneInfo values for Rando purposes
+class DXRStoredZoneInfo extends Info;
+
+var int VersionNum; //To theoretically help with upgrades if more information is added in this class
+
+var bool bLevelInfo;
+var bool bSkyZone;
+
+//Properties
+var() name   ZoneTag;
+var() vector ZoneGravity;
+var() vector ZoneVelocity;
+var() float  ZoneGroundFriction;
+var() float  ZoneFluidFriction;
+var() float	 ZoneTerminalVelocity;
+var() name   ZonePlayerEvent;
+var() int	 DamagePerSec;
+var() name	 DamageType;
+var() string DamageString;
+var() int	 MaxCarcasses;
+var() sound  EntrySound;	//only if waterzone
+var() sound  ExitSound;		// only if waterzone
+var() class<actor> EntryActor;	// e.g. a splash (only if water zone)
+var() class<actor> ExitActor;	// e.g. a splash (only if water zone)
+
+//Flags
+var()		bool   bWaterZone;   // Zone is water-filled.
+var()       bool   bFogZone;     // Zone is fog-filled.
+var()       bool   bKillZone;    // Zone instantly kills those who enter.
+var()		bool   bNeutralZone; // Players can't take damage in this zone.
+var()		bool   bGravityZone; // Use ZoneGravity.
+var()		bool   bPainZone;	 // Zone causes pain.
+var()		bool   bDestructive; // Destroys carcasses.
+var()		bool   bNoInventory;
+var()		bool   bMoveProjectiles;	// this velocity zone should impart velocity to projectiles and effects
+var()		bool   bBounceVelocity;		// this velocity zone should bounce actors that land in it
+
+
+//Lighting
+var(ZoneLight) byte AmbientBrightness, AmbientHue, AmbientSaturation;
+var(ZoneLight) color FogColor;
+var(ZoneLight) float FogDistance;
+
+var(ZoneLight) texture EnvironmentMap;
+var(ZoneLight) float TexUPanSpeed, TexVPanSpeed;
+var(ZoneLight) vector ViewFlash, ViewFog;
+
+
+//Reverb
+var(Reverb) bool bReverbZone;
+var(Reverb) bool bRaytraceReverb;
+var(Reverb) float SpeedOfSound;
+var(Reverb) byte MasterGain;
+var(Reverb) int  CutoffHz;
+var(Reverb) byte Delay[6];
+var(Reverb) byte Gain[6];
+
+
+static function DXRStoredZoneInfo Init(ZoneInfo z)
+{
+    local int i;
+    local DXRStoredZoneInfo szi;
+
+    szi = z.Spawn(class'DXRStoredZoneInfo',,,z.Location);
+
+    szi.bLevelInfo = (LevelInfo(z)!=None);
+    szi.bSkyZone = (SkyZoneInfo(z)!=None);
+
+    szi.Tag = z.Tag;
+    szi.Event = z.Event;
+    szi.SetOwner(z);
+
+    szi.ZoneTag = z.ZoneTag;
+    szi.ZoneGravity = z.ZoneGravity;
+    szi.ZoneVelocity = z.ZoneVelocity;
+    szi.ZoneGroundFriction = z.ZoneGroundFriction;
+    szi.ZoneFluidFriction = z.ZoneFluidFriction;
+    szi.ZoneTerminalVelocity = z.ZoneTerminalVelocity;
+    szi.ZonePlayerEvent = z.ZonePlayerEvent;
+    szi.DamagePerSec = z.DamagePerSec;
+    szi.DamageType = z.DamageType;
+    szi.DamageString = z.DamageString;
+    szi.MaxCarcasses = z.MaxCarcasses;
+    szi.EntrySound = z.EntrySound;
+    szi.ExitSound = z.ExitSound;
+    szi.EntryActor = z.EntryActor;
+    szi.ExitActor = z.ExitActor;
+
+    szi.bWaterZone = z.bWaterZone;
+    szi.bFogZone = z.bFogZone;
+    szi.bKillZone = z.bKillZone;
+    szi.bNeutralZone = z.bNeutralZone;
+    szi.bGravityZone = z.bGravityZone;
+    szi.bPainZone = z.bPainZone;
+    szi.bDestructive = z.bDestructive;
+    szi.bNoInventory = z.bNoInventory;
+    szi.bMoveProjectiles = z.bMoveProjectiles;
+    szi.bBounceVelocity = z.bBounceVelocity;
+
+    szi.AmbientBrightness = z.AmbientBrightness;
+    szi.AmbientHue = z.AmbientHue;
+    szi.AmbientSaturation = z.AmbientSaturation;
+    szi.FogColor = z.FogColor;
+    szi.FogDistance = z.FogDistance;
+
+    szi.EnvironmentMap = z.EnvironmentMap;
+    szi.TexUPanSpeed = z.TexUPanSpeed;
+    szi.TexVPanSpeed = z.TexVPanSpeed;
+    szi.ViewFlash = z.ViewFlash;
+    szi.ViewFog = z.ViewFog;
+
+    szi.bReverbZone = z.bReverbZone;
+    szi.bRaytraceReverb = z.bRaytraceReverb;
+    szi.SpeedOfSound = z.SpeedOfSound;
+    szi.MasterGain = z.MasterGain;
+    szi.CutoffHz = z.CutoffHz;
+    for (i=0;i<ArrayCount(szi.Delay);i++){
+        szi.Delay[i]=z.Delay[i];
+    }
+    for (i=0;i<ArrayCount(szi.Gain);i++){
+        szi.Gain[i]=z.Gain[i];
+    }
+
+
+    return szi;
+}
+
+static function bool IsFogZone(ZoneInfo z)
+{
+    local DXRStoredZoneInfo szi;
+
+    if (z.bFogZone) return True;
+
+    foreach z.ZoneActors(class'DXRStoredZoneInfo',szi){
+        if (szi.bFogZone) return True;
+    }
+
+    return False;
+}
+
+defaultproperties
+{
+    VersionNum=1
+    bAlwaysRelevant=True
+}

--- a/DXRando/DeusEx/Classes/InformationDevices.uc
+++ b/DXRando/DeusEx/Classes/InformationDevices.uc
@@ -10,6 +10,7 @@ var DXRPasswords passwords;
 var string plaintext;
 var string new_passwords[16];
 var string plaintextTag;
+var bool bFrobbed;
 
 function string _GetMapName()
 {
@@ -318,7 +319,27 @@ function bool Facelift(bool bOn)
 
 function Frob(actor Frobber, Inventory frobWith)
 {
+    local DXRando dxr;
+    local DataVaultImage image;
+
+    if (imageClass != None && !bFrobbed) {
+        foreach AllActors(class'DXRando', dxr) {
+            if (dxr.flags.IsBingoCampaignMode()) {
+                for (image = dxr.player.FirstImage; image != None; image = image.nextImage) {
+                    if (image.imageDescription == imageClass.default.imageDescription) {
+                        dxr.player.ClientMessage("You found a new copy of " $ imageClass.default.imageDescription $ " to look at");
+                        image.bPlayerViewedImage = false;
+                        break;
+                    }
+                }
+            }
+            break;
+        }
+    }
+    bFrobbed = true;
+
     Super.Frob(Frobber, frobWith);
+
     GlowOff();
 }
 

--- a/GUI/DeusEx/Classes/DXRBigMessage.uc
+++ b/GUI/DeusEx/Classes/DXRBigMessage.uc
@@ -80,10 +80,10 @@ event DrawWindow(GC gc)
 
     dxr = class'DXRando'.default.dxr;
     if (
-        dxr.flags.IsBingoCampaignMode() &&
-        dxr.flagbase.GetBool('TalkedToPaulAfterMessage_Played') &&
-        dxr.dxInfo.missionNumber == 4 &&
-        class'DXRBingoCampaign'.static.IsBingoEnd(4, dxr.flags.bingo_duration)
+        dxr.flags.IsBingoCampaignMode()
+        && dxr.flagbase.GetBool('TalkedToPaulAfterMessage_Played')
+        && dxr.dxInfo.missionNumber == 4
+        && class'DXRBingoCampaign'.static.IsBingoEnd(4, dxr.flags.bingo_duration)
     ) {
         message = class'DXRBingoCampaign'.static.GetBingoHoverHintText(dxr, "");
 

--- a/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
+++ b/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
@@ -209,7 +209,7 @@ function InitStats(DXRStats newstats)
     if(curMission == 99) {
         CompletedRun(total);
     }
-    if(curMission > 0) {
+    if(curMission > 0 && stats.dxr.flags.newgameplus_loops == 0) {
         last_flagshash = stats.dxr.flags.FlagsHash();
         default.last_flagshash = last_flagshash;
     }

--- a/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
+++ b/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
@@ -36,6 +36,8 @@ var config float x_pos, y_pos;
 var float prevSpeed, avgSpeed, lastTime;
 var int rememberedMission;
 
+var config int last_flagshash;
+
 // ----------------------------------------------------------------------
 // InitWindow()
 // ----------------------------------------------------------------------
@@ -207,6 +209,10 @@ function InitStats(DXRStats newstats)
     if(curMission == 99) {
         CompletedRun(total);
     }
+    if(curMission > 0) {
+        last_flagshash = stats.dxr.flags.FlagsHash();
+        default.last_flagshash = last_flagshash;
+    }
     SaveConfig();
 
     if(curMission < 1 || curMission > 15) {
@@ -216,6 +222,16 @@ function InitStats(DXRStats newstats)
 
     Show();
     StyleChanged();
+}
+
+static function bool CheckFlags(DXRFlags f)
+{
+    local int last;
+
+    if(f.moresettings.splits_overlay <= 0) return true;
+    last = class'HUDSpeedrunSplits'.default.last_flagshash;
+    if(last == 0) return true;
+    return f.FlagsHash() == last;
 }
 
 function CompletedRun(int total)

--- a/GUI/DeusEx/Classes/MenuChoice_Fog.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_Fog.uc
@@ -2,17 +2,18 @@ class MenuChoice_Fog extends DXRMenuUIChoiceBool;
 
 function SaveSetting()
 {
+    local DXRBrightness b;
+
     Super.SaveSetting();
     enabled = bool(GetValue());
-    if(!enabled) {
-        player.ConsoleCommand("set ZoneInfo bFogZone false");
-    }
+    b = DXRBrightness(class'DXRBrightness'.static.Find());
+    b.ApplyFog(enabled);
 }
 
 defaultproperties
 {
     enabled=True
     defaultvalue=True
-    HelpText="You can disable fog effects for additional performance in certain areas. Enabling will not take affect until you get to a new map."
+    HelpText="You can disable fog effects for additional performance in certain areas."
     actionText="Fog Effects"
 }

--- a/installer/GUI/InstallerWindow.py
+++ b/installer/GUI/InstallerWindow.py
@@ -242,7 +242,7 @@ class InstallerWindow(GUIBase):
 
         # DXVK max fps
         self.globalsettings['dxvkmaxfps'] = IntVar(master=self.frame, value=500)
-        self.dxvkmaxfpsframe = self.newLabeledWidget(self.frame, Spinbox, 'DXVK Max FPS: ', 'Maximum fps when using DXVK, default is 500 fps.', textvariable=self.globalsettings['dxvkmaxfps'], width=5, from_=30, to=500)
+        self.dxvkmaxfpsframe = self.newLabeledWidget(self.frame, Spinbox, 'DXVK Max FPS: ', 'Maximum fps when using DXVK, default is 500 fps. There may be issues going over 500.', textvariable=self.globalsettings['dxvkmaxfps'], width=5, from_=30, to=500)
         self.setgrid(self.dxvkmaxfpsframe, True, column=1, row=self.row, sticky='SW', padx=pad*6, pady=pad)
         self.row+=1
 

--- a/installer/Install/Config.py
+++ b/installer/Install/Config.py
@@ -89,6 +89,7 @@ class Config:
             key:str = line.get('key', '')
             changename = lowerchanges.get(key.lower())
             if changename:
+                tempchanges.pop(changename, None) # a value could be listed twice?
                 if changes[changename] == line['value']:
                     continue
                 lines.insert(i, { 'text': ';' + line['key'] + '=' + line['value'] })
@@ -96,7 +97,6 @@ class Config:
                 assert isinstance(changes[changename], str)
                 line['key'] = changename # fix casing?
                 line['value'] = changes[changename]
-                tempchanges.pop(changename)
 
         # add the things we wanted to change but didn't exist
         for (change, val) in tempchanges.items():

--- a/installer/Install/Install.py
+++ b/installer/Install/Install.py
@@ -103,8 +103,7 @@ def Install(exe:Path, flavors:dict, globalsettings:dict) -> dict:
         if ret and settings:
             settings.update(ret)
 
-    if globalsettings['speedupfix']:
-        EngineDllFix(system)
+    EngineDllFix(system, bool(globalsettings['speedupfix']))
 
     CopyDXVK(system, globalsettings['dxvk'], globalsettings['dxvkmaxfps'])
     CopyD3DRenderers(system, globalsettings['deus_nsf_d3d10_lighting'], globalsettings['d3d10_textures'])

--- a/installer/Install/Install.py
+++ b/installer/Install/Install.py
@@ -105,7 +105,9 @@ def Install(exe:Path, flavors:dict, globalsettings:dict) -> dict:
 
     EngineDllFix(system, bool(globalsettings['speedupfix']))
 
-    CopyDXVK(system, globalsettings['dxvk'], globalsettings['dxvkmaxfps'])
+    maxmaxfps = 1000 if globalsettings['speedupfix'] else 120
+    dxvkmaxfps = max(10, min(maxmaxfps, globalsettings['dxvkmaxfps']))
+    CopyDXVK(system, globalsettings['dxvk'], dxvkmaxfps)
     CopyD3DRenderers(system, globalsettings['deus_nsf_d3d10_lighting'], globalsettings['d3d10_textures'])
     InstallOGL2(system, globalsettings['ogl2'])
 
@@ -209,20 +211,22 @@ def VanillaFixConfigs(system, exename, kentie, globalsettings:dict, sourceINI: P
 
     if not globalsettings['dxvk'] and IsWindows():
         changes['Galaxy.GalaxyAudioSubsystem'] = {'Latency': '80'}
+    if 'DeusExe' not in changes:
+        changes['DeusExe'] = {}
 
     if 'D3D10Drv.D3D10RenderDevice' not in changes:
         changes['D3D10Drv.D3D10RenderDevice'] = {}
-    if not globalsettings['speedupfix']:
-        if 'DeusExe' not in changes:
-            changes['DeusExe'] = {}
-        changes['DeusExe'].update({'FPSLimit': '120'})
-        changes['D3D10Drv.D3D10RenderDevice'].update({'FPSLimit': '120', 'VSync': 'True'})
-    elif exename == 'DeusEx': # ensure we don't retain bad settings from old vanilla configs since we use the same exe file name?
-        if 'DeusExe' not in changes:
-            changes['DeusExe'] = {}
+
+    # FPS stuff
+    deusexeFPSLimit = 0
+    if not globalsettings['speedupfix'] and not globalsettings['dxvk']:
+        changes['DeusExe'].update({'FPSLimit': '0'}) # Kentie's DeusExe is bad at FPS limits, just let the renderer do it
+        changes['D3D10Drv.D3D10RenderDevice'].update({'FPSLimit': '120', 'VSync': 'False'})
+    else: # if we're using the speedup fix then we don't need to limit fps, if we're using DXVK then that handles the fps limit
         changes['DeusExe'].update({'FPSLimit': '0'})
         changes['D3D10Drv.D3D10RenderDevice'].update({'FPSLimit': '0', 'VSync': 'False'})
 
+    # D3D10 lighting
     if globalsettings['deus_nsf_d3d10_lighting']:
         changes['D3D10Drv.D3D10RenderDevice'].update({'ClassicLighting': 'False'})
     else:
@@ -277,6 +281,8 @@ def VanillaFixConfigs(system, exename, kentie, globalsettings:dict, sourceINI: P
                  'DeusEx.DXRando', 'DeusEx.DXRFlags', 'DeusEx.DXRTelemetry', 'DeusEx.DXRMenuScreenNewGame')),
             changes
         )
+        changes['DeusExe']['FPSLimit'] = str(deusexeFPSLimit) # always overwrite this value
+
     if changes:
         c = Config.Config(b)
         c.ModifyConfig(changes, additions={})


### PR DESCRIPTION
- make fall damage sound different for 0 damage
- new loadout to start with random aug instead of speed
- probably fixed big robots blocking paths #566
- MBM doesn't block M04 exit if it's not an end mission
- fixed HongKongGrays bingo event
- speedrun splits warning when starting with different settings
- UNATCO blockade isn't present in Battery Park until the raid starts. 
- mark images as unviewed when reacquired
- Make sure flashlight hints are appropriate in Halloween mode
- you can now toggle fog on and off
- Added Weapon Mod randomization odds to credits
- fixed "Snitches Get Stitches" bingo goal sometimes being impossible in MBM
- lebedev bingo mutual exclusion for lived vs unconscious
- Refactor M05 jail freebie weapon slightly and add a small light to the weapon. 
- Make your stolen equipment a DXRMissions goal so it shows in the spoilers (including on the map).
- A few backtracking fixes
- removed duplicate jocks from most game modes, they are only needed for bingo modes and entrance rando
- installer make Engine.dll speedup fix reversible
- installer tweak FPS limits based on settings
- removed a bunch of balance changes from Zero Rando Pure, reverting the following:
  - shorter chairs
  - tech goggles buffs
  - cheesing lasers with gas or grenades
  - removed startup messages

# Previously in v3.3.2.1 Alpha: https://github.com/Die4Ever/deus-ex-randomizer/pull/1091 (only minor changes)