### PR TITLE
v3.3.2.4 Alpha

### DIFF
--- a/DXRBalance/DeusEx/Classes/AugAqualung.uc
+++ b/DXRBalance/DeusEx/Classes/AugAqualung.uc
@@ -28,6 +28,9 @@ function Tick(float deltaTime)
     if (IsTicked() && EnergyRate==0) {
         player.swimTimer = player.swimDuration;
     }
+    if(bIsActive) {
+        player.swimBubbleTimer = 0;
+    }
 }
 
 defaultproperties

--- a/DXRBalance/DeusEx/Classes/AugAqualung.uc
+++ b/DXRBalance/DeusEx/Classes/AugAqualung.uc
@@ -1,8 +1,7 @@
 class DXRAugAqualung injects AugAqualung;
 
-function PostPostBeginPlay()
+function UpdateBalance()
 {
-    Super.PostPostBeginPlay();
     // description gets overwritten by language file, also DXRAugmentations reads from the default.Description
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
         Description = "Soda lime exostructures imbedded in the alveoli of the lungs convert CO2 to O2, allowing an agent to remain underwater indefinitely.";

--- a/DXRBalance/DeusEx/Classes/AugBallistic.uc
+++ b/DXRBalance/DeusEx/Classes/AugBallistic.uc
@@ -1,6 +1,6 @@
 class DXRAugBallistic injects AugBallistic;
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
         Level5Value = 0.15;
@@ -8,7 +8,6 @@ function BeginPlay()
         Level5Value = -1;
     }
     default.Level5Value = Level5Value;
-    Super.BeginPlay();
 }
 
 // vanilla level 1 is 0.80 (20%) but rounding causes it to show as 19%

--- a/DXRBalance/DeusEx/Classes/AugCombat.uc
+++ b/DXRBalance/DeusEx/Classes/AugCombat.uc
@@ -23,7 +23,7 @@ simulated function TickUse()
     Super.TickUse();
 }
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
         Level5Value = 2.25;
@@ -31,7 +31,6 @@ function BeginPlay()
         Level5Value = -1;
     }
     default.Level5Value = Level5Value;
-    Super.BeginPlay();
 }
 
 defaultproperties

--- a/DXRBalance/DeusEx/Classes/AugDefense.uc
+++ b/DXRBalance/DeusEx/Classes/AugDefense.uc
@@ -120,7 +120,7 @@ Begin:
     SetTimer(0.1, True);
 }
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
         EnergyRate=30;
@@ -128,7 +128,6 @@ function BeginPlay()
         EnergyRate=10;
     }
     default.EnergyRate = EnergyRate;
-    Super.BeginPlay();
 }
 
 // vanilla is EnergyRate=10, vanilla AugBallistic is EnergyRate=60

--- a/DXRBalance/DeusEx/Classes/AugEMP.uc
+++ b/DXRBalance/DeusEx/Classes/AugEMP.uc
@@ -1,21 +1,6 @@
 class DXRAugEMP injects AugEMP;
 
-function PostPostBeginPlay()
-{
-    Super.PostPostBeginPlay();
-    // DXRando: AugEMP makes you immune to Scramble Grenades
-    Description = "Nanoscale EMP generators partially protect individual nanites and reduce bioelectrical drain by canceling incoming pulses.  ";
-    if(class'MenuChoice_BalanceEtc'.static.IsEnabled()) {
-        Description = Description $ "All levels make you immune to Scramble Grenades.";
-    }
-    Description = Description $ "|n|nTECH ONE: Damage from EMP attacks is reduced slightly."
-        $ "|n|nTECH TWO: Damage from EMP attacks is reduced moderately."
-        $ "|n|nTECH THREE: Damage from EMP attacks is reduced significantly."
-        $ "|n|nTECH FOUR: An agent is nearly invulnerable to damage from EMP attacks.";
-    default.Description = Description;
-}
-
-function BeginPlay()
+function UpdateBalance()
 {
     local int i;
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
@@ -32,7 +17,17 @@ function BeginPlay()
     for(i=0; i<ArrayCount(LevelValues); i++) {
         default.LevelValues[i] = LevelValues[i];
     }
-    Super.BeginPlay();
+
+    // DXRando: AugEMP makes you immune to Scramble Grenades
+    Description = "Nanoscale EMP generators partially protect individual nanites and reduce bioelectrical drain by canceling incoming pulses.  ";
+    if(class'MenuChoice_BalanceEtc'.static.IsEnabled()) {
+        Description = Description $ "All levels make you immune to Scramble Grenades.";
+    }
+    Description = Description $ "|n|nTECH ONE: Damage from EMP attacks is reduced slightly."
+        $ "|n|nTECH TWO: Damage from EMP attacks is reduced moderately."
+        $ "|n|nTECH THREE: Damage from EMP attacks is reduced significantly."
+        $ "|n|nTECH FOUR: An agent is nearly invulnerable to damage from EMP attacks.";
+    default.Description = Description;
 }
 
 defaultproperties

--- a/DXRBalance/DeusEx/Classes/AugHeartLung.uc
+++ b/DXRBalance/DeusEx/Classes/AugHeartLung.uc
@@ -1,42 +1,28 @@
 class DXRAugHeartLung injects AugHeartLung;
 
-function PostPostBeginPlay()
-{
-    Super.PostPostBeginPlay();
-    // description gets overwritten by language file, also DXRAugmentations reads from the default.Description
-    UpdateBalance();
-}
-
 function UpdateBalance()
 {
     if(bAutomatic) {
         Description = "This synthetic heart circulates not only blood but a steady concentration of mechanochemical power cells, smart phagocytes, and liposomes containing prefab diamondoid machine parts,"
                         $ " resulting in upgraded performance for all installed augmentations, but also increasing their energy use."
                         $ "|n|n<UNATCO OPS FILE NOTE JR133-VIOLET> ";
-
+        MaxLevel=3;
+        LevelValues[0]=2;
     } else {
         Description = "This synthetic heart circulates not only blood but a steady concentration of mechanochemical power cells, smart phagocytes, and liposomes containing prefab diamondoid machine parts,"
                         $ " resulting in upgraded performance for all installed augmentations."
                         $ "|n|n<UNATCO OPS FILE NOTE JR133-VIOLET> ";
+        MaxLevel=0;
+        LevelValues[0]=1;
     }
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
         Description = Description $ "However, not all augmentations can be enhanced past their maximum upgrade level. -- Jaime Reyes <END NOTE>";
-        MaxLevel=3;
-        LevelValues[0]=2;
     } else {
         Description = Description $ "However, this will not enhance any augmentation past its maximum upgrade level. -- Jaime Reyes <END NOTE>|n|nNO UPGRADES";
-        MaxLevel=0;
-        LevelValues[0]=1;
     }
     default.Description = Description;
     default.MaxLevel = MaxLevel;
     default.LevelValues[0] = LevelValues[0];
-}
-
-simulated function SetAutomatic()
-{
-    Super.SetAutomatic();
-    UpdateBalance();
 }
 
 function Deactivate()
@@ -49,6 +35,7 @@ function Deactivate()
 
 defaultproperties
 {
+    bAutomatic=true
     AutoEnergyMult=0
     MaxLevel=3
     LevelValues(0)=2

--- a/DXRBalance/DeusEx/Classes/AugMuscle.uc
+++ b/DXRBalance/DeusEx/Classes/AugMuscle.uc
@@ -1,20 +1,5 @@
 class DXRAugMuscle injects AugMuscle;
 
-function PostPostBeginPlay()
-{
-    Super.PostPostBeginPlay();
-    if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
-        // description gets overwritten by language file, also DXRAugmentations reads from the default.Description
-        Description = "Muscle strength is amplified with ionic polymeric gel myofibrils that allow the agent to push and lift extraordinarily heavy objects."
-                        $ "|n|nTECH ONE: Strength is increased slightly.|n|nTECH TWO: An agent is inhumanly strong.";
-    } else {
-        Description = "Muscle strength is amplified with ionic polymeric gel myofibrils that allow the agent to push and lift extraordinarily heavy objects."
-                        $ "|n|nTECH ONE: Strength is increased slightly.|n|nTECH TWO: Strength is increased moderately."
-                        $ "|n|nTECH THREE: Strength is increased significantly.|n|nTECH FOUR: An agent is inhumanly strong.";
-    }
-    default.Description = Description;
-}
-
 simulated function int GetClassLevel()
 {
     if(MaxLevel == 3 && bHasIt && bIsActive) {
@@ -27,21 +12,27 @@ simulated function int GetClassLevel()
         return -1;
 }
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
         MaxLevel = 1;
         LevelValues[0] = 1.25;
         LevelValues[1] = 2;
+        // description gets overwritten by language file, also DXRAugmentations reads from the default.Description
+        Description = "Muscle strength is amplified with ionic polymeric gel myofibrils that allow the agent to push and lift extraordinarily heavy objects."
+                        $ "|n|nTECH ONE: Strength is increased slightly.|n|nTECH TWO: An agent is inhumanly strong.";
     } else {
         MaxLevel = 3;
         LevelValues[0] = 1.25;
         LevelValues[1] = 1.5;
+        Description = "Muscle strength is amplified with ionic polymeric gel myofibrils that allow the agent to push and lift extraordinarily heavy objects."
+                        $ "|n|nTECH ONE: Strength is increased slightly.|n|nTECH TWO: Strength is increased moderately."
+                        $ "|n|nTECH THREE: Strength is increased significantly.|n|nTECH FOUR: An agent is inhumanly strong.";
     }
     default.MaxLevel = MaxLevel;
     default.LevelValues[0] = LevelValues[0];
     default.LevelValues[1] = LevelValues[1];
-    Super.BeginPlay();
+    default.Description = Description;
 }
 
 // LevelValues only affect throwing velocity in vanilla, and in DXRando also DoJump

--- a/DXRBalance/DeusEx/Classes/AugPower.uc
+++ b/DXRBalance/DeusEx/Classes/AugPower.uc
@@ -1,11 +1,8 @@
 class DXRAugPower injects AugPower;
 
-simulated function SetAutomatic()
+simulated function UpdateBalance()
 {
-    local DXRAugmentations raugs;
     local int i;
-
-    Super.SetAutomatic();
 
     // HACK: a little wonky if you change the setting mid-game, but otherwise works
     energyRate = default.energyRate;
@@ -21,24 +18,19 @@ simulated function SetAutomatic()
 
     // power recirc is OP when it's free, RandoAug reads from defaults
     if(energyRate == 0) {
-        default.LevelValues[0] = 0.92;
-        default.LevelValues[1] = 0.85;
-        default.LevelValues[2] = 0.75;
-        default.LevelValues[3] = 0.6;
+        LevelValues[0] = 0.92;
+        LevelValues[1] = 0.85;
+        LevelValues[2] = 0.75;
+        LevelValues[3] = 0.6;
     } else {
-        default.LevelValues[0] = 0.9;
-        default.LevelValues[1] = 0.8;
-        default.LevelValues[2] = 0.6;
-        default.LevelValues[3] = 0.4;
+        LevelValues[0] = 0.9;
+        LevelValues[1] = 0.8;
+        LevelValues[2] = 0.6;
+        LevelValues[3] = 0.4;
     }
     for(i=0; i<ArrayCount(LevelValues); i++) {
-        LevelValues[i] = default.LevelValues[i];
+        default.LevelValues[i] = LevelValues[i];
     }
-
-    if(player != None)
-        raugs = DXRAugmentations(Human(player).DXRFindModule(class'DXRAugmentations'));
-    if(raugs != None)
-        raugs.RandoAug(self);
 }
 
 defaultproperties

--- a/DXRBalance/DeusEx/Classes/AugShield.uc
+++ b/DXRBalance/DeusEx/Classes/AugShield.uc
@@ -1,6 +1,6 @@
 class DXRAugShield injects AugShield;
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
         EnergyRate = 25;
@@ -11,7 +11,6 @@ function BeginPlay()
     }
     default.EnergyRate = EnergyRate;
     default.Level5Value = Level5Value;
-    Super.BeginPlay();
 }
 
 // vanilla level 1 is 0.80 (20%) but rounding causes it to show as 19%, same issue with level 2

--- a/DXRBalance/DeusEx/Classes/AugTarget.uc
+++ b/DXRBalance/DeusEx/Classes/AugTarget.uc
@@ -25,7 +25,7 @@ simulated function SetTargetingAugStatus(int Level, bool IsActive)
     DeusExRootWindow(Player.rootWindow).hud.augDisplay.targetLevel = Level;
 }
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
         Level5Value=-0.25;
@@ -33,7 +33,6 @@ function BeginPlay()
         Level5Value=-1;
     }
     default.Level5Value = Level5Value;
-    Super.BeginPlay();
 }
 
 defaultproperties

--- a/DXRBalance/DeusEx/Classes/AugmentationManager.uc
+++ b/DXRBalance/DeusEx/Classes/AugmentationManager.uc
@@ -159,7 +159,7 @@ simulated function Float CalcEnergyUse(float deltaTime)
     {
         if (AugPower(anAug) != None && anAug.bHasIt && anAug.bIsActive)
             energyMult = anAug.GetAugLevelValue();
-        if (AugHeartLung(anAug) != None && anAug.bHasIt && anAug.bIsActive)
+        if (AugHeartLung(anAug) != None && anAug.bHasIt && anAug.bIsActive && anAug.bAutomatic)
             boostMult = anAug.GetAugLevelValue();
 
         if (anAug.bHasIt && anAug.bIsActive)

--- a/DXRBalance/DeusEx/Classes/BalanceAugDrone.uc
+++ b/DXRBalance/DeusEx/Classes/BalanceAugDrone.uc
@@ -1,27 +1,5 @@
 class BalanceAugDrone injects AugDrone;
 
-function PostPostBeginPlay()
-{
-    Super.PostPostBeginPlay();
-    // description gets overwritten by language file, also DXRAugmentations reads from the default.Description
-    if(reconstructTime==1) {
-        Description = "Advanced nanofactories can assemble a spy drone upon demand which can then be remotely controlled by the agent until released or destroyed, at which a point a new drone will be assembled."
-                        $ " Detonating the drone costs 10 energy. Further upgrades equip the spy drones with better armor and a one-shot EMP attack."
-                        $ "|n|nTECH ONE: The drone is slow and has a very light EMP attack."
-                        $ "|n|nTECH TWO: The drone is fast and has a light EMP attack."
-                        $ "|n|nTECH THREE: The drone is very fast and has a medium EMP attack."
-                        $ "|n|nTECH FOUR: The drone is extremely fast and has a strong EMP attack.";
-    } else {
-        Description = "Advanced nanofactories can assemble a spy drone upon demand which can then be remotely controlled by the agent until released or destroyed, at which a point a new drone will be assembled."
-                        $ " Further upgrades equip the spy drones with better armor and a one-shot EMP attack."
-                        $ "|n|nTECH ONE: The drone can take little damage and has a very light EMP attack."
-                        $ "|n|nTECH TWO: The drone can take minor damage and has a light EMP attack."
-                        $ "|n|nTECH THREE: The drone can take moderate damage and has a medium EMP attack."
-                        $ "|n|nTECH FOUR: The drone can take heavy damage and has a strong EMP attack.";
-    }
-    default.Description = Description;
-}
-
 function Reset()
 {
     //Don't actually reset if the aug is already inactive
@@ -33,7 +11,7 @@ function Reset()
     Human(Player).SetDroneStats();
 }
 
-function BeginPlay()
+function UpdateBalance()
 {
     local int i;
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
@@ -43,6 +21,12 @@ function BeginPlay()
         LevelValues[1]=50;
         LevelValues[2]=70;
         LevelValues[3]=100;
+        Description = "Advanced nanofactories can assemble a spy drone upon demand which can then be remotely controlled by the agent until released or destroyed, at which a point a new drone will be assembled."
+                        $ " Detonating the drone costs 10 energy. Further upgrades equip the spy drones with better armor and a one-shot EMP attack."
+                        $ "|n|nTECH ONE: The drone is slow and has a very light EMP attack."
+                        $ "|n|nTECH TWO: The drone is fast and has a light EMP attack."
+                        $ "|n|nTECH THREE: The drone is very fast and has a medium EMP attack."
+                        $ "|n|nTECH FOUR: The drone is extremely fast and has a strong EMP attack.";
     } else {
         reconstructTime=30;
         EnergyRate=150;
@@ -50,13 +34,19 @@ function BeginPlay()
         LevelValues[1]=20;
         LevelValues[2]=35;
         LevelValues[3]=50;
+        Description = "Advanced nanofactories can assemble a spy drone upon demand which can then be remotely controlled by the agent until released or destroyed, at which a point a new drone will be assembled."
+                        $ " Further upgrades equip the spy drones with better armor and a one-shot EMP attack."
+                        $ "|n|nTECH ONE: The drone can take little damage and has a very light EMP attack."
+                        $ "|n|nTECH TWO: The drone can take minor damage and has a light EMP attack."
+                        $ "|n|nTECH THREE: The drone can take moderate damage and has a medium EMP attack."
+                        $ "|n|nTECH FOUR: The drone can take heavy damage and has a strong EMP attack.";
     }
     default.reconstructTime=reconstructTime;
     default.EnergyRate=EnergyRate;
     for(i=0; i<ArrayCount(LevelValues); i++) {
         default.LevelValues[i] = LevelValues[i];
     }
-    Super.BeginPlay();
+    default.Description = Description;
 }
 
 // original values went from 10 to 50, but we also adjust the multipliers in BalancePlayer.uc

--- a/DXRBalance/DeusEx/Classes/BalanceAugHealing.uc
+++ b/DXRBalance/DeusEx/Classes/BalanceAugHealing.uc
@@ -1,23 +1,5 @@
 class BalanceAugHealing injects AugHealing;
 
-function PostPostBeginPlay()
-{
-    Super.PostPostBeginPlay();
-    // description gets overwritten by language file, also DXRAugmentations reads from the default.Description
-    if(Level5Value > 0) {
-        Description = "Programmable polymerase automatically directs construction of proteins in injured cells, restoring an agent's health over time."
-                        $ "|n|nTECH ONE: Healing only fixes serious injuries."
-                        $ "|n|nTECH TWO: Healing fixes moderate injuries."
-                        $ "|n|nTECH THREE: Healing fixes most injuries."
-                        $ "|n|nTECH FOUR: Healing restores the agent to nearly full health.";
-    } else {
-        Description = "Programmable polymerase automatically directs construction of proteins in injured cells, restoring an agent to full health over time."
-                        $ "|n|nTECH ONE: Healing occurs at a normal rate.|n|nTECH TWO: Healing occurs at a slightly faster rate."
-                        $ "|n|nTECH THREE: Healing occurs at a moderately faster rate.|n|nTECH FOUR: Healing occurs at a significantly faster rate.";
-    }
-    default.Description = Description;
-}
-
 //DXRando: put a cap on the health that regen gives you
 state Active
 {
@@ -111,7 +93,7 @@ function bool NeedsHeal()
         || Player.HealthArmLeft < Min(i, Player.default.HealthArmLeft);
 }
 
-function BeginPlay()
+function UpdateBalance()
 {
     local int i;
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
@@ -121,6 +103,11 @@ function BeginPlay()
         LevelValues[2] = 55;
         LevelValues[3] = 70;
         Level5Value = 90;
+        Description = "Programmable polymerase automatically directs construction of proteins in injured cells, restoring an agent's health over time."
+                        $ "|n|nTECH ONE: Healing only fixes serious injuries."
+                        $ "|n|nTECH TWO: Healing fixes moderate injuries."
+                        $ "|n|nTECH THREE: Healing fixes most injuries."
+                        $ "|n|nTECH FOUR: Healing restores the agent to nearly full health.";
     } else {
         EnergyRate = 120;
         LevelValues[0] = 5;
@@ -128,13 +115,16 @@ function BeginPlay()
         LevelValues[2] = 25;
         LevelValues[3] = 40;
         Level5Value = -1;
+        Description = "Programmable polymerase automatically directs construction of proteins in injured cells, restoring an agent to full health over time."
+                        $ "|n|nTECH ONE: Healing occurs at a normal rate.|n|nTECH TWO: Healing occurs at a slightly faster rate."
+                        $ "|n|nTECH THREE: Healing occurs at a moderately faster rate.|n|nTECH FOUR: Healing occurs at a significantly faster rate.";
     }
     for(i=0; i<ArrayCount(LevelValues); i++) {
         default.LevelValues[i] = LevelValues[i];
     }
     default.EnergyRate = EnergyRate;
     default.Level5Value = Level5Value;
-    Super.BeginPlay();
+    default.Description = Description;
 }
 
 // original values go from 5 to 40, but those controlled healing rate, EnergyRate of 120

--- a/DXRBalance/DeusEx/Classes/BalanceAugLight.uc
+++ b/DXRBalance/DeusEx/Classes/BalanceAugLight.uc
@@ -25,14 +25,6 @@ simulated function float GetEnergyRate()
     return EnergyRate;
 }
 
-function PostPostBeginPlay()
-{
-    Super.PostPostBeginPlay();
-    default.Description="Bioluminescent cells within the retina provide coherent illumination of the agent's field of view.";
-    Description = default.Description;
-    GetEnergyRate();// HACK: UpdateInfo function is still using the EnergyRate variable not the GetEnergyRate() function
-}
-
 function TravelPostAccept()
 {
     Super.TravelPostAccept();
@@ -45,7 +37,7 @@ function bool IncLevel()
     GetEnergyRate();// HACK: UpdateInfo function is still using the EnergyRate variable not the GetEnergyRate() function
 }
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
         MaxLevel=1;
@@ -56,7 +48,9 @@ function BeginPlay()
     }
     default.MaxLevel=MaxLevel;
     default.EnergyRate=EnergyRate;
-    Super.BeginPlay();
+    Description="Bioluminescent cells within the retina provide coherent illumination of the agent's field of view.";
+    default.Description = Description;
+    GetEnergyRate();// HACK: UpdateInfo function is still using the EnergyRate variable not the GetEnergyRate() function
 }
 
 defaultproperties

--- a/DXRBalance/DeusEx/Classes/BalanceAugSpeed.uc
+++ b/DXRBalance/DeusEx/Classes/BalanceAugSpeed.uc
@@ -42,7 +42,7 @@ function Reset()
     }
 }
 
-function BeginPlay()
+function UpdateBalance()
 {
     local int i;
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
@@ -62,7 +62,6 @@ function BeginPlay()
         default.LevelValues[i] = LevelValues[i];
     }
     default.Level5Value = Level5Value;
-    Super.BeginPlay();
 }
 
 //original went from 1.2 up to 1.8, I've thought about nerfing the max speed so you can't just run past all enemies, but I think that would require an unreasonably large nerf

--- a/DXRBalance/DeusEx/Classes/BalanceDTS.uc
+++ b/DXRBalance/DeusEx/Classes/BalanceDTS.uc
@@ -1,6 +1,6 @@
 class BalanceDTS injects WeaponNanoSword;
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceItems'.static.IsEnabled()) {
         HitDamage = 24;
@@ -11,7 +11,6 @@ function BeginPlay()
     }
     default.HitDamage = HitDamage;
     default.AreaOfEffect = AreaOfEffect;
-    Super.BeginPlay();
 }
 
 // original HitDamage was 20, AOE_Cone causes it to be treated as a shotgun with 3 (or 5?) projectiles multiplying the damage, see DeusExWeapon and search for AOE_Cone

--- a/DXRBalance/DeusEx/Classes/BuffAugVision.uc
+++ b/DXRBalance/DeusEx/Classes/BuffAugVision.uc
@@ -41,7 +41,7 @@ simulated function SetVisionAugStatus(int Level, int LevelValue, bool IsActive)
     }
 }
 
-simulated function PreBeginPlay()
+simulated function UpdateBalance()
 {
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
         LevelValues[2]=640;
@@ -52,7 +52,6 @@ simulated function PreBeginPlay()
     }
     default.LevelValues[2]=LevelValues[2];
     default.LevelValues[3]=LevelValues[3];
-    Super.PreBeginPlay();
 }
 
 // level value is feet*16

--- a/DXRBalance/DeusEx/Classes/BuffRifle.uc
+++ b/DXRBalance/DeusEx/Classes/BuffRifle.uc
@@ -1,6 +1,6 @@
 class BuffRifle injects WeaponAssaultGun;
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceItems'.static.IsEnabled()) {
         HitDamage = 4;
@@ -14,7 +14,6 @@ function BeginPlay()
     default.HitDamage = HitDamage;
     default.maxRange = maxRange;
     default.AccurateRange = AccurateRange;
-    Super.BeginPlay();
 }
 
 // way lower range, 4 damage

--- a/DXRBalance/DeusEx/Classes/PistolBalance.uc
+++ b/DXRBalance/DeusEx/Classes/PistolBalance.uc
@@ -1,6 +1,6 @@
 class PistolBalance injects WeaponPistol;
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceItems'.static.IsEnabled()) {
         HitDamage = 12;
@@ -17,7 +17,6 @@ function BeginPlay()
     default.BaseAccuracy = BaseAccuracy;
     default.maxRange=maxRange;
     default.AccurateRange=AccurateRange;
-    Super.BeginPlay();
 }
 
 // lower damage and range, better accuracy

--- a/DXRBalance/DeusEx/Classes/SkillComputer.uc
+++ b/DXRBalance/DeusEx/Classes/SkillComputer.uc
@@ -1,6 +1,6 @@
 class SkillComputer injects SkillComputer;
 
-function BeginPlay()
+function UpdateBalance()
 {
     local int i;
 
@@ -19,7 +19,6 @@ function BeginPlay()
     for(i=0; i<ArrayCount(LevelValues); i++) {
         default.LevelValues[i] = LevelValues[i];
     }
-    Super.BeginPlay();
 }
 
 // vanilla is 1, 1, 2, 4

--- a/DXRBalance/DeusEx/Classes/SkillEnviro.uc
+++ b/DXRBalance/DeusEx/Classes/SkillEnviro.uc
@@ -1,6 +1,6 @@
 class SkillEnviro injects SkillEnviro;
 
-function BeginPlay()
+function UpdateBalance()
 {
     local int i;
 
@@ -19,7 +19,6 @@ function BeginPlay()
     for(i=0; i<ArrayCount(LevelValues); i++) {
         default.LevelValues[i] = LevelValues[i];
     }
-    Super.BeginPlay();
 }
 
 defaultproperties

--- a/DXRBalance/DeusEx/Classes/SkillMedicine.uc
+++ b/DXRBalance/DeusEx/Classes/SkillMedicine.uc
@@ -1,6 +1,6 @@
 class SkillMedicine injects SkillMedicine;
 
-function BeginPlay()
+function UpdateBalance()
 {
     local int i;
     if(class'MenuChoice_BalanceSkills'.static.IsEnabled()) {
@@ -18,7 +18,6 @@ function BeginPlay()
     for(i=0; i<ArrayCount(LevelValues); i++) {
         default.LevelValues[i] = LevelValues[i];
     }
-    Super.BeginPlay();
 }
 
 // LevelValues get multiplied by 30

--- a/DXRBalance/DeusEx/Classes/StealthPistolBalance.uc
+++ b/DXRBalance/DeusEx/Classes/StealthPistolBalance.uc
@@ -1,6 +1,6 @@
 class StealthPistolBalance injects WeaponStealthPistol;
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceItems'.static.IsEnabled()) {
         HitDamage = 9;
@@ -17,7 +17,6 @@ function BeginPlay()
     default.BaseAccuracy = BaseAccuracy;
     default.maxRange=maxRange;
     default.AccurateRange=AccurateRange;
-    Super.BeginPlay();
 }
 
 // slightly higher damage, lower range, better accuracy

--- a/DXRBalance/DeusEx/Classes/SwordBuff.uc
+++ b/DXRBalance/DeusEx/Classes/SwordBuff.uc
@@ -1,6 +1,6 @@
 class SwordBuff injects WeaponSword;
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceItems'.static.IsEnabled()) {
         HitDamage = 12;
@@ -11,7 +11,6 @@ function BeginPlay()
     }
     default.HitDamage = HitDamage;
     default.anim_speed = anim_speed;
-    Super.BeginPlay();
 }
 
 // vanilla is 64 range, 10 damage, 64 range (I honestly consider this to be a bug)

--- a/DXRBalance/DeusEx/Classes/ThrownProjectile.uc
+++ b/DXRBalance/DeusEx/Classes/ThrownProjectile.uc
@@ -34,6 +34,7 @@ simulated function PreBeginPlay()
 {
     // based on the player's skill: scale arming time for player attached grenades, and fuse length for thrown grenades (fuseLength is used for thrown grenades, but also the SetTimer call for arming attached grenades)
     local #var(PlayerPawn) player;
+    local float f;
 
     Super.PreBeginPlay();
     if(class'MenuChoice_BalanceSkills'.static.IsDisabled()) {
@@ -42,7 +43,11 @@ simulated function PreBeginPlay()
     player = #var(PlayerPawn)(Owner);
     if(player != None) {
         // high skill gives the player faster arming time for attached grenades, and fuse time for thrown grenades
-        fuseLength += 3.0 * player.SkillSystem.GetSkillLevelValue(class'SkillDemolition');
+        if(bProximityTriggered) f = 3;
+        else f = 1;
+        f = player.SkillSystem.GetSkillLevelValue(class'SkillDemolition'); // negative numbers
+        if(bProximityTriggered) fuseLength += f * 3.0;
+        else fuseLength += f * 1.5;
         fuseLength = FClamp(fuseLength, 0.2, 6);
     } else if(!bProximityTriggered) {
         // enemy fuses for thrown grenades, a bit quicker than vanilla

--- a/DXRBalance/DeusEx/Classes/WeaponAssaultShotgun.uc
+++ b/DXRBalance/DeusEx/Classes/WeaponAssaultShotgun.uc
@@ -1,6 +1,6 @@
 class DXRWeaponAssaultShotgun injects WeaponAssaultShotgun;
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceItems'.static.IsEnabled()) {
         HitDamage = 5;
@@ -20,7 +20,6 @@ function BeginPlay()
     default.AccurateRange = AccurateRange;
     default.maxRange = maxRange;
     default.AIMaxRange = AIMaxRange;
-    Super.BeginPlay();
 }
 
 // vanilla is 4 damage, 0.8 accuracy, 1200 AccurateRange, 2400 maxRange

--- a/DXRBalance/DeusEx/Classes/WeaponRifle.uc
+++ b/DXRBalance/DeusEx/Classes/WeaponRifle.uc
@@ -1,6 +1,6 @@
 class DXRWeaponRifle injects WeaponRifle;
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceItems'.static.IsEnabled()) {
         ShotTime = 1;
@@ -17,7 +17,6 @@ function BeginPlay()
     default.ReloadCount = ReloadCount;
     default.ReloadTime = ReloadTime;
     default.bCanHaveModReloadCount = bCanHaveModReloadCount;
-    Super.BeginPlay();
 }
 
 // vanilla is shottime=1.5, reloadcount=6, reloadtime=1 (inherited from DeusExWeapon), bCanHaveModReloadCount=True

--- a/DXRBalance/DeusEx/Classes/WeaponSawedOffShotgun.uc
+++ b/DXRBalance/DeusEx/Classes/WeaponSawedOffShotgun.uc
@@ -1,6 +1,6 @@
 class DXRWeaponSawedOffShotgun injects WeaponSawedOffShotgun;
 
-function BeginPlay()
+function UpdateBalance()
 {
     if(class'MenuChoice_BalanceItems'.static.IsEnabled()) {
         HitDamage = 6;
@@ -20,7 +20,6 @@ function BeginPlay()
     default.AccurateRange = AccurateRange;
     default.maxRange = maxRange;
     default.AIMaxRange = AIMaxRange;
-    Super.BeginPlay();
 }
 
 // vanilla is 5 damage, 0.6 accuracy, 1200 AccurateRange, 2400 maxRange

--- a/DXRCore/DeusEx/Classes/DXRBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRBase.uc
@@ -307,7 +307,7 @@ simulated function bool RandoLevelValues(Actor a, float min, float max, float we
     }
 
 #ifdef injections
-    if(aug != None && aug.default.Level5Value != -1) {
+    if(aug != None && aug.default.Level5Value != -1 && class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
         defaultval = aug.default.Level5Value;
         val += defaultval - aug.default.LevelValues[3];// increment past the level 4 strength
         t = DescriptionLevel(a, 4, word, val, defaultval);// DescriptionLevel applies bounds checks

--- a/DXRCore/DeusEx/Classes/DXRInfo.uc
+++ b/DXRCore/DeusEx/Classes/DXRInfo.uc
@@ -229,7 +229,7 @@ function bool IsChristmasSeason()
     return false;
 }
 
-function bool OnTitleScreen()
+static function bool OnTitleScreen()
 {
     local DXRando dxr;
     dxr = class'DXRando'.default.dxr;
@@ -242,7 +242,7 @@ function bool OnTitleScreen()
     return dxr.LocalURL=="DX" || dxr.LocalURL=="DXONLY";
 }
 
-function bool OnEndgameMap()
+static function bool OnEndgameMap()
 {
     local DXRando dxr;
     dxr = class'DXRando'.default.dxr;

--- a/DXRFixes/DeusEx/Classes/Skill.uc
+++ b/DXRFixes/DeusEx/Classes/Skill.uc
@@ -1,6 +1,13 @@
 class DXRSkill merges Skill;
 // merges instead of injects, because: Error, DeusEx.Skill's superclass must be Engine.Actor, not DeusEx.SkillInjBase
 
+function UpdateBalance();
+function BeginPlay()
+{
+    UpdateBalance();
+    Super.BeginPlay();
+}
+
 // IncLevel is mostly vanilla, but with a message when upgrading
 function bool IncLevel(optional DeusExPlayer usePlayer)
 {

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -795,7 +795,9 @@ function PreFirstEntryMapFixes()
 
         if(!dxr.flags.IsZeroRandoPure()) {
             p=MJ12Clone1(Spawnm(class'MJ12Clone1',,, vect(635,0,-65),rot(0,32768,0))); //Should he just be a PlaceholderEnemy now?
-            p.InitializeAlliances();
+            p.SetAlliance('MJ12');
+            ChangeInitialAlliance(p,'Player',-1,true);
+            p.InitializePawn();
         }
         class'PlaceholderEnemy'.static.Create(self,vectm(0,0,-75)); //Middle of room with 4 containers
         class'PlaceholderEnemy'.static.Create(self,vectm(0,0,565)); //Walkway over UC room

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
@@ -164,8 +164,8 @@ function SetUNATCOTargetOrders(#var(prefix)ScriptedPawn troop)
 
     if (reinforceTag=='') return;
 
-    troop.SetOrders('RunningTo',reinforceTag,True);
     troop.bKeepWeaponDrawn=True;
+    troop.SetOrders('RunningTo',reinforceTag,True);
 }
 
 
@@ -438,6 +438,21 @@ function PostFirstEntryMapFixes()
             foreach AllActors(class'#var(prefix)ScriptedPawn',sp){
                 SetUNATCOTargetOrders(sp);
             }
+
+            //A point for the MJ12 Attack Force to run to (the stairs of Osgoode & Sons)
+            //This location works for both Vanilla maps and Revision
+            reinforce = Spawn(class'DXRReinforcementPoint',,'MJ12AttackForceTarget',vectm(530,1900,-450));
+            reinforce.SetCollisionSize(200,100); //Make it bigger than the other reinforcement points
+
+            //Make the Attack Force run to the reinforcement point instead of directly attacking the player
+            foreach AllActors(class'#var(prefix)ScriptedPawn',sp){
+                if (sp.Tag!='MJ12AttackForce' && sp.Tag!='MJ12AttackForce_clone') continue;
+
+                sp.bKeepWeaponDrawn=True;
+                sp.SetOrders('RunningTo','MJ12AttackForceTarget',True);
+            }
+
+
             break;
     }
 }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
@@ -236,6 +236,22 @@ function PreFirstEntryMapFixes()
     switch(dxr.localURL)
     {
         case "08_NYC_STREET":
+
+            //Reinforcements for the sixth cop
+            if(!dxr.flags.IsZeroRandoPure()) {
+                pawn=#var(prefix)UNATCOTroop(Spawnm(class'#var(prefix)UNATCOTroop',,'troop6', vect(-85,80,-460)));
+                pawn.SetAlliance('UNATCO');
+                ChangeInitialAlliance(pawn,'Player',-1,true);
+                pawn.bInWorld=false;
+                pawn.InitializePawn();
+
+                pawn=#var(prefix)UNATCOTroop(Spawnm(class'#var(prefix)UNATCOTroop',,'troop6', vect(-150,80,-460)));
+                pawn.SetAlliance('UNATCO');
+                ChangeInitialAlliance(pawn,'Player',-1,true);
+                pawn.bInWorld=false;
+                pawn.InitializePawn();
+            }
+
             // fix alliances
             foreach AllActors(class'ScriptedPawn', pawn) {
                 switch(pawn.Alliance) {

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
@@ -325,6 +325,10 @@ function PreFirstEntryMapFixes_Final(bool isVanilla)
         }
     }
 
+    foreach AllActors(class'DeusExMover', d, 'Generator_overload') {
+        d.MoverEncroachType = ME_IgnoreWhenEncroach;
+    }
+
     //Generator Failsafe buttons should spit out some sort of message if the coolant isn't cut
     //start_buzz1 and start_buzz2 are the tags that get hit when the coolant isn't cut
     se = Spawn(class'SpecialEvent',,'start_buzz1');

--- a/DXRModules/DeusEx/Classes/DXRAugmentations.uc
+++ b/DXRModules/DeusEx/Classes/DXRAugmentations.uc
@@ -345,6 +345,10 @@ simulated function RandoAug(Augmentation a)
     local string add_desc;
     if( dxr == None ) return;
 
+#ifdef vanilla
+    a.SetAutomatic();// fixes descriptions/balance now that we have loaded flags
+#endif
+
     SetGlobalSeed("RandoAugLoc " $ a.class.name);
     if (a.AugmentationLocation!=LOC_Default && chance_single(dxr.flags.moresettings.aug_loc_rando)){
         PickRandomAugLocation(a);
@@ -362,7 +366,7 @@ simulated function RandoAug(Augmentation a)
         add_desc = "DXRando: You can see characters, goals, items, datacubes, vehicles, crates, and electronic devices through walls. ";
     }
     else if( #var(prefix)AugLight(a) != None && class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
-        if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
+        if(!class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
             // don't change it
         } else if(dxr.flags.IsHalloweenMode()) {
             add_desc = "DXRando: The light costs more energy in Halloween modes. Can be upgraded to level 2 which costs no energy and is brighter. ";

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -315,6 +315,8 @@ simulated function LoadFlags()
 
 simulated function string BindFlags(int mode, optional string str)
 {
+    local int i;
+
     if(mode != Hashing) {
         // keep the flagshash more stable for leaderboards
         if( FlagInt('Rando_seed', seed, mode, str) )
@@ -440,6 +442,23 @@ simulated function string BindFlags(int mode, optional string str)
     FlagInt('Rando_clothes_looting',clothes_looting,mode,str);
 
     FlagInt('Rando_aug_loc_rando',moresettings.aug_loc_rando,mode,str);
+
+    if(mode!=Reading && mode!=Writing) {
+        i = int(class'MenuChoice_BalanceAugs'.static.IsEnabled());
+        FlagInt('MenuChoice_BalanceAugs', i, mode, str);
+        i = int(class'MenuChoice_BalanceEtc'.static.IsEnabled());
+        FlagInt('MenuChoice_BalanceEtc', i, mode, str);
+        i = int(class'MenuChoice_BalanceItems'.static.IsEnabled());
+        FlagInt('MenuChoice_BalanceItems', i, mode, str);
+        i = int(class'MenuChoice_BalanceMaps'.static.IsEnabled());
+        FlagInt('MenuChoice_BalanceMaps', i, mode, str);
+        i = int(class'MenuChoice_BalanceSkills'.static.IsEnabled());
+        FlagInt('MenuChoice_BalanceSkills', i, mode, str);
+        i = int(class'MenuChoice_AutoAugs'.default.enabled);
+        FlagInt('MenuChoice_AutoAugs', i, mode, str);
+        i = class'MenuChoice_PasswordAutofill'.static.GetSetting();
+        FlagInt('MenuChoice_PasswordAutofill', i, mode, str);
+    }
 
     return str;
 }
@@ -626,6 +645,20 @@ simulated function string flagNameToHumanName(name flagname){
             return "Enemy weapons rando";
         case 'Rando_aug_loc_rando':
             return "Aug Slot Randomization";
+        case 'MenuChoice_BalanceAugs':
+            return "Aug Balance Changes";
+        case 'MenuChoice_BalanceEtc':
+            return "Etc Balance Changes";
+        case 'MenuChoice_BalanceItems':
+            return "Items Balance Changes";
+        case 'MenuChoice_BalanceMaps':
+            return "Maps Balance Changes";
+        case 'MenuChoice_BalanceSkills':
+            return "Skills Balance Changes";
+        case 'MenuChoice_PasswordAutofill':
+            return "Password Assistance";
+        case 'MenuChoice_AutoAugs':
+            return "Semi-Automatic Augs";
         default:
             err("flagNameToHumanName: " $ flagname $ " missing human readable name");
             return flagname $ "(ADD HUMAN READABLE NAME!)"; //Showing the raw flag name will stand out more
@@ -766,11 +799,25 @@ simulated function string flagValToHumanVal(name flagname, int val){
 
 
         case 'Rando_maxrando':
+        case 'MenuChoice_BalanceAugs':
+        case 'MenuChoice_BalanceEtc':
+        case 'MenuChoice_BalanceItems':
+        case 'MenuChoice_BalanceMaps':
+        case 'MenuChoice_BalanceSkills':
+        case 'MenuChoice_AutoAugs':
             if (val == 1) {
                 return "Enabled";
             } else {
                 return "Disabled";
             }
+
+        case 'MenuChoice_PasswordAutofill':
+            switch(val) {
+            case 0: return "No Assistance";
+            case 1: return "Mark Known Passwords";
+            case 2: return "Autofill Passwords";
+            }
+            break;
 
         case 'Rando_autosave':
             switch(val) {

--- a/DXRModules/DeusEx/Classes/DXRSkills.uc
+++ b/DXRModules/DeusEx/Classes/DXRSkills.uc
@@ -143,6 +143,10 @@ simulated function RandoSkill(Skill aSkill)
     local bool banned;
     if( dxr == None ) return;
 
+#ifdef vanilla
+    aSkill.UpdateBalance();
+#endif
+
     if( dxr.dxInfo != None && dxr.dxInfo.missionNumber > 0 ) {
         // TODO: new game screen should use the starting mission if it isn't 1, but it needs to work even when doing a new game while already in a game
         i = dxr.dxInfo.missionNumber;

--- a/DXRModules/DeusEx/Classes/DXRWeapons.uc
+++ b/DXRModules/DeusEx/Classes/DXRWeapons.uc
@@ -31,6 +31,10 @@ simulated function RandoWeapon(DeusExWeapon w, optional bool silent)
     local int oldseed, i;
     local float min_weapon_dmg, max_weapon_dmg, min_weapon_shottime, max_weapon_shottime, new_damage, default_shottime;
     if( dxr == None ) return;
+#ifdef vanilla
+    DXRWeapon(w).UpdateBalance();
+#endif
+
     oldseed = SetGlobalSeed("RandoWeapon " $ w.class.name);
 
     if( loadouts != None ) loadouts.AdjustWeapon(w);

--- a/DXRVanilla/DeusEx/Classes/Augmentation.uc
+++ b/DXRVanilla/DeusEx/Classes/Augmentation.uc
@@ -10,13 +10,14 @@ function PostBeginPlay()
     local DXRAugmentations a;
     Super.PostBeginPlay();
 
-    SetAutomatic();
-
     foreach AllActors(class'DXRAugmentations', a) {
         a.RandoAug(self);
-        break;
+        return; // RandoAug calls SetAutomatic()
     }
+    SetAutomatic();
 }
+
+simulated function UpdateBalance();
 
 simulated function SetAutomatic()
 {
@@ -27,12 +28,14 @@ simulated function SetAutomatic()
 
     if(class'MenuChoice_AutoAugs'.default.enabled) {
         bAutomatic = default.bAutomatic;
+        UpdateBalance(); // make sure energyRate is correct
         if(bAutomatic) {
             energyRate = default.energyRate * AutoEnergyMult;
         }
     }
     else {
         bAutomatic = false;
+        UpdateBalance();
     }
 }
 

--- a/DXRVanilla/DeusEx/Classes/HUDObjectBelt.uc
+++ b/DXRVanilla/DeusEx/Classes/HUDObjectBelt.uc
@@ -10,6 +10,41 @@ function UpdateObjectText(int pos)
     }
 }
 
+// DXRando: replace a used item with another of the same type
+function RemoveObjectFromBelt(Inventory item)
+{
+    local int i;
+    local int StartPos;
+    local Inventory n;
+
+    StartPos = 1;
+    if ( (Player != None) && (Player.Level.NetMode != NM_Standalone) && (Player.bBeltIsMPInventory) )
+        StartPos = 0;
+
+        for (i=StartPos; IsValidPos(i); i++)
+        {
+            if (objects[i].GetItem() == item)
+            {
+                objects[i].SetItem(None);
+                item.bInObjectBelt = False;
+                item.beltPos = -1;
+                if(!item.bDisplayableInv) {
+                    for(n=Player.Inventory; n!=None; n=n.Inventory) {
+                        if(n==item) continue;
+                        if(n.class!=item.class) continue;
+                        if(n.Icon==None) continue;
+                        if(n.beltPos!=-1) continue;
+                        if(!n.bDisplayableInv) continue;
+                        if(n.bDeleteMe) continue;
+                        AddObjectToBelt(n, i, false);
+                        return;
+                    }
+                }
+                return;
+            }
+        }
+}
+
 event DrawWindow(GC gc)
 {
     Super.DrawWindow(gc);

--- a/DXRVanilla/DeusEx/Classes/Weapon.uc
+++ b/DXRVanilla/DeusEx/Classes/Weapon.uc
@@ -17,9 +17,13 @@ function PostBeginPlay()
 
     m = DXRWeapons(class'DXRWeapons'.static.Find(true));
     if(m != None) {
-        m.RandoWeapon(self);
+        m.RandoWeapon(self);// RandoWeapon calls UpdateBalance()
+    } else {
+        UpdateBalance();
     }
 }
+
+simulated function UpdateBalance();
 
 function ScopeOn()
 {

--- a/DXRando/DeusEx/Classes/DXRReinforcementPoint.uc
+++ b/DXRando/DeusEx/Classes/DXRReinforcementPoint.uc
@@ -61,5 +61,6 @@ function Init(Actor o)
 
 defaultproperties
 {
-    bCollideActors=true;
+    bCollideActors=true
+    CollisionRadius=100
 }

--- a/DXRando/DeusEx/Classes/DXRReinforcementPoint.uc
+++ b/DXRando/DeusEx/Classes/DXRReinforcementPoint.uc
@@ -1,0 +1,65 @@
+//An object for the UNATCO troops in M08 to run towards, instead of just
+//directly ordering them to attack the player (which breaks stealth)
+class DXRReinforcementPoint extends Info;
+
+event BaseChange()
+{
+    if (Base==None && Owner!=None){
+        SetLocation(Owner.Location);
+        SetBase(Owner);
+    }
+}
+
+//In reality, this isn't *really* needed, because in mission 8,
+//there will only be one of each guy.  If we allowed these to be
+//placed on clones, there could be multiple, but we don't.
+event Timer()
+{
+    local DXRReinforcementPoint rp;
+    local bool found;
+
+    if (Owner==None){
+        //The owner died?
+
+        //See if there are other reinforcement points left
+        foreach AllActors(class'DXRReinforcementPoint',rp,Tag){
+            if (rp!=Self){
+                found=True;
+                break;
+            }
+        }
+
+        if (found){
+            //if there are other reinforcement points, this one can be destroyed
+            Destroy();
+        }
+        SetTimer(0,false);
+    }
+}
+
+//Once pawns reach us, just wander (so that RunningTo doesn't just leave them standing there)
+function Touch( actor Other )
+{
+    local #var(prefix)ScriptedPawn sp;
+
+    sp = #var(prefix)ScriptedPawn(other);
+
+    if (sp==None) return;
+    if (sp.OrderTag!=Tag) return;
+
+    sp.SetOrders('Wandering',,True);
+}
+
+function Init(Actor o)
+{
+    SetOwner(o);
+    SetBase(o);
+
+    //Don't need to track to see if we're the last reinforcement point left
+    //SetTimer(1,true);
+}
+
+defaultproperties
+{
+    bCollideActors=true;
+}

--- a/DXRando/DeusEx/Classes/DXRReinforcementPoint.uc
+++ b/DXRando/DeusEx/Classes/DXRReinforcementPoint.uc
@@ -47,7 +47,16 @@ function Touch( actor Other )
     if (sp==None) return;
     if (sp.OrderTag!=Tag) return;
 
+    //Set the reinforcement point as the new home point, so they don't wander away
+    sp.bUseHome = false;
+    sp.InitializeHomeBase();
+
+    sp.ClearNextState();
     sp.SetOrders('Wandering',,True);
+
+    //This is an interesting idea I had to prevent clumping, but I think Touch
+    //doesn't really work if the collision radius is extended through someone?
+    //SetCollisionSize(CollisionRadius+sp.CollisionRadius,CollisionHeight);
 }
 
 function Init(Actor o)

--- a/GUI/DeusEx/Classes/MenuChoice_BalanceEtc.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_BalanceEtc.uc
@@ -11,6 +11,17 @@ static function bool IsDisabled()
     return !IsEnabled();
 }
 
+event InitWindow()
+{
+    Super.InitWindow();
+
+    if(!class'DXRInfo'.static.OnTitleScreen()) {
+        SetSensitivity(false);
+        btnInfo.SetSensitivity(false);
+        btnAction.SetSensitivity(false);
+    }
+}
+
 defaultproperties
 {
     value=1

--- a/GUI/DeusEx/Classes/MenuChoice_BalanceEtc.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_BalanceEtc.uc
@@ -1,5 +1,6 @@
 class MenuChoice_BalanceEtc extends DXRMenuUIChoiceInt;
 
+// works fine in BeginPlay because that only happens when traveling, but flags aren't loaded quickly enough for PostPostBeginPlay when loading a save and the game mode of the title screen was different from the save game
 static function bool IsEnabled()
 {
     return (default.value==2) || (default.value==1 && !class'DXRFlags'.default.bZeroRandoPure);

--- a/GUI/DeusEx/Classes/MenuChoice_PasswordAutofill.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_PasswordAutofill.uc
@@ -13,11 +13,8 @@ function SaveSetting()
 
 static function int GetSetting()
 {
-    local DXRando dxr;
     if(default.value == 3) {
-        dxr = class'DXRando'.default.dxr;
-        if(dxr==None) return 2;
-        if(dxr.flags.IsZeroRandoPure()) return 0;
+        if(class'DXRFlags'.default.bZeroRandoPure) return 0;
         return 2;
     }
     return default.value;

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
@@ -33,11 +33,11 @@ function CreateChoices()
     CreateChoice(class'MenuChoice_ShowNewSeed');
 
 #ifdef vanilla
-    //CreateChoice(class'MenuChoice_BalanceAugs');
-    //CreateChoice(class'MenuChoice_BalanceSkills');
-    //CreateChoice(class'MenuChoice_BalanceItems');
-    //CreateChoice(class'MenuChoice_BalanceMaps');
-    //CreateChoice(class'MenuChoice_BalanceEtc');
+    CreateChoice(class'MenuChoice_BalanceAugs');
+    CreateChoice(class'MenuChoice_BalanceSkills');
+    CreateChoice(class'MenuChoice_BalanceItems');
+    //CreateChoice(class'MenuChoice_BalanceMaps');// TODO: change everything in DXRMapFixups to use this, most can be done with find/replace
+    CreateChoice(class'MenuChoice_BalanceEtc');
 #endif
 }
 


### PR DESCRIPTION
# v3.3.2.4 Alpha

- Mission 8 UNATCO Troops run to the location of the killed cop, instead of directly targeting the player
- M08 MJ12 Attack Force runs to Osgoode & Sons instead of Attacking the player directly #1104
- Add UNATCO reinforcements for the sixth cop in M08, and fix the guy in HK level 2 labs
- tweak grenade fuse length scaling with demo skill
- fix balance changes when loading saves that have a different gamemode from the title screen or the previous loaded game
- aqualung now prevents bubbles, because science
- using an item from the belt will replace it with another item of the same type instead of emptying the belt slot
- area51_final Generator_overload glass cover ME_IgnoreWhenEncroach
- balance toggles now visible in the menu, disabled during gameplay

# Previously in v3.3.2.3 Alpha: https://github.com/Die4Ever/deus-ex-randomizer/pull/1101

# Previously in v3.3.2.2 Alpha: https://github.com/Die4Ever/deus-ex-randomizer/pull/1096

# Previously in v3.3.2.1 Alpha: https://github.com/Die4Ever/deus-ex-randomizer/pull/1091 (only minor changes)