### PR TITLE
v3.3.2.5 Alpha

### DIFF
--- a/DXRBalance/DeusEx/Classes/AugPower.uc
+++ b/DXRBalance/DeusEx/Classes/AugPower.uc
@@ -6,7 +6,7 @@ simulated function UpdateBalance()
 
     // HACK: a little wonky if you change the setting mid-game, but otherwise works
     energyRate = default.energyRate;
-    if(class'MenuChoice_AutoAugs'.default.enabled) {
+    if(class'MenuChoice_AutoAugs'.static.IsEnabled()) {
         bAlwaysActive = default.bAlwaysActive;
         if(bAlwaysActive) {
             energyRate = 0;

--- a/DXRBalance/DeusEx/Classes/ChargedPickup.uc
+++ b/DXRBalance/DeusEx/Classes/ChargedPickup.uc
@@ -31,7 +31,7 @@ simulated function Float GetCurrentCharge()
 function ChargedPickupBegin(DeusExPlayer Player)
 {
     local Human p;
-    if(bOneUseOnly) {
+    if(bOneUseOnly && class'MenuChoice_BalanceItems'.static.IsEnabled()) {
         p = Human(Owner);
         if( p != None ) {
             if(p.InHand == self) {

--- a/DXRCore/DeusEx/Classes/DXRBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRBase.uc
@@ -325,7 +325,12 @@ simulated function bool RandoLevelValues(Actor a, float min, float max, float we
     }
 #endif
 
-    if(wet == 0) {
+    if((aug!=None && class'MenuChoice_BalanceAugs'.static.IsDisabled())
+        || (sk!=None && class'MenuChoice_BalanceSkills'.static.IsDisabled())) {
+        // TODO: descriptions for balance disabled
+        s = "";
+    }
+    else if(wet == 0) {
         s = "(Strength) " $ word $ ":|n    " $ s;
     } else {
         s = "(DXRando) " $ word $ ":|n    " $ s;
@@ -345,7 +350,7 @@ simulated function bool RandoLevelValues(Actor a, float min, float max, float we
     if(add_desc != "") {
         s = s $ "|n|n" $ add_desc;
     }
-    if( InStr(Desc, s) == -1 ) {
+    if( InStr(Desc, s) == -1 && s != "" ) {
         Desc = s $ "|n|n" $ Desc;
         return true;
     }

--- a/DXRCore/DeusEx/Classes/DXRMenuBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuBase.uc
@@ -676,13 +676,15 @@ function string GetEnumValue(int e)
 
 function string SetEnumValue(int e, string text)
 {
-    local int i;
+    local int i, old;
+    old = enums[e].value;
     for(i=0; i<ArrayCount(enums[e].values); i++) {
         if(enums[e].values[i] == text) {
             enums[e].value = i;
             enums[e].btn.SetButtonText(text);
         }
     }
+    return enums[e].values[old];
 }
 
 event StyleChanged()

--- a/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -244,25 +244,25 @@ function HandleNewGameButton()
 
     if(!class'HUDSpeedrunSplits'.static.CheckFlags(f)) {
         nextScreenNum=RMB_NewGame;
-        root.MessageBox(SplitsBtnTitle,SplitsBtnMessage,0,False,Self);
+        class'BingoHintMsgBox'.static.Create(root, SplitsBtnTitle,SplitsBtnMessage,0,False,Self);
     }
     else if(dxr.rando_beaten == 0 && f.DifficultyName(f.difficulty) ~= "Extreme") {
         nextScreenNum=RMB_NewGame;
-        root.MessageBox(ExtremeBtnTitle,ExtremeBtnMessage,0,False,Self);
+        class'BingoHintMsgBox'.static.Create(root, ExtremeBtnTitle,ExtremeBtnMessage,0,False,Self);
     }
     else if(dxr.rando_beaten == 0 && f.DifficultyName(f.difficulty) ~= "Impossible") {
         nextScreenNum=RMB_NewGame;
-        root.MessageBox(ImpossibleBtnTitle,ImpossibleBtnMessage,0,False,Self);
-    }
-    else if(dxr.rando_beaten == 0 && f.GameModeName(f.gamemode) != "Normal Randomizer" && !f.IsReducedRando()) {
-        nextScreenNum=RMB_NewGame;
-        s = Sprintf(GameModeBtnMessage, f.GameModeName(f.gamemode));
-        class'BingoHintMsgBox'.static.Create(root, GameModeBtnTitle, s, 0, False, self);
+        class'BingoHintMsgBox'.static.Create(root, ImpossibleBtnTitle,ImpossibleBtnMessage,0,False,Self);
     }
     else if(dxr.rando_beaten == 0 && autosave_enum>0 && GetEnumValue(autosave_enum)!="Autosave Every Entry" && GetEnumValue(autosave_enum)!="Extra Safe (1+GB per playthrough)") {
         nextScreenNum=RMB_NewGame;
         s = Sprintf(AutosaveBtnMessage, GetEnumValue(autosave_enum));
         class'BingoHintMsgBox'.static.Create(root, AutosaveBtnTitle, s, 0, False, self);
+    }
+    else if(dxr.rando_beaten == 0 && f.GameModeName(f.gamemode) != "Normal Randomizer" && !f.IsReducedRando()) {
+        nextScreenNum=RMB_NewGame;
+        s = Sprintf(GameModeBtnMessage, f.GameModeName(f.gamemode));
+        class'BingoHintMsgBox'.static.Create(root, GameModeBtnTitle, s, 0, False, self);
     }
     else {
         DoNewGameScreen();
@@ -284,11 +284,11 @@ function DoNewGameScreen()
 
 function HandleMaxRandoButton()
 {
-    if (dxr.rando_beaten != 0){
+    if (false && dxr.rando_beaten != 0){
         DoMaxRandoButtonConfirm();
     } else {
         nextScreenNum=RMB_MaxRando;
-        root.MessageBox(MaxRandoBtnTitle,MaxRandoBtnMessage,0,False,Self);
+        class'BingoHintMsgBox'.static.Create(root, MaxRandoBtnTitle,MaxRandoBtnMessage,0,False,Self);
     }
 }
 
@@ -376,17 +376,17 @@ defaultproperties
     padding_width=20
     padding_height=10
     MaxRandoBtnTitle="Are you sure?"
-    MaxRandoBtnMessage="It appears you're new to DX Randomizer.  Max Rando will randomize all the settings, which will likely result in a bad first time experience.  Are you sure you want to proceed?"
+    MaxRandoBtnMessage="It appears you're new to DX Randomizer.|n|nMax Rando will randomize all the settings, including ammo and equipment scarcity, which will likely result in a bad first time experience.|nBy continuing, you waive your right to ragequit.|n|nAre you sure you want to proceed?"
     AdvancedBtnTitle="Advanced Settings?"
-    AdvancedBtnMessage="It appears you're new to DX Randomizer.  We recommend playing with default settings for a better first time experience.  Are you sure you want to adjust advanced settings?"
+    AdvancedBtnMessage="It appears you're new to DX Randomizer.|n|nWe recommend playing with default settings for a better first time experience.|nBy continuing, you waive your right to ragequit.|n|nAre you sure you want to adjust advanced settings?"
     ExtremeBtnTitle="Extreme Difficulty?"
-    ExtremeBtnMessage="It appears you're new to DX Randomizer.  Extreme difficulty means fewer items, less ammo, more enemies, higher skill costs, fewer medbots, and many other challenges.  Are you sure?"
+    ExtremeBtnMessage="It appears you're new to DX Randomizer.|n|nExtreme difficulty means fewer items, less ammo, more enemies, higher skill costs, fewer medbots, and many other challenges.|nBy continuing, you waive your right to ragequit.|n|nAre you sure you want to play Extreme difficulty?"
     ImpossibleBtnTitle="Impossible Difficulty?"
-    ImpossibleBtnMessage="It appears you're new to DX Randomizer.  Impossible difficulty means fewer items, less ammo, more enemies, higher skill costs, fewer medbots, and many other challenges.  Are you sure?"
+    ImpossibleBtnMessage="It appears you're new to DX Randomizer.|n|nImpossible difficulty means fewer items, less ammo, more enemies, higher skill costs, fewer medbots, and many other challenges.|nBy continuing, you waive your right to ragequit.|n|nAre you sure you want to play Impossible difficulty?"
     GameModeBtnTitle="Advanced Game Mode?"
-    GameModeBtnMessage="It appears you're new to DX Randomizer.  This game mode is confusing and difficult for new DXRando players. We suggest starting with Normal Randomizer or one of the Reduced Randomization modes instead.|n|nAre you sure you want to continue with %s?"
+    GameModeBtnMessage="It appears you're new to DX Randomizer.|n|nThis game mode is confusing and difficult for new DXRando players. We suggest starting with Normal Randomizer or one of the Reduced Randomization modes instead.|nBy continuing, you waive your right to ragequit.|n|nAre you sure you want to continue with %s?"
     AutosaveBtnTitle="Autosave?"
-    AutosaveBtnMessage="It appears you're new to DX Randomizer.|n|nWe suggest starting with the default option for Autosave Every Entry.|n|nAre you sure you want to continue with %s?"
+    AutosaveBtnMessage="It appears you're new to DX Randomizer.|n|nWe suggest starting with the default option for Autosave Every Entry.|nBy continuing, you waive your right to ragequit.|n|nAre you sure you want to continue with %s?"
     SplitsBtnTitle="Mismatched Splits!"
-    SplitsBtnMessage="It appears that your DXRSplits.ini file is for different settings than this.  Are you sure you want to continue?"
+    SplitsBtnMessage="It appears that your DXRSplits.ini file is for different settings than this.|n|nAre you sure you want to continue?"
 }

--- a/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -6,7 +6,7 @@ var string ExtremeBtnTitle, ExtremeBtnMessage;
 var string ImpossibleBtnTitle, ImpossibleBtnMessage;
 var string SplitsBtnTitle, SplitsBtnMessage;
 
-var int gamemode_enum, autosave_enum, difficulty_enum;
+var int gamemode_enum, autosave_enum, difficulty_enum, mirroredmaps_wnd;
 
 enum ERandoMessageBoxModes
 {
@@ -128,7 +128,7 @@ function BindControls(optional string action)
     mirrored_maps_files_found = class'DXRMapVariants'.static.MirrorMapsAvailable();
 
     if(mirrored_maps_files_found) {
-        NewMenuItem("Mirrored Maps %", "Enable mirrored maps if you have the files downloaded for them.");
+        mirroredmaps_wnd = NewMenuItem("Mirrored Maps %", "Enable mirrored maps if you have the files downloaded for them.");
         if(f.mirroredmaps == -1 && f.IsZeroRando()) {
             f.mirroredmaps = 0; // default to 0% because of Zero Rando
         } else if(f.mirroredmaps == -1) {
@@ -179,6 +179,8 @@ function string SetEnumValue(int e, string text)
 
     // HACK: this allows you to override the autosave option instead of SetDifficulty forcing it by game mode
     old = Super.SetEnumValue(e, text);
+    if(text == old) return old;
+
     if(e == gamemode_enum && #defined(injections)) {
         if(InStr(text, "Halloween")!=-1)
         {
@@ -207,8 +209,14 @@ function string SetEnumValue(int e, string text)
                 enums[difficulty_enum].values[i] = f.DifficultyName(i);
             }
             Super.SetEnumValue(difficulty_enum, f.DifficultyName(1));
+
+            if(InStr(text, "Zero Rando")!=-1 && mirroredmaps_wnd>0) {
+                MenuUIEditWindow(wnds[mirroredmaps_wnd]).SetText("0");
+            }
         }
     }
+
+    return old;
 }
 
 function EnumListAddButton(DXREnumList list, string title, string val, string prev)

--- a/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -4,6 +4,8 @@ var string MaxRandoBtnTitle, MaxRandoBtnMessage;
 var string AdvancedBtnTitle, AdvancedBtnMessage;
 var string ExtremeBtnTitle, ExtremeBtnMessage;
 var string ImpossibleBtnTitle, ImpossibleBtnMessage;
+var string GameModeBtnTitle, GameModeBtnMessage;
+var string AutosaveBtnTitle, AutosaveBtnMessage;
 var string SplitsBtnTitle, SplitsBtnMessage;
 
 var int gamemode_enum, autosave_enum, difficulty_enum, mirroredmaps_wnd;
@@ -236,6 +238,7 @@ function EnumListAddButton(DXREnumList list, string title, string val, string pr
 
 function HandleNewGameButton()
 {
+    local string s;
     local DXRFlags f;
     f = GetFlags();
 
@@ -250,6 +253,16 @@ function HandleNewGameButton()
     else if(dxr.rando_beaten == 0 && f.DifficultyName(f.difficulty) ~= "Impossible") {
         nextScreenNum=RMB_NewGame;
         root.MessageBox(ImpossibleBtnTitle,ImpossibleBtnMessage,0,False,Self);
+    }
+    else if(dxr.rando_beaten == 0 && f.GameModeName(f.gamemode) != "Normal Randomizer" && !f.IsReducedRando()) {
+        nextScreenNum=RMB_NewGame;
+        s = Sprintf(GameModeBtnMessage, f.GameModeName(f.gamemode));
+        class'BingoHintMsgBox'.static.Create(root, GameModeBtnTitle, s, 0, False, self);
+    }
+    else if(dxr.rando_beaten == 0 && autosave_enum>0 && GetEnumValue(autosave_enum)!="Autosave Every Entry" && GetEnumValue(autosave_enum)!="Extra Safe (1+GB per playthrough)") {
+        nextScreenNum=RMB_NewGame;
+        s = Sprintf(AutosaveBtnMessage, GetEnumValue(autosave_enum));
+        class'BingoHintMsgBox'.static.Create(root, AutosaveBtnTitle, s, 0, False, self);
     }
     else {
         DoNewGameScreen();
@@ -370,6 +383,10 @@ defaultproperties
     ExtremeBtnMessage="It appears you're new to DX Randomizer.  Extreme difficulty means fewer items, less ammo, more enemies, higher skill costs, fewer medbots, and many other challenges.  Are you sure?"
     ImpossibleBtnTitle="Impossible Difficulty?"
     ImpossibleBtnMessage="It appears you're new to DX Randomizer.  Impossible difficulty means fewer items, less ammo, more enemies, higher skill costs, fewer medbots, and many other challenges.  Are you sure?"
+    GameModeBtnTitle="Advanced Game Mode?"
+    GameModeBtnMessage="It appears you're new to DX Randomizer.  This game mode is confusing and difficult for new DXRando players. We suggest starting with Normal Randomizer or one of the Reduced Randomization modes instead.|n|nAre you sure you want to continue with %s?"
+    AutosaveBtnTitle="Autosave?"
+    AutosaveBtnMessage="It appears you're new to DX Randomizer.|n|nWe suggest starting with the default option for Autosave Every Entry.|n|nAre you sure you want to continue with %s?"
     SplitsBtnTitle="Mismatched Splits!"
     SplitsBtnMessage="It appears that your DXRSplits.ini file is for different settings than this.  Are you sure you want to continue?"
 }

--- a/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
@@ -425,7 +425,7 @@ function HandleNewGameButton()
 
     if(!class'HUDSpeedrunSplits'.static.CheckFlags(f)) {
         nextScreenNum=RMB_NewGame;
-        root.MessageBox(SplitsBtnTitle,SplitsBtnMessage,0,False,Self);
+        class'BingoHintMsgBox'.static.Create(root, SplitsBtnTitle,SplitsBtnMessage,0,False,Self);
     }
     else {
         DoNewGameScreen();
@@ -468,5 +468,5 @@ defaultproperties
     actionButtons(1)=(Align=HALIGN_Right,Action=AB_Other,Text="|&Next",Key="NEXT")
     actionButtons(2)=(Align=HALIGN_Right,Action=AB_Other,Text="|&Randomize",Key="RANDOMIZE")
     SplitsBtnTitle="Mismatched Splits!"
-    SplitsBtnMessage="It appears that your DXRSplits.ini file is for different settings than this.  Are you sure you want to continue?"
+    SplitsBtnMessage="It appears that your DXRSplits.ini file is for different settings than this.|n|nAre you sure you want to continue?"
 }

--- a/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -5,7 +5,7 @@ simulated static function CurrentVersion(optional out int major, optional out in
     major=3;
     minor=3;
     patch=2;
-    build=4;//build can't be higher than 99
+    build=5;//build can't be higher than 99
 }
 
 simulated static function bool VersionIsStable()

--- a/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
+++ b/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
@@ -297,12 +297,14 @@ function _TakeDamageBase(int Damage, Pawn instigatedBy, Vector hitlocation, Vect
         // and hits absorbed by shields do less knockback
         mult = FMin(Damage, actualDamage);
         mult += loge(mult);
-        mult *= 0.3;
+        mult *= 0.2;
         if(mult > 0) {
             momentum *= mult;
-            SetPhysics(PHYS_Falling);
-            // need to lift off the ground cause once they land and start walking that overrides their velocity
-            momentum.Z = FMax(momentum.Z, 0.4 * VSize(momentum));
+            if(!Region.Zone.bWaterZone) {
+                SetPhysics(PHYS_Falling);
+                // need to lift off the ground cause once they land and start walking that overrides their velocity
+                momentum.Z = FMax(momentum.Z, 0.4 * VSize(momentum));
+            }
             Velocity += momentum / Mass;
         }
     }

--- a/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
+++ b/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
@@ -35,14 +35,15 @@ function ThrowInventory(bool gibbed)
     local Inventory item, nextItem;
     local bool drop, melee;
 
-    if(gibbed && class'MenuChoice_BalanceEtc'.static.IsDisabled()) return; // don't give items when gibbed
-
     item = Inventory;
     while( item != None ) {
         nextItem = item.Inventory;
-        if(class'MenuChoice_ThrowMelee'.default.enabled)
+        if(class'MenuChoice_ThrowMelee'.default.enabled) {
             melee = class'DXRActorsBase'.static.IsMeleeWeapon(item);
-        drop = (item.IsA('NanoKey') && gibbed) || (melee && !gibbed) || (gibbed && item.bDisplayableInv);
+            drop = melee && !gibbed; // drop melee weapon even if not gibbed
+        }
+        drop = drop || item.IsA('NanoKey') && gibbed; // drop nanokeys when gibbed
+        drop = drop || gibbed && item.bDisplayableInv && class'MenuChoice_BalanceEtc'.static.IsEnabled(); // drop all other visible items when gibbed
         if( DeusExWeapon(item) != None && DeusExWeapon(item).bNativeAttack )
             drop = false;
         if( Ammo(item) != None )

--- a/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
+++ b/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
@@ -35,6 +35,8 @@ function ThrowInventory(bool gibbed)
     local Inventory item, nextItem;
     local bool drop, melee;
 
+    if(gibbed && class'MenuChoice_BalanceEtc'.static.IsDisabled()) return; // don't give items when gibbed
+
     item = Inventory;
     while( item != None ) {
         nextItem = item.Inventory;
@@ -284,10 +286,11 @@ function _TakeDamageBase(int Damage, Pawn instigatedBy, Vector hitlocation, Vect
             DrawShield();
     }
 
-    if(!bInvincible && damageType != 'Stunned' && damageType != 'TearGas' && damageType != 'HalonGas' &&
-            damageType != 'PoisonGas' && damageType != 'Radiation' && damageType != 'EMP' &&
-            damageType != 'NanoVirus' && damageType != 'Drowned' &&
-            damageType != 'Poison' && damageType != 'PoisonEffect')
+    if(!bInvincible && class'MenuChoice_BalanceEtc'.static.IsEnabled()
+        && damageType != 'Stunned' && damageType != 'TearGas' && damageType != 'HalonGas'
+        && damageType != 'PoisonGas' && damageType != 'Radiation' && damageType != 'EMP'
+        && damageType != 'NanoVirus' && damageType != 'Drowned'
+        && damageType != 'Poison' && damageType != 'PoisonEffect')
     {
         // Impart momentum, DXRando multiply momentum by damage
         // pick the smaller between Damage and actualDamage so that stealth hits don't do insane knockback

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
@@ -43,6 +43,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)GuntherHermann gunther;
     local #var(prefix)HumanCivilian hc;
     local #var(prefix)OrdersTrigger ot;
+    local #var(prefix)AllianceTrigger at;
     local #var(prefix)FlagTrigger ft;
     local #var(prefix)ComputerPublic compublic;
     local bool VanillaMaps;
@@ -99,6 +100,26 @@ function PreFirstEntryMapFixes()
                 ft.flagValue=False;
             }
         }
+
+        if (class'MenuChoice_BalanceMaps'.static.ModerateEnabled()){
+            //Leo will no longer directly be ordered to attack the player, he will just go hostile and face them
+            //This prevents him from breaking stealth
+            foreach AllActors(class'#var(prefix)OrdersTrigger',ot,'TerroristCommanderAttacks'){
+                class'FacePlayerTrigger'.static.Create(self,'TerroristCommanderAttacks','TerroristCommander',ot.Location);
+
+                at = Spawn(class'#var(injectsprefix)AllianceTrigger',,'TerroristCommanderAttacks',ot.Location);
+                at.SetCollision(False,False,False);
+                at.Event='TerroristCommander';
+                at.Alliance='Leader';
+                at.Alliances[0].allianceName='Player';
+                at.Alliances[0].allianceLevel=-1.0;
+                at.Alliances[0].bPermanent=true;
+
+                ot.Destroy();
+                break;
+            }
+        }
+
 
         Spawn(class'PlaceholderItem',,, vectm(2378.5,-10810.9,-857)); //Sunken Ship
         Spawn(class'PlaceholderItem',,, vectm(2436,-10709.4,-857)); //Sunken Ship

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
@@ -16,7 +16,7 @@ function PostFirstEntryMapFixes()
             m.bIsDoor = false;// this prevents Lloyd from opening the door
         }
 
-        if(!dxr.flags.IsZeroRando()) {
+        if(class'MenuChoice_BalanceMaps'.static.MajorEnabled()) {
             foreach AllActors(class'BlockPlayer', bp) {
                 if(bp.Group == 'waterblock') {
                     bp.bBlockPlayers = false;

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
@@ -17,6 +17,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)Trigger trig;
     local #var(prefix)MapExit exit;
     local #var(prefix)BlackHelicopter jock;
+    local #var(prefix)OrdersTrigger ot;
     local DXRHoverHint hoverHint;
     local DXRButtonHoverHint buttonHint;
     local #var(prefix)Button1 button;
@@ -234,6 +235,18 @@ function PreFirstEntryMapFixes()
 
         break;
     case "02_NYC_HOTEL":
+        if (class'MenuChoice_BalanceMaps'.static.ModerateEnabled()){
+            //The terrorist guarding Gilbert will no longer be ordered to attack the player
+            //There is already an AllianceTrigger ready to swap his alliances, and he is always
+            //facing the right way anyway.  Just delete the OrdersTrigger
+            foreach AllActors(class'#var(prefix)OrdersTrigger',ot){
+                if (ot.Event!='GilbertTerrorist' && ot.Orders!='Attacking') continue;
+                ot.Destroy();
+                break;
+            }
+        }
+
+
         if (VanillaMaps){
             Spawn(class'#var(prefix)Binoculars',,, vectm(-610.374573,-3221.998779,94.160065)); //Paul's bedside table
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
@@ -61,7 +61,7 @@ function PreFirstEntryMapFixes()
             }
         }
 
-        if(!dxr.flags.IsZeroRando()) {
+        if(class'MenuChoice_BalanceMaps'.static.MajorEnabled()) {
             k = Spawn(class'#var(prefix)NanoKey',,, vectm(1574.209839, -238.380142, 342));
             k.KeyID = 'ControlRoomDoor';
             k.Description = "Control Room Door Key";
@@ -223,7 +223,7 @@ function PreFirstEntryMapFixes()
         class'PlaceholderEnemy'.static.Create(self,vectm(1676,-1535,64),,'Shitting');
         class'PlaceholderEnemy'.static.Create(self,vectm(1334,-1404,64),,'Shitting');
 
-        if(!dxr.flags.IsZeroRando()) {
+        if(class'MenuChoice_BalanceMaps'.static.MajorEnabled()) {
             // this map is too hard
             Spawn(class'#var(prefix)AdaptiveArmor',,, vectm(-1890,1840,1775)); //Rooftop apartment hall
             Spawn(class'#var(prefix)AdaptiveArmor',,, vectm(700,850,1175)); //Apartment top floor

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -112,7 +112,7 @@ function PreFirstEntryMapFixes()
         fg=Spawn(class'#var(prefix)FishGenerator',,, vectm(-1274,-3892,177));//Near Boat dock
         fg.ActiveArea=2000;
 
-        if(!dxr.flags.IsZeroRando()) {
+        if(dxr.flags.IsEntranceRando()) {
             //rebreather because of #TOOCEAN connection
             AddActor(class'Rebreather', vect(-936.151245, -3464.031006, 293.710968));
         }
@@ -156,7 +156,7 @@ function PreFirstEntryMapFixes()
                 m.Tag = 'Sewerdoor';
             }
         }
-        if(!dxr.flags.IsZeroRando()) {
+        if(class'MenuChoice_BalanceMaps'.static.MajorEnabled()) {
             foreach AllActors(class'Trigger', t) {
                 //disable the platforms that fall when you step on them
                 if( t.Event == 'firstplatform' || t.Event == 'platform2' ) {
@@ -185,7 +185,7 @@ function PreFirstEntryMapFixes()
         a = AddActor(class'DynamicBlockPlayer', vect(-3065,-405,-130));
         SetActorScale(a, 1.3);
 
-        if(!dxr.flags.IsZeroRando()) {
+        if(dxr.flags.IsEntranceRando()) {
             //rebreather because of #TOOCEAN connection
             //Bookshelf near pool tables
             Spawn(class'Rebreather',,, vectm(1411.798950, 546.628845, 247.708572));
@@ -208,7 +208,7 @@ function PreFirstEntryMapFixes()
         break;
 
     case "03_NYC_AIRFIELD":
-        if(!dxr.flags.IsZeroRando()) {
+        if(dxr.flags.IsEntranceRando()) {
             //rebreather because of #TOOCEAN connection
             Spawn(class'Rebreather',,, vectm(-2031.959473, 995.781067, 75.709816));
         }
@@ -399,7 +399,7 @@ function PreFirstEntryMapFixes()
         break;
 
     case "03_NYC_UNATCOISLAND":
-        if(!dxr.flags.IsReducedRando()) {
+        if(class'MenuChoice_ToggleMemes'.static.IsEnabled(dxr.flags)) {
             foreach AllActors(class'#var(prefix)UNATCOTroop', unatco) {
                 if(unatco.BindName != "PrivateLloyd") continue;
                 unatco.FamiliarName = "Corporal Lloyd";
@@ -420,7 +420,7 @@ function PreFirstEntryMapFixes()
         FixAlexsEmail();
         MakeTurretsNonHostile(); //Revision has hostile turrets near jail
 
-        if(!dxr.flags.IsZeroRando()) {
+        if(class'MenuChoice_BalanceMaps'.static.MajorEnabled()) {
             k = Spawn(class'#var(prefix)NanoKey',,, vectm(965,900,-28));
             k.KeyID = 'JaimeClosetKey';
             k.Description = "MedLab Closet Key Code";
@@ -577,7 +577,7 @@ function FixAnnaAmbush()
     local #var(prefix)AnnaNavarre anna;
     local #var(prefix)ThrownProjectile p;
 
-    if(dxr.flags.IsZeroRando()) return;
+    if(!class'MenuChoice_BalanceMaps'.static.MajorEnabled()) return;
 
     foreach AllActors(class'#var(prefix)AnnaNavarre', anna) {break;}
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -83,6 +83,7 @@ function PreFirstEntryMapFixes()
     local DXRHoverHint hoverHint;
     local #var(prefix)HumanCivilian hc;
     local #var(prefix)OrdersTrigger ot;
+    local #var(prefix)AllianceTrigger at;
     local AlarmUnit au;
     local vector loc;
     local #var(prefix)ComputerPublic compublic;
@@ -290,6 +291,26 @@ function PreFirstEntryMapFixes()
         break;
 
     case "03_NYC_BROOKLYNBRIDGESTATION":
+
+        if (class'MenuChoice_BalanceMaps'.static.ModerateEnabled()){
+            //El Rey will no longer directly be ordered to attack the player, he will just go hostile and face them
+            //This prevents him from breaking stealth
+            foreach AllActors(class'#var(prefix)OrdersTrigger',ot,'elreyattacks'){
+                class'FacePlayerTrigger'.static.Create(self,'elreyattacks','Elrey',ot.Location);
+
+                at = Spawn(class'#var(injectsprefix)AllianceTrigger',,'elreyattacks',ot.Location);
+                at.SetCollision(False,False,False);
+                at.Event='Elrey';
+                at.Alliance='ThugGang';
+                at.Alliances[0].allianceName='Player';
+                at.Alliances[0].allianceLevel=-1.0;
+                at.Alliances[0].bPermanent=true;
+
+                ot.Destroy();
+                break;
+            }
+        }
+
         if (VanillaMaps){
             //Put a button behind the hidden bathroom door
             //Mostly for entrance rando, but just in case

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -109,7 +109,7 @@ function PreFirstEntryMapFixes()
         if (VanillaMaps){
             Spawn(class'#var(prefix)Binoculars',,, vectm(-610.374573,-3221.998779,94.160065)); //Paul's bedside table
 
-            if(!dxr.flags.IsZeroRando()) {
+            if(class'MenuChoice_BalanceMaps'.static.MajorEnabled()) {
                 key = Spawn(class'#var(prefix)NanoKey',,, vectm(-967,-1240,-74)); //In a mail nook
                 key.KeyID = 'CrackRoom';
                 key.Description = "'Ton Hotel, North Room Key";
@@ -139,7 +139,7 @@ function PreFirstEntryMapFixes()
         } else {
             Spawn(class'#var(prefix)Binoculars',,, vectm(-90,-3958,95)); //Paul's bedside table
 
-            if(!dxr.flags.IsZeroRando()) {
+            if(class'MenuChoice_BalanceMaps'.static.MajorEnabled()) {
                 key = Spawn(class'#var(prefix)NanoKey',,, vectm(-900,-1385,-74)); //In a mail nook
                 key.KeyID = 'Hotelroom1'; //CrackRoom doesn't exist in Revision M04 - doesn't hurt to add a key to a different room instead
                 key.Description = "'Ton Hotel, South Room Key";
@@ -170,7 +170,7 @@ function PreFirstEntryMapFixes()
         break;
 
     case "04_NYC_NSFHQ":
-        if(!dxr.flags.IsReducedRando()) {
+        if(class'MenuChoice_BalanceMaps'.static.MajorEnabled()) {
             foreach AllActors(class'#var(prefix)AutoTurret', turret) {
                 turret.Event = '';
                 turret.Destroy();
@@ -207,7 +207,7 @@ function PreFirstEntryMapFixes()
             door.KeyIDNeeded='BasementDoor';
         }
 
-        if(!dxr.flags.IsReducedRando()) {
+        if(class'MenuChoice_BalanceMaps'.static.MajorEnabled()) {
             k = #var(prefix)Karkian(Spawnm(class'#var(prefix)Karkian',,, vect(54.688416, 1208.957275, -237.351410), rot(0,32768,0)));
             k.BindName="NSFMinotaur";
             k.bImportant = true;
@@ -299,12 +299,14 @@ function PreFirstEntryMapFixes()
         class'PlaceholderEnemy'.static.Create(self,vectm(-438,1120,544),,,,'UNATCO',1);
         class'PlaceholderEnemy'.static.Create(self,vectm(-89,1261,304),,,,'UNATCO',1);
 
-        dxr.flagbase.SetBool('DXRando_NSFHQVisited', true,, 5);
+        if(class'MenuChoice_BalanceMaps'.static.MinorEnabled()) {
+            dxr.flagbase.SetBool('DXRando_NSFHQVisited', true,, 5);
+        }
 
         break;
 
     case "04_NYC_UNATCOISLAND":
-        if(!dxr.flags.IsReducedRando()) {
+        if(class'MenuChoice_ToggleMemes'.static.IsEnabled(dxr.flags)) {
             foreach AllActors(class'#var(prefix)UNATCOTroop', lloyd) {
                 if(lloyd.BindName != "PrivateLloyd") continue;
                 lloyd.FamiliarName = "Sergeant Lloyd";
@@ -343,7 +345,7 @@ function PreFirstEntryMapFixes()
         FixAlexsEmail();
         MakeTurretsNonHostile(); //Revision has hostile turrets near jail
 
-        if(!dxr.flags.IsZeroRando()) {
+        if(class'MenuChoice_BalanceMaps'.static.MajorEnabled()) {
             key = Spawn(class'#var(prefix)NanoKey',,, vectm(965,900,-28));
             key.KeyID = 'JaimeClosetKey';
             key.Description = "MedLab Closet Key Code";
@@ -686,7 +688,7 @@ function NYC_04_CheckPaulRaid()
         if( paul.Health <= 0 ) dead++;
         if( ! paul.bInvincible ) continue;
 
-        if(!dxr.flags.IsZeroRandoPure()) {
+        if(class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) {
             paul.bInvincible = false;
             SetPawnHealth(paul, 400);
         }
@@ -702,7 +704,7 @@ function NYC_04_CheckPaulRaid()
     }
 
     if( dead > 0 || dxr.flagbase.GetBool('PaulDenton_Dead') ) {
-        if(!dxr.flags.IsZeroRandoPure()) player().ClientMessage("RIP Paul :(",, true);
+        if(!dxr.flags.IsZeroRando()) player().ClientMessage("RIP Paul :(",, true);
         dxr.flagbase.SetBool('PaulDenton_Dead', true,, 999);
         SetTimer(0, False);
     }
@@ -734,7 +736,7 @@ function NYC_04_MarkPaulSafe()
         paul.SetOrders('Leaving', 'PaulLeaves', True);
     }
 
-    if(health > 0 && !dxr.flags.IsZeroRandoPure()) {
+    if(health > 0 && !dxr.flags.IsZeroRando() && !paul.bInvincible) {
         player().ClientMessage("Paul had " $ health $ "% health remaining.");
     }
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -47,6 +47,8 @@ function PreFirstEntryMapFixes()
     local #var(prefix)Keypad3 kp;
     local #var(prefix)Cigarettes cigs;
     local #var(prefix)ComputerPublic compublic;
+    local #var(prefix)OrdersTrigger ot;
+    local #var(prefix)AllianceTrigger at;
 
     local DXREnemies dxre;
     local int i;
@@ -196,6 +198,40 @@ function PreFirstEntryMapFixes()
         }
         foreach AllActors(class'#var(prefix)JaimeReyes', j) {
             RemoveFears(j);
+        }
+
+        if (class'MenuChoice_BalanceMaps'.static.ModerateEnabled()){
+            //Manderley becomes hostile, rather than being ordered to Attack (which breaks stealth)
+            foreach AllActors(class'#var(prefix)OrdersTrigger',ot,'killjc'){
+                class'FacePlayerTrigger'.static.Create(self,'killjc','JosephManderley',ot.Location);
+
+                at = Spawn(class'#var(injectsprefix)AllianceTrigger',,'killjc',ot.Location);
+                at.SetCollision(False,False,False);
+                at.Event='JosephManderley';
+                at.Alliance='UNATCO';
+                at.Alliances[0].allianceName='Player';
+                at.Alliances[0].allianceLevel=-1.0;
+                at.Alliances[0].bPermanent=true;
+
+                ot.Destroy();
+                break;
+            }
+
+            //Anna becomes hostile, rather than being ordered to Attack (which breaks stealth)
+            foreach AllActors(class'#var(prefix)OrdersTrigger',ot,'annahate'){
+                class'FacePlayerTrigger'.static.Create(self,'annahate','AnnaNavarre',ot.Location);
+
+                at = Spawn(class'#var(injectsprefix)AllianceTrigger',,'annahate',ot.Location);
+                at.SetCollision(False,False,False);
+                at.Event='AnnaNavarre';
+                at.Alliance='UNATCO';
+                at.Alliances[0].allianceName='Player';
+                at.Alliances[0].allianceLevel=-1.0;
+                at.Alliances[0].bPermanent=true;
+
+                ot.Destroy();
+                break;
+            }
         }
 
         class'PlaceholderEnemy'.static.Create(self,vectm(164,-424,48),,'Sitting');

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -289,6 +289,7 @@ function PreFirstEntryMapFixes()
     case "05_NYC_UNATCOISLAND":
         foreach AllActors(class'#var(prefix)UNATCOTroop', lloyd) {
             if(lloyd.BindName != "PrivateLloyd") continue;
+            if( ! class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) continue;
             RemoveFears(lloyd);
             lloyd.MinHealth = 0;
             lloyd.BaseAccuracy *= 0.1;

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -166,7 +166,7 @@ function PreFirstEntryMapFixes()
                 anna.AgitationDecayRate = 0;
             }
 
-            if(!dxr.flags.IsZeroRando()) {
+            if(class'MenuChoice_BalanceMaps'.static.MajorEnabled()) {
                 k = Spawn(class'#var(prefix)NanoKey',,, vectm(420,195,333));
                 k.KeyID = 'UNOfficeDoorKey';
                 k.Description = "UNATCO Office Door Key";
@@ -289,7 +289,7 @@ function PreFirstEntryMapFixes()
     case "05_NYC_UNATCOISLAND":
         foreach AllActors(class'#var(prefix)UNATCOTroop', lloyd) {
             if(lloyd.BindName != "PrivateLloyd") continue;
-            if( ! class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) continue;
+            if( ! class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) break; // not in Zero Rando
             RemoveFears(lloyd);
             lloyd.MinHealth = 0;
             lloyd.BaseAccuracy *= 0.1;
@@ -300,6 +300,8 @@ function PreFirstEntryMapFixes()
                     dxre.GiveRandomWeapon(lloyd, false, 2);
                     dxre.GiveRandomMeleeWeapon(lloyd);
                 }
+            }
+            if(class'MenuChoice_ToggleMemes'.static.IsEnabled(dxr.flags)) {
                 lloyd.FamiliarName = "Master Sergeant Lloyd";
                 lloyd.UnfamiliarName = "Master Sergeant Lloyd";
             }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -387,7 +387,7 @@ function PreFirstEntryMapFixes()
             //The other ones are tagged as Dogs
             if (g.Tag=='Greasel'){
                 g.BindName="JerryTheVentGreasel";
-                if(!dxr.flags.IsReducedRando()) {
+                if(dxr.flags.IsBingoMode() || class'MenuChoice_ToggleMemes'.static.IsEnabled(dxr.flags)) {
                     g.FamiliarName = "Jerry the Vent Greasel";
                     g.UnfamiliarName = "Jerry the Vent Greasel";
                 }
@@ -695,20 +695,6 @@ function PreFirstEntryMapFixes()
             }
         }
 
-        if (dxr.flags.IsZeroRando() == false) {
-            // give nervous worker some new threads so he stands out
-            foreach AllActors(class'Male1', male) {
-                if (male.BindName == "Disgruntled_Guy") {
-                    male.MultiSkins[3] = Texture'NervousWorkerPants';
-                    male.MultiSkins[5] = Texture'NervousWorkerBody';
-                    male.MultiSkins[6] = Texture'DeusExCharacters.Skins.FramesTex1';
-                    male.MultiSkins[7] = Texture'DeusExCharacters.Skins.LensesTex1';
-                    male.CarcassType = class'NervousWorkerCarcass';
-                    break;
-                }
-            }
-        }
-
         Spawn(class'PlaceholderItem',,, vectm(12.36,1556.5,-51)); //1st floor front cube
         Spawn(class'PlaceholderItem',,, vectm(643.5,2139.7,-51.7)); //1st floor back cube
         Spawn(class'PlaceholderItem',,, vectm(210.94,2062.23,204.3)); //2nd floor front cube
@@ -793,7 +779,7 @@ function PreFirstEntryMapFixes()
         Spawn(class'PlaceholderContainer',,, vectm(691.3,-358.4,-1007.9)); //Near UC
         Spawn(class'PlaceholderContainer',,, vectm(174,-2862,1057)); //Near upper security computer
 
-        if(!dxr.flags.IsZeroRandoPure()) {
+        if(class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) {
             p=MJ12Clone1(Spawnm(class'MJ12Clone1',,, vect(635,0,-65),rot(0,32768,0))); //Should he just be a PlaceholderEnemy now?
             p.SetAlliance('MJ12');
             ChangeInitialAlliance(p,'Player',-1,true);
@@ -1037,7 +1023,7 @@ function AnyEntryMapFixes()
         HandleJohnSmithDeath();
         if (dxr.flagbase.GetBool('Disgruntled_Guy_Dead')){
             foreach AllActors(class'#var(DeusExPrefix)Carcass', carc, 'John_Smith_Body') {
-                if (dxr.flags.IsZeroRando()) {
+                if (dxr.flags.settings.goals > 0) {
                     if (carc.bHidden) {
                         carc.bHidden = false;
                         carc.ItemName = "John Smith (Dead)";

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
@@ -238,7 +238,7 @@ function PreFirstEntryMapFixes()
         case "08_NYC_STREET":
 
             //Reinforcements for the sixth cop
-            if(!dxr.flags.IsZeroRandoPure()) {
+            if (class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) {
                 pawn=#var(prefix)UNATCOTroop(Spawnm(class'#var(prefix)UNATCOTroop',,'troop6', vect(-85,80,-460)));
                 pawn.SetAlliance('UNATCO');
                 ChangeInitialAlliance(pawn,'Player',-1,true);
@@ -441,33 +441,34 @@ function PostFirstEntryMapFixes()
     {
         case "08_NYC_STREET":
 
-            //Place reinforcement points on the cops
-            foreach AllActors(class'#var(prefix)ScriptedPawn',sp){
-                rpTag = FindReinforcementPointTag(sp.Tag);
-                if (rpTag!=''){
-                    reinforce = sp.Spawn(class'DXRReinforcementPoint',,rpTag,sp.Location);
-                    reinforce.Init(sp);
+            if (class'MenuChoice_BalanceMaps'.static.MinorEnabled()){
+                //Place reinforcement points on the cops
+                foreach AllActors(class'#var(prefix)ScriptedPawn',sp){
+                    rpTag = FindReinforcementPointTag(sp.Tag);
+                    if (rpTag!=''){
+                        reinforce = sp.Spawn(class'DXRReinforcementPoint',,rpTag,sp.Location);
+                        reinforce.Init(sp);
+                    }
+                }
+
+                //Make sure the troopers are running to the reinforcement points
+                foreach AllActors(class'#var(prefix)ScriptedPawn',sp){
+                    SetUNATCOTargetOrders(sp);
+                }
+
+                //A point for the MJ12 Attack Force to run to (the stairs of Osgoode & Sons)
+                //This location works for both Vanilla maps and Revision
+                reinforce = Spawn(class'DXRReinforcementPoint',,'MJ12AttackForceTarget',vectm(530,1900,-450));
+                reinforce.SetCollisionSize(200,100); //Make it bigger than the other reinforcement points
+
+                //Make the Attack Force run to the reinforcement point instead of directly attacking the player
+                foreach AllActors(class'#var(prefix)ScriptedPawn',sp){
+                    if (sp.Tag!='MJ12AttackForce' && sp.Tag!='MJ12AttackForce_clone') continue;
+
+                    sp.bKeepWeaponDrawn=True;
+                    sp.SetOrders('RunningTo','MJ12AttackForceTarget',True);
                 }
             }
-
-            //Make sure the troopers are running to the reinforcement points
-            foreach AllActors(class'#var(prefix)ScriptedPawn',sp){
-                SetUNATCOTargetOrders(sp);
-            }
-
-            //A point for the MJ12 Attack Force to run to (the stairs of Osgoode & Sons)
-            //This location works for both Vanilla maps and Revision
-            reinforce = Spawn(class'DXRReinforcementPoint',,'MJ12AttackForceTarget',vectm(530,1900,-450));
-            reinforce.SetCollisionSize(200,100); //Make it bigger than the other reinforcement points
-
-            //Make the Attack Force run to the reinforcement point instead of directly attacking the player
-            foreach AllActors(class'#var(prefix)ScriptedPawn',sp){
-                if (sp.Tag!='MJ12AttackForce' && sp.Tag!='MJ12AttackForce_clone') continue;
-
-                sp.bKeepWeaponDrawn=True;
-                sp.SetOrders('RunningTo','MJ12AttackForceTarget',True);
-            }
-
 
             break;
     }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
@@ -328,7 +328,7 @@ function PreFirstEntryMapFixes()
             if (VanillaMaps){
                 Spawn(class'#var(prefix)Binoculars',,, vectm(-610.374573,-3221.998779,94.160065)); //Paul's bedside table
 
-                if(!dxr.flags.IsZeroRando()) {
+                if(class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) {
                     SpawnDatacubeTextTag(vectm(-840,-2920,85), rotm(0,0,0,0), '02_Datacube07',False); //Paul's stash code, in bottom of closet
 
                     k = Spawn(class'#var(prefix)NanoKey',,, vectm(-967,-1240,-74)); //In a mail nook
@@ -364,7 +364,7 @@ function PreFirstEntryMapFixes()
             } else {
                 Spawn(class'#var(prefix)Binoculars',,, vectm(-90,-3958,95)); //Paul's bedside table
 
-                if(!dxr.flags.IsZeroRando()) {
+                if(class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) {
                     k = Spawn(class'#var(prefix)NanoKey',,, vectm(-900,-1385,-74)); //In a mail nook
                     k.KeyID = 'Hotelroom1';
                     k.Description = "'Ton Hotel, South Room Key";

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
@@ -178,6 +178,7 @@ function PreFirstEntryMapFixes_Bunker(bool isVanilla)
 
     //Swap the button at the top of the elevator to a keypad to make this path a bit more annoying
     foreach AllActors(class'Switch2',s2){
+        if( ! class'MenuChoice_BalanceMaps'.static.ModerateEnabled() ) break;
         if (s2.Event=='elevator_mtunnel_up'){
             k = Spawn(class'Keypad2',,,s2.Location,s2.Rotation);
             k.validCode="17092019"; //September 17th, 2019 - First day of "Storm Area 51"

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
@@ -338,21 +338,23 @@ function PreFirstEntryMapFixes_Final(bool isVanilla)
     se = Spawn(class'SpecialEvent',,'start_buzz2');
     se.Message = "Coolant levels normal - Failsafe cannot be disabled";
 
-    //The mechanic in the Reactor Room is no longer directly ordered to attack you (which breaks your stealth)
-    //Instead, he is set to be hostile to the player and turns to face you
-    foreach AllActors(class'#var(prefix)OrdersTrigger',ot,'power_guy_attacks'){
-        class'FacePlayertrigger'.static.Create(self,'power_guy_attacks','PowerMech',ot.Location);
+    if (class'MenuChoice_BalanceMaps'.static.ModerateEnabled()){
+        //The mechanic in the Reactor Room is no longer directly ordered to attack you (which breaks your stealth)
+        //Instead, he is set to be hostile to the player and turns to face you
+        foreach AllActors(class'#var(prefix)OrdersTrigger',ot,'power_guy_attacks'){
+            class'FacePlayerTrigger'.static.Create(self,'power_guy_attacks','PowerMech',ot.Location);
 
-        at = Spawn(class'#var(injectsprefix)AllianceTrigger',,'power_guy_attacks',ot.Location);
-        at.SetCollision(False,False,False);
-        at.Event='PowerMech';
-        at.Alliance='Mechanic';
-        at.Alliances[0].allianceName='Player';
-        at.Alliances[0].allianceLevel=-1.0;
-        at.Alliances[0].bPermanent=true;
+            at = Spawn(class'#var(injectsprefix)AllianceTrigger',,'power_guy_attacks',ot.Location);
+            at.SetCollision(False,False,False);
+            at.Event='PowerMech';
+            at.Alliance='Mechanic';
+            at.Alliances[0].allianceName='Player';
+            at.Alliances[0].allianceLevel=-1.0;
+            at.Alliances[0].bPermanent=true;
 
-        ot.Destroy();
-        break;
+            ot.Destroy();
+            break;
+        }
     }
 
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
@@ -582,7 +582,7 @@ function PreFirstEntryMapFixes_Page(bool isVanilla)
     local AmbientSound as;
     local DXRAmbientSoundTrigger ast;
 
-    if(!dxr.flags.IsZeroRando()) {
+    if(dxr.flags.settings.infodevices > 0) {
         //Rather than duplicating the existing cubes, add new clone text so there are more possibilities
         if (isVanilla){
             cloneCubeLoc[0]=vectm(6197.620117,-8455.201172,-5117.649902); //Weird little window near broken door (on Page side)
@@ -651,7 +651,7 @@ function PreFirstEntryMapFixes_Page(bool isVanilla)
             }
         }
 
-        if(!dxr.flags.IsZeroRando()) {
+        if(class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) {
             //Add a switch to manually trigger the infolink that gives you the Helios computer password
             AddSwitch( vect(5635.609375,-5352.036133,-5240.890625), rot(0, 0, 0), 'PasswordCallReset', "Forgot your Password?");
         }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
@@ -279,6 +279,8 @@ function PreFirstEntryMapFixes_Final(bool isVanilla)
     local Dispatcher disp;
     local FlagTrigger ft;
     local OnceOnlyTrigger oot;
+    local #var(prefix)OrdersTrigger ot;
+    local #var(prefix)AllianceTrigger at;
     local int i;
 
     //Increase the radius of the datalink that opens the sector 4 blast doors
@@ -335,6 +337,23 @@ function PreFirstEntryMapFixes_Final(bool isVanilla)
     se.Message = "Coolant levels normal - Failsafe cannot be disabled";
     se = Spawn(class'SpecialEvent',,'start_buzz2');
     se.Message = "Coolant levels normal - Failsafe cannot be disabled";
+
+    //The mechanic in the Reactor Room is no longer directly ordered to attack you (which breaks your stealth)
+    //Instead, he is set to be hostile to the player and turns to face you
+    foreach AllActors(class'#var(prefix)OrdersTrigger',ot,'power_guy_attacks'){
+        class'FacePlayertrigger'.static.Create(self,'power_guy_attacks','PowerMech',ot.Location);
+
+        at = Spawn(class'#var(injectsprefix)AllianceTrigger',,'power_guy_attacks',ot.Location);
+        at.SetCollision(False,False,False);
+        at.Event='PowerMech';
+        at.Alliance='Mechanic';
+        at.Alliances[0].allianceName='Player';
+        at.Alliances[0].allianceLevel=-1.0;
+        at.Alliances[0].bPermanent=true;
+
+        ot.Destroy();
+        break;
+    }
 
 
     if (isVanilla) {

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -339,6 +339,14 @@ function PreFirstEntryMapFixes()
             break;
         }
 
+        foreach AllActors(class'#var(prefix)OrdersTrigger',ot) {
+            if (ot.Event=='MorganEverett' && ot.Orders=='WaitingFor'){
+                //Make Morgan also face towards the door as you enter
+                class'FacePlayerTrigger'.static.Create(self,'MorganEverett',ot.Location,ot.CollisionRadius,ot.CollisionHeight);
+                break;
+            }
+        }
+
         //Add teleporter hint text to Jock
         foreach AllActors(class'#var(prefix)MapExit',exit,'CalledByDispatcher'){break;}
         foreach AllActors(class'#var(prefix)BlackHelicopter',jock,'BlackHelicopter'){break;}

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -12,7 +12,6 @@ function PreFirstEntryMapFixes()
     local #var(prefix)DamageTrigger dt;
     local #var(prefix)DataLinkTrigger dlt;
     local #var(prefix)ComputerSecurity cs;
-    local #var(prefix)AutoTurret at;
     local #var(prefix)WIB wib;
     local #var(prefix)MorganEverett everett;
     local #var(prefix)Chad chad;

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -342,7 +342,7 @@ function PreFirstEntryMapFixes()
         foreach AllActors(class'#var(prefix)OrdersTrigger',ot) {
             if (ot.Event=='MorganEverett' && ot.Orders=='WaitingFor'){
                 //Make Morgan also face towards the door as you enter
-                class'FacePlayerTrigger'.static.Create(self,'MorganEverett',ot.Location,ot.CollisionRadius,ot.CollisionHeight);
+                class'FacePlayerTrigger'.static.Create(self,'EverettFacesPlayer','MorganEverett',ot.Location,ot.CollisionRadius,ot.CollisionHeight);
                 break;
             }
         }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -73,7 +73,7 @@ function PreFirstEntryMapFixes()
             }
             AddSwitch( vect(-2190.893799, 1203.199097, -6.663990), rot(0,0,0), 'catacombs_blastdoorB' );
 
-            if(!dxr.flags.IsReducedRando()) {
+            if(class'MenuChoice_ToggleMemes'.static.IsEnabled(dxr.flags)) {
                 foreach AllActors(class'ScriptedPawn',sp){
                     if(sp.BindName=="bums"){
                         sp.bImportant=True;
@@ -164,7 +164,7 @@ function PreFirstEntryMapFixes()
     case "10_PARIS_METRO":
         if (VanillaMaps){
             //Add a key for the media store
-            if(!dxr.flags.IsZeroRando()) {
+            if(dxr.flags.settings.goals > 0) {
                 //On the table in the cafe
                 k = Spawn(class'#var(prefix)NanoKey',,, vectm(-2020,1115,340));
                 k.KeyID = 'mediastore_door';
@@ -180,8 +180,6 @@ function PreFirstEntryMapFixes()
                 m.KeyIDNeeded='mediastore_door';
             }
 
-
-
             // make the apartment stairs less hidden, not safe to have stairs without a light!
             CandleabraLight(vect(1825.758057, 1481.900024, 576.077698), rot(0, 16384, 0));
             CandleabraLight(vect(1162.240112, 1481.900024, 879.068848), rot(0, 16384, 0));
@@ -194,7 +192,7 @@ function PreFirstEntryMapFixes()
         hoverHint.SetBaseActor(jock);
 
         //If neither flag is set, JC never talked to Jaime, so he just didn't bother
-        if (!dxr.flags.IsZeroRandoPure() && !dxr.flagbase.GetBool('JaimeRecruited') && !dxr.flagbase.GetBool('JaimeLeftBehind')){
+        if (class'MenuChoice_BalanceMaps'.static.ModerateEnabled() && !dxr.flagbase.GetBool('JaimeRecruited') && !dxr.flagbase.GetBool('JaimeLeftBehind')){
             //Need to pretend he *was* recruited, so that he doesn't spawn
             dxr.flagbase.SetBool('JaimeRecruited',True);
         }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -339,11 +339,13 @@ function PreFirstEntryMapFixes()
             break;
         }
 
-        foreach AllActors(class'#var(prefix)OrdersTrigger',ot) {
-            if (ot.Event=='MorganEverett' && ot.Orders=='WaitingFor'){
-                //Make Morgan also face towards the door as you enter
-                class'FacePlayerTrigger'.static.Create(self,'EverettFacesPlayer','MorganEverett',ot.Location,ot.CollisionRadius,ot.CollisionHeight);
-                break;
+        if (class'MenuChoice_BalanceMaps'.static.MinorEnabled()){
+            foreach AllActors(class'#var(prefix)OrdersTrigger',ot) {
+                if (ot.Event=='MorganEverett' && ot.Orders=='WaitingFor'){
+                    //Make Morgan also face towards the door as you enter
+                    class'FacePlayerTrigger'.static.Create(self,'EverettFacesPlayer','MorganEverett',ot.Location,ot.CollisionRadius,ot.CollisionHeight);
+                    break;
+                }
             }
         }
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -195,7 +195,7 @@ function PreFirstEntryMapFixes()
         hoverHint.SetBaseActor(jock);
 
         //If neither flag is set, JC never talked to Jaime, so he just didn't bother
-        if (!dxr.flagbase.GetBool('JaimeRecruited') && !dxr.flagbase.GetBool('JaimeLeftBehind')){
+        if (!dxr.flags.IsZeroRandoPure() && !dxr.flagbase.GetBool('JaimeRecruited') && !dxr.flagbase.GetBool('JaimeLeftBehind')){
             //Need to pretend he *was* recruited, so that he doesn't spawn
             dxr.flagbase.SetBool('JaimeRecruited',True);
         }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
@@ -331,9 +331,11 @@ function PreFirstEntryMapFixes()
             }
         }
 
-        if(!dxr.flags.IsZeroRandoPure()) {
+        if(class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) {
             foreach AllActors(class'#var(prefix)OrdersTrigger', ot) {
                 if(ot.Event == 'muncher') {
+                    class'FacePlayerTrigger'.static.Create(self,'MuncherTurnsToFace','muncher',ot.Location,ot.CollisionRadius,ot.CollisionHeight);
+                    //Muncher is already hostile to the player, so just need to make them turn to face the player
                     ot.Destroy();
                 }
             }

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
@@ -462,29 +462,30 @@ function PreFirstEntryMapFixes()
 
     case "14_Oceanlab_silo":
         if (VanillaMaps){
-            if(!dxr.flags.IsReducedRando()) {
-                foreach AllActors(class'#var(prefix)HowardStrong', hs) {
-                    hs.ChangeAlly('', 1, true);
-                    hs.ChangeAlly('mj12', 1, true);
-                    hs.ChangeAlly('spider', 1, true);
+            foreach AllActors(class'#var(prefix)HowardStrong', hs) {
+                hs.ChangeAlly('', 1, true);
+                hs.ChangeAlly('mj12', 1, true);
+                hs.ChangeAlly('spider', 1, true);
+                if(class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) {
                     RemoveFears(hs);
                     hs.MinHealth = 0;
                     hs.BaseAccuracy *= 0.1;
-
                     GiveItem(hs, class'#var(prefix)BallisticArmor');
+                    if(!#defined(vmd)) {// vmd allows AI to equip armor, so maybe he doesn't need the health boost?
+                        SetPawnHealth(hs, 200);
+                    }
+                    hs.LeaveWorld();
+                }
+                if(!dxr.flags.IsReducedRando()) {
                     dxre = DXREnemies(dxr.FindModule(class'DXREnemies'));
                     if(dxre != None) {
                         dxre.GiveRandomWeapon(hs, false, 2);
                         dxre.GiveRandomMeleeWeapon(hs);
                     }
+                }
+                if(class'MenuChoice_ToggleMemes'.static.IsEnabled(dxr.flags) && class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) {
                     hs.FamiliarName = "Howard Stronger";
                     hs.UnfamiliarName = "Howard Stronger";
-
-                    if(!#defined(vmd)) {// vmd allows AI to equip armor, so maybe he doesn't need the health boost?
-                        SetPawnHealth(hs, 200);
-                    }
-
-                    hs.LeaveWorld();
                 }
             }
 
@@ -520,11 +521,12 @@ function PreFirstEntryMapFixes()
         class'PlaceholderEnemy'.static.Create(self,vectm(-1257,-3472,1468));
         class'PlaceholderEnemy'.static.Create(self,vectm(1021,-3323,1476));
 
-
-        dxr.flagbase.SetBool('MS_UnhideHelicopter', True,, 15);
-        foreach AllActors(class'DataLinkTrigger', dlt, 'klax') {
-            dlt.Destroy();
-            break;
+        if(class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) {
+            dxr.flagbase.SetBool('MS_UnhideHelicopter', True,, 15);
+            foreach AllActors(class'DataLinkTrigger', dlt, 'klax') {
+                dlt.Destroy();
+                break;
+            }
         }
 
         break;
@@ -618,7 +620,7 @@ function VandenbergCmdFixTimsDoor()
     local #var(DeusExPrefix)Mover door;
     local #var(prefix)NanoKey key;
 
-    if(!dxr.flags.IsZeroRando()) {
+    if(class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) {
         //Add a key to Tim's closet
         foreach AllActors(class'#var(DeusExPrefix)Mover',door){
             if (door.Name=='DeusExMover28'){
@@ -641,7 +643,7 @@ function VandenbergCmdRevisionFixWatchtowerDoor()
     local #var(DeusExPrefix)Mover door;
     local #var(prefix)NanoKey key;
 
-    if(!dxr.flags.IsZeroRando()) {
+    if(class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) {
         //Add a key to the watch tower
         foreach AllActors(class'#var(DeusExPrefix)Mover',door){
             if (door.Name=='DeusExMover42'){
@@ -666,7 +668,7 @@ function UnleashingBotsOpenCommsDoor()
     local #var(prefix)DataLinkTrigger dt;
     local #var(prefix)FlagTrigger ft;
 
-    if(dxr.flags.IsZeroRandoPure()) return;
+    if(dxr.flags.settings.enemiesshuffled==0 && dxr.flags.loadout==0) return;
 
     // releasing the bots should be enough to get into the comms building, especially for Stick With the Prod players
 
@@ -928,8 +930,10 @@ function AnyEntryMapFixes()
             hs.ChangeAlly('', 1, true);
             hs.ChangeAlly('mj12', 1, true);
             hs.ChangeAlly('spider', 1, true);
-            RemoveFears(hs);
-            hs.MinHealth = 0;
+            if(class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) {
+                RemoveFears(hs);
+                hs.MinHealth = 0;
+            }
         }
 
         Player().StartDataLinkTransmission("DL_FrontGate");
@@ -1025,6 +1029,8 @@ function TimerMapFixes()
 
 function private _SiloGoalChecks() {
     local BlackHelicopter chopper;
+
+    if(!class'MenuChoice_BalanceMaps'.static.ModerateEnabled()) return;
 
     // by design, no infolink plays after killing Howard Strong if the missile hasn't been redirected
     if (dxr.flagbase.GetBool('DXR_SiloEscapeHelicopterUnhidden') || !dxr.flagbase.GetBool('missile_launched')) {

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
@@ -952,11 +952,8 @@ function AnyEntryMapFixes()
         SetTimer(1, true);
         break;
     case "12_VANDENBERG_CMD":
-        Player().StartDataLinkTransmission("DL_no_carla");
-
         // timer to count the MJ12 Bots
         SetTimer(1, True);
-
         break;
 
     case "14_OCEANLAB_LAB":

--- a/DXRMissions/DeusEx/Classes/DXRMissionsM08.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsM08.uc
@@ -266,11 +266,11 @@ function AddAssaultSquadLocations(string locName, int numLocs)
                 AddSingleLocation(vectm(-1577,-1585,-438),numAdded,numLocs);
                 break;
             case "Basketball Court":
-                AddSingleLocation(vectm(3008,-2807,-448),numAdded,numLocs);
-                AddSingleLocation(vectm(2945,-2773,-448),numAdded,numLocs);
-                AddSingleLocation(vectm(3008,-2709,-448),numAdded,numLocs);
-                AddSingleLocation(vectm(2958,-2628,-448),numAdded,numLocs);
-                AddSingleLocation(vectm(3035,-2560,-448),numAdded,numLocs);
+                AddSingleLocation(vectm(2450, -2400, -448),numAdded,numLocs);
+                AddSingleLocation(vectm(2550, -2400, -448),numAdded,numLocs);
+                AddSingleLocation(vectm(2650, -2400, -448),numAdded,numLocs);
+                AddSingleLocation(vectm(2490, -2500, -448),numAdded,numLocs);
+                AddSingleLocation(vectm(2600, -2500, -448),numAdded,numLocs);
                 break;
             case "Smuggler Front Door":
                 AddSingleLocation(vectm(2552,-1108,-464),numAdded,numLocs);

--- a/DXRMissions/DeusEx/Classes/DXRMissionsVandenberg.uc
+++ b/DXRMissions/DeusEx/Classes/DXRMissionsVandenberg.uc
@@ -460,6 +460,15 @@ function AfterMoveGoalToLocation(Goal g, GoalLocation Loc)
     }
 }
 
+function AfterMovePlayerToStartLocation(GoalLocation Loc)
+{
+    local #var(prefix)InterpolateTrigger it;
+
+    if(dxr.localURL=="12_VANDENBERG_CMD" && Loc.name!="Roof") {
+        Player().StartDataLinkTransmission("DL_no_carla");
+    }
+}
+
 function PreFirstEntryMapFixes()
 {
     local #var(prefix)ScriptedPawn sp;

--- a/DXRModules/DeusEx/Classes/DXRAugmentations.uc
+++ b/DXRModules/DeusEx/Classes/DXRAugmentations.uc
@@ -278,15 +278,6 @@ function static RandomizeAugCannister(DXRando dxr, #var(prefix)AugmentationCanni
 
     a.AddAugs[0] = augs[0].Name;
     a.AddAugs[1] = augs[1].Name;
-
-    if(!#defined(vmd)) {
-        if(augs[0] != None && augs[1] != None)
-            a.ItemName = a.default.ItemName $": "$ augs[0].default.AugmentationName $ " / " $ augs[1].default.AugmentationName;
-        else if(augs[0] != None)
-            a.ItemName = a.default.ItemName $": "$ augs[0].default.AugmentationName;
-        else if(augs[1] != None)
-            a.ItemName = a.default.ItemName $": "$ augs[1].default.AugmentationName;
-    }
 }
 
 // HX uses the regular Augmentation base class

--- a/DXRModules/DeusEx/Classes/DXRBacktracking.uc
+++ b/DXRModules/DeusEx/Classes/DXRBacktracking.uc
@@ -513,10 +513,8 @@ function VandGasAnyEntry()
         CreateInterpolationPoints( 'backtrack_exit', vectm(2520.256836, -2489.873535, -1402.078857) );
         CreateCameraInterpolationPoints( 'backtrack_exit', 'backtrack_camera', vectm(-500,250,0) );
 
-        if(!dxr.flags.IsZeroRando()) {
-            // I could also give Jock a "Let's go" conversation
-            BacktrackChopper('backtrack_exit', 'backtrack_chopper', 'backtrack_exit', "", 'backtrack_camera', "12_VANDENBERG_CMD", 'PathNode8', "", vect(2520.256836, -2489.873535, -1402.078857), rot(0,0,0) );
-        }
+        // I could also give Jock a "Let's go" conversation
+        BacktrackChopper('backtrack_exit', 'backtrack_chopper', 'backtrack_exit', "", 'backtrack_camera', "12_VANDENBERG_CMD", 'PathNode8', "", vect(2520.256836, -2489.873535, -1402.078857), rot(0,0,0) );
     }
 
     // repeat flights to the sub base, not silly

--- a/DXRModules/DeusEx/Classes/DXRBingoCampaign.uc
+++ b/DXRModules/DeusEx/Classes/DXRBingoCampaign.uc
@@ -407,12 +407,6 @@ static function int GetBingoMask(int missionNumber, int bingoDuration)
     for (mission = GetBingoEnd(missionNumber, bingoDuration); mission >= missionNumber; mission--) {
         bingoMask = bingoMask | (1 << mission);
     }
-    if ((bingoMask & 2048) != 0) {    // M11
-        bingoMask = bingoMask | 1024; // M10
-    }
-    if ((bingoMask & 16384) != 0) {   // M14
-        bingoMask = bingoMask | 4096; // M12
-    }
     bingoMask = bingoMask & 57214; // remove M07 and M13
 
     return bingoMask;

--- a/DXRModules/DeusEx/Classes/DXRDatacubes.uc
+++ b/DXRModules/DeusEx/Classes/DXRDatacubes.uc
@@ -1631,6 +1631,7 @@ function RandoHacks()
 {
     local #var(prefix)HackableDevices h;
 
+    if(dxr.flags.settings.deviceshackable <=0 && dxr.flags.IsZeroRando()) return;
     SetSeed( "RandoHacks" );
 
     foreach AllActors(class'#var(prefix)HackableDevices', h) {

--- a/DXRModules/DeusEx/Classes/DXRDoors.uc
+++ b/DXRModules/DeusEx/Classes/DXRDoors.uc
@@ -254,6 +254,17 @@ function CheckConfig()
     min_mindmg_adjust=0.3;
     max_mindmg_adjust=1.2;
 
+    if(dxr.flags.settings.doorspickable <= 0 && dxr.flags.IsZeroRando()) {
+        min_lock_adjust=1;
+        max_lock_adjust=1;
+    }
+    if(dxr.flags.settings.doorsdestructible <= 0 && dxr.flags.IsZeroRando()) {
+        min_door_adjust=1;
+        max_door_adjust=1;
+        min_mindmg_adjust=1;
+        max_mindmg_adjust=1;
+    }
+
     Super.CheckConfig();
 }
 

--- a/DXRModules/DeusEx/Classes/DXREnemies.uc
+++ b/DXRModules/DeusEx/Classes/DXREnemies.uc
@@ -206,7 +206,7 @@ function RandoEnemies(int percent, int hidden_percent)
     for(e=0; e<num_enemies; e++)
     {
         p = enemies[e];
-        if(p.bHasCloak) p.CloakThreshold = p.Health - 10;// make Anna and Walt cloak quickly
+        if(p.bHasCloak && class'MenuChoice_BalanceEtc'.static.IsEnabled()) p.CloakThreshold = p.Health - 10;// make Anna and Walt cloak quickly
         _perc = percent;
         if(p.bHidden) _perc = hidden_percent;
 

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -864,7 +864,7 @@ function SetWatchFlags() {
         bt.bingoEvent="MadeBasket";
         WatchFlag('StantonAmbushDefeated');
         WatchFlag('GreenKnowsAboutDowd');
-        MarkBingo("MaggieLived");
+        MarkBingo("MaggieLived", true);
         break;
     case "08_NYC_SMUG":
         WatchFlag('M08WarnedSmuggler');
@@ -1024,7 +1024,7 @@ function SetWatchFlags() {
                 wib.bImportant = true;
         }
         WatchFlag('SilhouetteHostagesAllRescued');
-        MarkBingo("AimeeLeMerchantLived");
+        MarkBingo("AimeeLeMerchantLived", true);
         break;
     case "10_PARIS_METRO":
         WatchFlag('M10EnteredBakery');

--- a/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -3242,6 +3242,12 @@ static function bool BingoGoalCanFail(string event)
         case "TechGoggles_Activated":
         case "Rebreather_Activated":
         case "FireExtinguisher_Activated":
+        case "ViewPortraits":
+        case "ViewSchematics":
+        case "ViewMaps":
+        case "ImageOpened_WaltonSimons":
+        case "ViewDissection":
+        case "ViewTouristPics":
             return false;
         default:
             return true;

--- a/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -1,6 +1,7 @@
 class DXREventsBase extends DXRActorsBase;
 
-const FAILED_MISSION_MASK = 1;
+const FAILED_MISSION_MASK = 1; // probably failed
+const ABSOLUTELY_FAILED_MISSION_MASK = 0xFFFFFFFF;
 
 var bool died;
 var() name watchflags[32];
@@ -1313,7 +1314,7 @@ function bool CheckBingoWin(DXRando dxr, int numBingos, int oldBingos)
     return false;
 }
 
-function _MarkBingo(coerce string eventname)
+function _MarkBingo(coerce string eventname, optional bool ifNotFailed)
 {
     local int previousbingos, nowbingos, time;
     local PlayerDataItem data;
@@ -1336,7 +1337,7 @@ function _MarkBingo(coerce string eventname)
 
     MarkBingoFailedEvents(eventName); //Making progress on one bingo goal might infer that another has failed
 
-    if( ! data.IncrementBingoProgress(eventname)) return;
+    if( ! data.IncrementBingoProgress(eventname, ifNotFailed)) return;
 
     nowbingos = data.NumberOfBingos();
     l(self$"._MarkBingo("$eventname$") previousbingos: "$previousbingos$", nowbingos: "$nowbingos);
@@ -1365,13 +1366,13 @@ function _MarkBingo(coerce string eventname)
     }
 }
 
-static function MarkBingo(coerce string eventname)
+static function MarkBingo(coerce string eventname, optional bool ifNotFailed)
 {
     local DXREvents e;
     e = DXREvents(Find());
     log(e$".MarkBingo "$eventname);
     if(e != None) {
-        e._MarkBingo(eventname);
+        e._MarkBingo(eventname, ifNotFailed);
     }
 }
 

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -877,9 +877,11 @@ function OverwriteDecorations()
     local #var(prefix)Barrel1 b;
     local int i;
     foreach AllActors(class'DeusExDecoration', d) {
-        if( d.IsA('CrateBreakableMedCombat') || d.IsA('CrateBreakableMedGeneral') || d.IsA('CrateBreakableMedMedical') ) {
+        if( class'MenuChoice_BalanceEtc'.static.IsEnabled()
+            && (d.IsA('CrateBreakableMedCombat') || d.IsA('CrateBreakableMedGeneral') || d.IsA('CrateBreakableMedMedical')) ) {
             d.Mass = 35;
             d.HitPoints = 1;
+            d.default.HitPoints = 1;
         }
         for(i=0; i < ArrayCount(DecorationsOverwrites); i++) {
             if(DecorationsOverwritesClasses[i] == None) continue;
@@ -887,6 +889,7 @@ function OverwriteDecorations()
             if( d.bIsSecretGoal == True) continue;
             d.bInvincible = DecorationsOverwrites[i].bInvincible;
             d.HitPoints = DecorationsOverwrites[i].HitPoints;
+            d.default.HitPoints = DecorationsOverwrites[i].HitPoints; // fixes the ScaleGlow
             d.minDamageThreshold = DecorationsOverwrites[i].minDamageThreshold;
             d.bFlammable = DecorationsOverwrites[i].bFlammable;
             d.Flammability = DecorationsOverwrites[i].Flammability;
@@ -938,6 +941,9 @@ function FixAutoTurrets()
 {
 #ifdef fixes
     local #var(prefix)AutoTurret at;
+
+    if(!class'MenuChoice_BalanceMaps'.static.MinorEnabled()) return;
+
     foreach AllActors(class'#var(prefix)AutoTurret',at){
         at.gunDamage=at.Default.gunDamage; //One turret in Cathedral has non-standard damage
         at.fireRate=at.Default.fireRate; //Make sure large and small turrets use their appropriate firerates

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -1114,7 +1114,7 @@ function SetAllLampsState(optional bool type1, optional bool type2, optional boo
 #ifdef vanilla
     local #var(prefix)Lamp lmp;
 
-    if (class'MenuChoice_AutoLamps'.default.enabled == false)
+    if (!class'MenuChoice_AutoLamps'.static.IsEnabled())
         return;
 
     if (rad == 0.0) {

--- a/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -859,6 +859,8 @@ function ScaleZoneDamage()
     local ZoneInfo z;
     local float f;
 
+    if(class'MenuChoice_BalanceEtc'.static.IsDisabled()) return;
+
 #ifdef injections
     foreach AllActors(class'ZoneInfo',z){
         if (z.bPainZone){

--- a/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -1,5 +1,6 @@
 class DXRFlags extends DXRFlagsNGPMaxRando transient;
 
+const FullRando = 0;
 const EntranceRando = 1;
 const HordeMode = 2;
 const RandoLite = 3;
@@ -14,6 +15,7 @@ const WaltonWarex3 = 11;
 const ZeroRandoPlus = 12;
 const OneItemMode = 13;
 const BingoCampaign = 14;
+const NormalRandomizer = 15;
 const HordeZombies = 1020;
 const WaltonWareHalloweenEntranceRando = 1029;
 const HalloweenEntranceRando = 1030;
@@ -528,12 +530,13 @@ function FlagsSettings SetDifficulty(int new_difficulty)
 
     if(!class'MenuChoice_ToggleMemes'.static.IsEnabled(self)) settings.dancingpercent = 0;
 
-    if(gamemode == RandoMedium) {
+    if(gamemode == RandoMedium || gamemode == NormalRandomizer) { // Normal is the same as Medium, except it doesn't count as Reduced Rando when dealing with balance changes or memes
         settings.startinglocations = 0;
         settings.goals = 0;
         settings.dancingpercent = 0;
         settings.enemiesrandomized *= 0.8;
-        moresettings.enemies_weapons *= 0.8;
+        settings.ammo = (settings.ammo+100) / 2;
+        moresettings.enemies_weapons *= 0.5;
     }
     else if(IsReducedRando()) {
         settings.doorsmode = 0;
@@ -749,7 +752,8 @@ function string DifficultyName(int diff)
 
 function int GameModeIdForSlot(int slot)
 {// allow us to reorder in the menu, similar to DXRLoadouts::GetIdForSlot
-    if(slot--==0) return 0;
+    if(slot--==0) return NormalRandomizer;
+    if(slot--==0) return FullRando;
     if(slot--==0) return HalloweenMode;
     if(slot--==0) return EntranceRando;
     if(slot--==0) return HalloweenEntranceRando;
@@ -779,7 +783,9 @@ function int GameModeIdForSlot(int slot)
 function string GameModeName(int gamemode)
 {
     switch(gamemode) {
-    case 0:
+    case FullRando:
+        return "Full Randomizer";
+    case NormalRandomizer:
         return "Normal Randomizer";
 #ifdef injections
     case EntranceRando:
@@ -1102,6 +1108,7 @@ function ExtendedTests()
 
 defaultproperties
 {
+    gamemode=15// Normal Randomizer
     difficulty=2
     autosave=2
     loadout=0

--- a/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -753,9 +753,11 @@ function string DifficultyName(int diff)
     if (diff>=ArrayCount(difficulty_names)){
         return "INVALID DIFFICULTY "$diff;
     }
-    if(IsZeroRando() && !#bool(hx)) {
+#ifndef hx
+    if(IsZeroRando()) {
         return vanilla_difficulty_names[diff];
     }
+#endif
     return difficulty_names[diff];
 }
 

--- a/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -27,7 +27,8 @@ var string difficulty_names[4];// Easy, Medium, Hard, DeusEx
 var FlagsSettings difficulty_settings[4];
 var MoreFlagsSettings more_difficulty_settings[4];
 #else
-var string difficulty_names[5];// Super Easy QA, Easy, Normal, Hard, Extreme
+var string vanilla_difficulty_names[5];// Super Easy QA, Easy, Medium, Hard, Realistic
+var string difficulty_names[5];// Super Easy QA, Normal, Hard, Extreme, Impossible
 var FlagsSettings difficulty_settings[5];
 var MoreFlagsSettings more_difficulty_settings[5];
 #endif
@@ -126,6 +127,7 @@ function CheckConfig()
     i=0;
 #ifndef hx
     difficulty_names[i] = "Super Easy QA";
+    vanilla_difficulty_names[i] = "Super Easy QA";
     difficulty_settings[i].CombatDifficulty = 0;
     difficulty_settings[i].doorsmode = alldoors + doormutuallyinclusive;
     difficulty_settings[i].doorsdestructible = 100;
@@ -202,6 +204,7 @@ function CheckConfig()
     difficulty_names[i] = "Easy";
 #else
     difficulty_names[i] = "Normal";
+    vanilla_difficulty_names[i] = "Easy";
     difficulty_settings[i].CombatDifficulty = 1.3;
 #endif
     difficulty_settings[i].doorsmode = undefeatabledoors + doormutuallyinclusive;
@@ -278,6 +281,7 @@ function CheckConfig()
     difficulty_names[i] = "Medium";
 #else
     difficulty_names[i] = "Hard";
+    vanilla_difficulty_names[i] = "Medium";
     difficulty_settings[i].CombatDifficulty = 2;
 #endif
     difficulty_settings[i].doorsmode = undefeatabledoors + doorindependent;
@@ -354,6 +358,7 @@ function CheckConfig()
     difficulty_names[i] = "Hard";
 #else
     difficulty_names[i] = "Extreme";
+    vanilla_difficulty_names[i] = "Hard";
     difficulty_settings[i].CombatDifficulty = 3;
 #endif
     difficulty_settings[i].doorsmode = undefeatabledoors + doorindependent;
@@ -430,6 +435,7 @@ function CheckConfig()
     difficulty_names[i] = "DeusEx";
 #else
     difficulty_names[i] = "Impossible";
+    vanilla_difficulty_names[i] = "Realistic";
     difficulty_settings[i].CombatDifficulty = 4;
 #endif
     difficulty_settings[i].doorsmode = undefeatabledoors + doorindependent;
@@ -746,6 +752,9 @@ function string DifficultyName(int diff)
 {
     if (diff>=ArrayCount(difficulty_names)){
         return "INVALID DIFFICULTY "$diff;
+    }
+    if(IsZeroRando() && !#bool(hx)) {
+        return vanilla_difficulty_names[diff];
     }
     return difficulty_names[diff];
 }
@@ -1109,7 +1118,7 @@ function ExtendedTests()
 defaultproperties
 {
     gamemode=15// Normal Randomizer
-    difficulty=2
+    difficulty=1
     autosave=2
     loadout=0
     crowdcontrol=0

--- a/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -454,7 +454,7 @@ simulated function string BindFlags(int mode, optional string str)
         FlagInt('MenuChoice_BalanceMaps', i, mode, str);
         i = int(class'MenuChoice_BalanceSkills'.static.IsEnabled());
         FlagInt('MenuChoice_BalanceSkills', i, mode, str);
-        i = int(class'MenuChoice_AutoAugs'.default.enabled);
+        i = int(class'MenuChoice_AutoAugs'.static.IsEnabled());
         FlagInt('MenuChoice_AutoAugs', i, mode, str);
         i = class'MenuChoice_PasswordAutofill'.static.GetSetting();
         FlagInt('MenuChoice_PasswordAutofill', i, mode, str);

--- a/DXRModules/DeusEx/Classes/DXRMissions.uc
+++ b/DXRModules/DeusEx/Classes/DXRMissions.uc
@@ -474,23 +474,26 @@ function bool _ChooseGoalLocations(out int goalsToLocations[32])
     // build list of availLocs based on flags, also count _num_starts
     _num_locs = 0;
     _num_starts = 0;
+    goalsToLocations[num_goals] = -1;
     for(i=0; i<num_locations; i++) {
         // exclude the vanilla start locations if randomized starting locations are disabled
-        if( dxr.flags.settings.startinglocations <= 0 && (VANILLA_START & locations[i].bitMask) != 0 )
+        if( dxr.flags.settings.startinglocations <= 0 && (VANILLA_START & locations[i].bitMask) != 0 ) {
+            goalsToLocations[num_goals] = i; // write this as the start location so mutual exclusions work
             continue;
+        }
         // exclude the vanilla goal locations if randomized goal locations are disabled
         if( dxr.flags.settings.goals <= 0 && (VANILLA_GOAL & locations[i].bitMask) != 0 )
             continue;
 
         if( (START_LOCATION & locations[i].bitMask) != 0) {
-            goalLocs[_num_starts++] = _num_locs;
+            goalLocs[_num_starts++] = _num_locs;// build temporary goalLocs
         }
         availLocs[_num_locs++] = i;
     }
 
     // choose a starting location
     goalsToLocations[num_goals] = -1;
-    if(_num_starts > 0) {
+    if(_num_starts > 0 && goalsToLocations[num_goals] == -1) {
         _num_goal_locs = _num_starts;
         r = rng(_num_goal_locs);
         a = goalLocs[r];
@@ -510,6 +513,7 @@ function bool _ChooseGoalLocations(out int goalsToLocations[32])
     }
 
     if(num_goals == 0) return true;
+    if(dxr.flags.settings.goals <= 0) return true;
 
     // do the goals in a random order
     for(i=0; i<num_goals; i++) {

--- a/DXRModules/DeusEx/Classes/DXRReduceItems.uc
+++ b/DXRModules/DeusEx/Classes/DXRReduceItems.uc
@@ -38,55 +38,57 @@ function CheckConfig()
         mission_scaling[i] = 100;
     }
 
-    i=0;
-    _item_reductions[i].type = class'#var(prefix)Ammo10mm';
-    _item_reductions[i].percent = 85;
-    i++;
+    if(class'MenuChoice_BalanceItems'.static.IsEnabled()) {
+        i=0;
+        _item_reductions[i].type = class'#var(prefix)Ammo10mm';
+        _item_reductions[i].percent = 85;
+        i++;
 
-    _item_reductions[i].type = class'#var(prefix)AmmoPlasma';
-    _item_reductions[i].percent = 130;
-    i++;
+        _item_reductions[i].type = class'#var(prefix)AmmoPlasma';
+        _item_reductions[i].percent = 130;
+        i++;
 
-    _item_reductions[i].type = class'#var(prefix)Ammo762mm';
-    _item_reductions[i].percent = 85;
-    i++;
+        _item_reductions[i].type = class'#var(prefix)Ammo762mm';
+        _item_reductions[i].percent = 85;
+        i++;
 
-    _item_reductions[i].type = class'#var(prefix)AmmoShell';
-    _item_reductions[i].percent = 85;
-    i++;
+        _item_reductions[i].type = class'#var(prefix)AmmoShell';
+        _item_reductions[i].percent = 85;
+        i++;
 
-    _item_reductions[i].type = class'#var(prefix)AmmoDart';
-    _item_reductions[i].percent = 120;
-    i++;
+        _item_reductions[i].type = class'#var(prefix)AmmoDart';
+        _item_reductions[i].percent = 120;
+        i++;
 
-    _item_reductions[i].type = class'#var(prefix)AmmoDartFlare';
-    _item_reductions[i].percent = 120;
-    i++;
+        _item_reductions[i].type = class'#var(prefix)AmmoDartFlare';
+        _item_reductions[i].percent = 120;
+        i++;
 
-    i=0;
-    _max_ammo[i].type = class'#var(prefix)Ammo10mm';
-    _max_ammo[i].percent = 60;
-    i++;
+        i=0;
+        _max_ammo[i].type = class'#var(prefix)Ammo10mm';
+        _max_ammo[i].percent = 60;
+        i++;
 
-    _max_ammo[i].type = class'#var(prefix)AmmoPlasma';
-    _max_ammo[i].percent = 130;
-    i++;
+        _max_ammo[i].type = class'#var(prefix)AmmoPlasma';
+        _max_ammo[i].percent = 130;
+        i++;
 
-    _max_ammo[i].type = class'#var(prefix)Ammo762mm';
-    _max_ammo[i].percent = 85;
-    i++;
+        _max_ammo[i].type = class'#var(prefix)Ammo762mm';
+        _max_ammo[i].percent = 85;
+        i++;
 
-    _max_ammo[i].type = class'#var(prefix)AmmoShell';
-    _max_ammo[i].percent = 85;
-    i++;
+        _max_ammo[i].type = class'#var(prefix)AmmoShell';
+        _max_ammo[i].percent = 85;
+        i++;
 
-    _max_ammo[i].type = class'#var(prefix)AmmoDart';
-    _max_ammo[i].percent = 130;
-    i++;
+        _max_ammo[i].type = class'#var(prefix)AmmoDart';
+        _max_ammo[i].percent = 130;
+        i++;
 
-    _max_ammo[i].type = class'#var(prefix)AmmoDartFlare';
-    _max_ammo[i].percent = 130;
-    i++;
+        _max_ammo[i].type = class'#var(prefix)AmmoDartFlare';
+        _max_ammo[i].percent = 130;
+        i++;
+    }
 
     Super.CheckConfig();
 }
@@ -441,9 +443,11 @@ simulated function SetMaxCopies(class<DeusExPickup> type, int percent)
 
         f = float(percent) / 100.0;
         f *= _GetItemMult(_item_reductions, p.class);
-        f *= rngrangeseeded(1, 0.8, 1.2, p.class.name);
-        p.maxCopies = float(p.default.maxCopies) * f * 0.8;
-        p.maxCopies = Clamp(p.maxCopies, 1, p.default.maxCopies*10);
+        f *= float(p.default.maxCopies);
+        if(percent < 100) {
+            f *= rngrangeseeded(1, 0.8, 1.2, p.class.name) * 0.8;
+        }
+        p.maxCopies = Clamp(f, 1, p.default.maxCopies*10);
         owner = #var(PlayerPawn)(p.Owner);
         if(owner == None)
             owner = player(true);
@@ -474,9 +478,11 @@ simulated function SetMaxAmmo(class<Ammo> type, int percent)
 
         f = float(percent) / 100.0;
         f *= _GetItemMult(_max_ammo, a.class);
-        f *= rngrangeseeded(1, 0.8, 1.2, a.class.name);
-        a.MaxAmmo = float(a.default.MaxAmmo) * f * 0.8;
-        a.MaxAmmo = Clamp(a.MaxAmmo, 1, a.default.MaxAmmo*10);
+        f *= float(a.default.MaxAmmo);
+        if(percent < 100) {
+            f *= rngrangeseeded(1, 0.8, 1.2, a.class.name) * 0.8;
+        }
+        a.MaxAmmo = Clamp(f, 1, a.default.MaxAmmo*10);
 
         owner = #var(PlayerPawn)(a.Owner);
         if(owner == None)

--- a/DXRModules/DeusEx/Classes/DXRWeapons.uc
+++ b/DXRModules/DeusEx/Classes/DXRWeapons.uc
@@ -119,6 +119,10 @@ simulated function bool RandoProjectile(DeusExWeapon w, out class<Projectile> p,
         d = p;
         p.default.Damage = ratio * f;
         w.HitDamage = ratio * f;// write back the weapon damage
+        if(class'MenuChoice_BalanceItems'.static.IsDisabled()) {
+            p = class'#var(prefix)PlasmaBolt';
+            d = p;
+        }
         break;
 
     case class'#var(prefix)Rocket':
@@ -128,6 +132,10 @@ simulated function bool RandoProjectile(DeusExWeapon w, out class<Projectile> p,
         d = p;
     case class'RocketFixTicks':// no break
         p.default.Damage = ratio * 300.0;
+        if(class'MenuChoice_BalanceItems'.static.IsDisabled()) {
+            p = class'#var(prefix)Rocket';
+            d = p;
+        }
         break;
 
     case class'#var(prefix)RocketWP':
@@ -135,12 +143,16 @@ simulated function bool RandoProjectile(DeusExWeapon w, out class<Projectile> p,
         break;
 
     case class'#var(prefix)HECannister20mm':
-        // normally the damage should be * 150, but that means a 50% damage rifle could have trouble breaking many doors even with only 3 explosion ticks
-        p.default.Damage = ratio * 180.0;
+        p.default.Damage = ratio * 150.0;
         p = class'HECannisterFixTicks';
         d = p;
     case class'HECannisterFixTicks':// no break
+        // normally the damage should be * 150, but that means a 50% damage rifle could have trouble breaking many doors even with only 3 explosion ticks
         p.default.Damage = ratio * 180.0;
+        if(class'MenuChoice_BalanceItems'.static.IsDisabled()) {
+            p = class'#var(prefix)HECannister20mm';
+            d = p;
+        }
         break;
 
     case class'#var(prefix)Shuriken':

--- a/DXRVanilla/DeusEx/Classes/Augmentation.uc
+++ b/DXRVanilla/DeusEx/Classes/Augmentation.uc
@@ -27,7 +27,7 @@ simulated function SetAutomatic()
         energyRate = default.energyRate;
     }
 
-    if(class'MenuChoice_AutoAugs'.default.enabled) {
+    if(class'MenuChoice_AutoAugs'.static.IsEnabled()) {
         bAutomatic = default.bAutomatic;
         UpdateBalance(); // make sure energyRate is correct
         if(bAutomatic) {

--- a/DXRVanilla/DeusEx/Classes/Weapon.uc
+++ b/DXRVanilla/DeusEx/Classes/Weapon.uc
@@ -173,10 +173,16 @@ simulated function bool NearWallCheck()
 
     // trace out one foot in front of the pawn
     StartTrace = Owner.Location;
-    EndTrace = StartTrace + Vector(Pawn(Owner).ViewRotation) * 50;
-
-    StartTrace.Z += Pawn(Owner).EyeHeight;
-    EndTrace.Z += Pawn(Owner).EyeHeight;
+    if(class'MenuChoice_BalanceItems'.static.IsEnabled()) {
+        EndTrace = StartTrace + Vector(Pawn(Owner).ViewRotation) * 50;
+        StartTrace.Z += Pawn(Owner).EyeHeight;
+        EndTrace.Z += Pawn(Owner).EyeHeight;
+    }
+    else {
+        EndTrace = StartTrace + Vector(Pawn(Owner).ViewRotation) * 32;
+        StartTrace.Z += Pawn(Owner).BaseEyeHeight;
+        EndTrace.Z += Pawn(Owner).BaseEyeHeight;
+    }
 
     HitActor = Trace(HitLocation, HitNormal, EndTrace, StartTrace);
     if ((HitActor == Level) || ((HitActor != None) && HitActor.IsA('Mover')))

--- a/DXRando/DeusEx/Classes/DXRHoverHint.uc
+++ b/DXRando/DeusEx/Classes/DXRHoverHint.uc
@@ -78,7 +78,7 @@ function SetBaseActor(Actor base)
     }
 }
 
-function bool ShouldDisplay(float dist)
+function bool _ShouldDisplay(float dist)
 {
     if (dist > VisibleDistance){
         return False;
@@ -98,6 +98,15 @@ function bool ShouldDisplay(float dist)
     }
 
     return True;
+}
+
+function bool ShouldDisplay(float dist)
+{
+    if (_ShouldDisplay(dist)==False){
+        return False;
+    }
+
+    return !class'DXRFlags'.default.bZeroRando;
 }
 
 function bool ShouldSelfDestruct()

--- a/DXRando/DeusEx/Classes/DXRTeleporterHoverHint.uc
+++ b/DXRando/DeusEx/Classes/DXRTeleporterHoverHint.uc
@@ -71,7 +71,7 @@ function String GetHintText()
 
 function bool ShouldDisplay(float dist)
 {
-    if (Super.ShouldDisplay(dist)==False){
+    if (_ShouldDisplay(dist)==False){
         return False;
     }
 

--- a/DXRando/DeusEx/Classes/FacePlayerTrigger.uc
+++ b/DXRando/DeusEx/Classes/FacePlayerTrigger.uc
@@ -1,0 +1,58 @@
+//This trigger makes the targeted pawn turn to face towards the player when activated (by touch or trigger)
+class FacePlayerTrigger extends Trigger;
+
+function Touch(Actor Other)
+{
+    Super.Touch(Other);
+
+    if (IsRelevant(Other))
+    {
+        FacePlayer();
+        if(bTriggerOnceOnly) Destroy();
+    }
+}
+
+event Trigger( Actor Other, Pawn EventInstigator )
+{
+    FacePlayer();
+    if(bTriggerOnceOnly) Destroy();
+}
+
+
+function FacePlayer()
+{
+    local #var(prefix)ScriptedPawn sp;
+    local #var(PlayerPawn) player;
+
+    if (Event != '') {
+        foreach AllActors(class'#var(PlayerPawn)',player){break;}
+        if (player==None) return;
+
+        foreach AllActors(class '#var(prefix)ScriptedPawn', sp, Event) {
+            sp.LookAtActor(player,true,true,true);
+        }
+    }
+
+}
+
+static function FacePlayerTrigger Create(Actor a, Name event, vector loc, optional float rad, optional float height)
+{
+    local FacePlayerTrigger fpt;
+
+    fpt = a.Spawn(class'FacePlayerTrigger',,,loc);
+    fpt.event = event;
+
+    if (rad!=0 && height!=0){
+        fpt.SetCollisionSize(rad,height); //You want collision
+    } else {
+        fpt.SetCollision(False,False,False); //Disable collision, trigger only
+    }
+
+    return fpt;
+
+}
+
+defaultproperties
+{
+    bTriggerOnceOnly=true
+}

--- a/DXRando/DeusEx/Classes/FacePlayerTrigger.uc
+++ b/DXRando/DeusEx/Classes/FacePlayerTrigger.uc
@@ -23,6 +23,7 @@ function FacePlayer()
 {
     local #var(prefix)ScriptedPawn sp;
     local #var(PlayerPawn) player;
+    local name cloneevent;
 
     if (Event != '') {
         foreach AllActors(class'#var(PlayerPawn)',player){break;}
@@ -31,15 +32,21 @@ function FacePlayer()
         foreach AllActors(class '#var(prefix)ScriptedPawn', sp, Event) {
             sp.LookAtActor(player,true,true,true);
         }
+
+        //Also apply to any clones
+        cloneevent = class'DXRInfo'.static.StringToName(Event $ "_clone");
+        foreach AllActors(class '#var(prefix)ScriptedPawn', sp, cloneevent) {
+            sp.LookAtActor(player,true,true,true);
+        }
     }
 
 }
 
-static function FacePlayerTrigger Create(Actor a, Name event, vector loc, optional float rad, optional float height)
+static function FacePlayerTrigger Create(Actor a, name Tag, Name event, vector loc, optional float rad, optional float height)
 {
     local FacePlayerTrigger fpt;
 
-    fpt = a.Spawn(class'FacePlayerTrigger',,,loc);
+    fpt = a.Spawn(class'FacePlayerTrigger',,Tag,loc);
     fpt.event = event;
 
     if (rad!=0 && height!=0){

--- a/DXRando/DeusEx/Classes/HECannisterFixTicks.uc
+++ b/DXRando/DeusEx/Classes/HECannisterFixTicks.uc
@@ -19,5 +19,5 @@ Begin:
 // MomentumTransfer vanilla is 40000 for some reason
 defaultproperties
 {
-    MomentumTransfer=10000
+    MomentumTransfer=9001
 }

--- a/DXRando/DeusEx/Classes/PlasmaBoltFixTicks.uc
+++ b/DXRando/DeusEx/Classes/PlasmaBoltFixTicks.uc
@@ -16,12 +16,10 @@ Begin:
     SetTimer(0.25/float(gradualHurtSteps), True);
 }
 
-// vanilla MomentumTransfer is 5000
 defaultproperties
 {
     blastRadius=128
     Damage=18
-    MomentumTransfer=6000
 #ifndef hx
     mpDamage=18
     mpBlastRadius=128

--- a/DXRando/DeusEx/Classes/PlayerDataItem.uc
+++ b/DXRando/DeusEx/Classes/PlayerDataItem.uc
@@ -1,6 +1,7 @@
 class PlayerDataItem extends Inventory config(DXRBingo);
 
-const FAILED_MISSION_MASK = 1;
+const FAILED_MISSION_MASK = 1; // probably failed
+const ABSOLUTELY_FAILED_MISSION_MASK = 0xFFFFFFFF;
 
 var travel bool local_inited;
 var travel int version, initial_version;
@@ -154,13 +155,17 @@ simulated function int GetBingoMissionMask(int x, int y)
     return bingo_missions_masks[x*5+y];
 }
 
-simulated function bool IncrementBingoProgress(string event)
+simulated function bool IncrementBingoProgress(string event, bool ifNotFailed)
 {
     local int i;
     for(i=0; i<ArrayCount(bingo); i++) {
         if(!(bingo[i].event ~= event)) continue;
-        if((bingo_missions_masks[i] & FAILED_MISSION_MASK)!=0) {
-            log(self$".IncrementBingoProgress("$event$") not incrementing because the goal is already marked as failed");
+        if(bingo_missions_masks[i] == ABSOLUTELY_FAILED_MISSION_MASK) {
+            log(self$".IncrementBingoProgress("$event$") not incrementing because the goal is already marked as absolutely failed");
+            break;
+        }
+        if(ifNotFailed && (bingo_missions_masks[i] & FAILED_MISSION_MASK)!=0) {
+            log(self$".IncrementBingoProgress("$event$") not incrementing because the goal is already marked as probably failed");
             break;
         }
         bingo[i].progress++;

--- a/DXRando/DeusEx/Classes/WaterCooler.uc
+++ b/DXRando/DeusEx/Classes/WaterCooler.uc
@@ -8,6 +8,7 @@ function Frob(Actor Frobber, Inventory frobWith)
     local bool oldUsing, newUsing;
     local int oldNumUses;
     local bool chugged;
+    local float cooldown;
 
 #ifdef hx
     oldUsing = BubbleTime > 0.0;
@@ -24,12 +25,18 @@ function Frob(Actor Frobber, Inventory frobWith)
 #endif
 
     if (newUsing && !oldUsing) {
+        if(class'MenuChoice_BalanceEtc'.static.IsEnabled() || #defined(vmd)) {
+            cooldown = 0.4;
+        } else {
+            cooldown = 2;
+        }
+
         if(!#defined(vmd))
-            SetTimer(0.4, False);
+            SetTimer(cooldown, False);
         if( oldNumUses == default.numUses || (#defined(vmd) && timesUsed==0) )
             firstUse = Level.TimeSeconds;
         timesUsed++;
-        chugged = numUses <= 0 && oldNumUses > 0 && firstUse > 0 && Level.TimeSeconds - firstUse < 6;
+        chugged = numUses <= 0 && oldNumUses > 0 && firstUse > 0 && Level.TimeSeconds - firstUse < cooldown*15;
         if(#defined(vmd)) {
             chugged = timesUsed == 5 && firstUse > 0 && Level.TimeSeconds - firstUse < 15;
         }

--- a/DXRando/DeusEx/Classes/WaterFountain.uc
+++ b/DXRando/DeusEx/Classes/WaterFountain.uc
@@ -8,6 +8,7 @@ function Frob(Actor Frobber, Inventory frobWith)
     local bool oldUsing, newUsing;
     local int oldNumUses;
     local bool chugged;
+    local float cooldown;
 
 #ifdef hx
     oldUsing = BubbleTime > 0.0;
@@ -24,12 +25,18 @@ function Frob(Actor Frobber, Inventory frobWith)
 #endif
 
     if (newUsing && !oldUsing) {
+        if(class'MenuChoice_BalanceEtc'.static.IsEnabled() || #defined(vmd)) {
+            cooldown = 0.4;
+        } else {
+            cooldown = 2;
+        }
+
         if(!#defined(vmd))
-            SetTimer(0.4, False);
+            SetTimer(cooldown, False);
         if( oldNumUses == default.numUses || (#defined(vmd) && timesUsed==0) )
             firstUse = Level.TimeSeconds;
         timesUsed++;
-        chugged = numUses <= 0 && oldNumUses > 0 && firstUse > 0 && Level.TimeSeconds - firstUse < 6;
+        chugged = numUses <= 0 && oldNumUses > 0 && firstUse > 0 && Level.TimeSeconds - firstUse < cooldown*15;
         if(#defined(vmd)) {
             chugged = timesUsed == 5 && firstUse > 0 && Level.TimeSeconds - firstUse < 15;
         }

--- a/GUI/DeusEx/Classes/BingoHintMsgBox.uc
+++ b/GUI/DeusEx/Classes/BingoHintMsgBox.uc
@@ -5,16 +5,6 @@ class BingoHintMsgBox extends MenuUIMessageBoxWindow;
 
 var PersonaScrollAreaWindow winScroll;
 
-event InitWindow()
-{
-	Super.InitWindow();
-
-	btnOK = winButtonBar.AddButton(btnLabelOK, HALIGN_Right);
-
-	numButtons = 1;
-	SetFocusWindow(btnOK);
-}
-
 function CreateTextWindow()
 {
     winScroll = PersonaScrollAreaWindow(winClient.NewChild(Class'PersonaScrollAreaWindow'));
@@ -24,8 +14,27 @@ function CreateTextWindow()
     winScroll.SetSize(490,95);
 
     winText.SetTextAlignments(HALIGN_Left, VALIGN_Center);
-	winText.SetFont(Font'FontMenuHeaders_DS');
-	winText.SetWindowAlignments(HALIGN_Full, VALIGN_Full, textBorderX, textBorderY);
+    winText.SetFont(Font'FontMenuHeaders_DS');
+    winText.SetWindowAlignments(HALIGN_Full, VALIGN_Full, textBorderX, textBorderY);
+}
+
+static function BingoHintMsgBox Create
+    (
+    DeusExRootWindow root,
+    String msgTitle,
+    String msgText,
+    int msgBoxMode,
+    bool hideCurrentScreen,
+    Window winParent
+    )
+{
+    local BingoHintMsgBox msgbox;
+    msgbox = BingoHintMsgBox(root.PushWindow(class'BingoHintMsgBox', hideCurrentScreen));
+    msgbox.SetTitle(msgTitle);
+    msgbox.SetMessageText(msgText);
+    msgBox.SetMode(msgBoxMode);
+    msgbox.SetNotifyWindow(winParent);
+    return msgbox;
 }
 
 defaultproperties

--- a/GUI/DeusEx/Classes/BingoTile.uc
+++ b/GUI/DeusEx/Classes/BingoTile.uc
@@ -41,7 +41,7 @@ event DrawWindow(GC gc)
         gc.SetStyle(DSTY_Normal);
         gc.DrawPattern(0, 0, width, height, 0, 0, Texture'Solid');
     }
-    else if(bActiveMission==-1) {
+    else if(bActiveMission==-1 && progress<max) {
         c.R = 30;
         c.G = 0;
         c.B = 0;
@@ -123,7 +123,7 @@ simulated function string GetHelpText()
     helpmsg=helpmsg$"|n|n"$GenerateMissionString();
 
     //mention that the goal has been failed (bit 0: FAILED_MISSION_MASK)
-    if ((missions & 1)!=0){
+    if ((missions & 1)!=0 && progress<max){
         helpmsg=helpmsg$"|n";
         helpmsg = helpmsg $ "Progress: Failed";
     } else if (max>1){ //Or show actual progress towards the goal

--- a/GUI/DeusEx/Classes/DXRPersonaImageGoalHintWindow.uc
+++ b/GUI/DeusEx/Classes/DXRPersonaImageGoalHintWindow.uc
@@ -4,7 +4,6 @@ class DXRPersonaImageGoalHintWindow expands PersonaImageNoteWindow;
 event bool MouseButtonPressed(float pointX, float pointY, EInputKey button,
                               int numClicks)
 {
-    local BingoHintMsgBox msgbox;
     local DXRDataVaultMapImageNote note;
 
     note = DXRDataVaultMapImageNote(GetNote());
@@ -12,13 +11,9 @@ event bool MouseButtonPressed(float pointX, float pointY, EInputKey button,
     if (note==None){
         return false;
     }
-    
-    msgbox = BingoHintMsgBox(DeusExRootWindow(player.rootWindow).PushWindow(class'BingoHintMsgBox',False));
-    msgbox.SetTitle(note.HelpTitle);
-    msgbox.SetMessageText(note.HelpText);
-    msgbox.SetNotifyWindow(Self);
 
-	return true;
+    class'BingoHintMsgBox'.static.Create(DeusExRootWindow(player.rootWindow), note.HelpTitle, note.HelpText, 1, False, self);
+    return true;
 }
 
 event bool BoxOptionSelected(Window msgBoxWindow, int buttonNumber)

--- a/GUI/DeusEx/Classes/FrobDisplayWindow.uc
+++ b/GUI/DeusEx/Classes/FrobDisplayWindow.uc
@@ -282,6 +282,8 @@ function string GetStrInfo(Actor a, out int numLines)
         return WeaponStrInfo(#var(DeusExPrefix)Weapon(a),numLines);
     else if ( #var(prefix)BeamTrigger(a)!=None || #var(prefix)LaserTrigger(a)!=None)
         return LaserStrInfo(a,numLines);
+    else if ( #var(prefix)AugmentationCannister(a) != None )
+        return AugCanStrInfo(#var(prefix)AugmentationCannister(a));
     else if (!a.bStatic && player.bObjectNames)
         return OtherStrInfo(a, numLines);
 
@@ -661,6 +663,28 @@ function string LaserStrInfo(Actor a, out int numLines)
     return strInfo;
 }
 
+function string AugCanStrInfo(#var(prefix)AugmentationCannister augCan) {
+    local Augmentation anAug, aug0, aug1;
+    local string strInfo;
+
+    if (player == None)
+        return augCan.ItemName;
+
+    for (anAug = player.AugmentationSystem.FirstAug; anAug != None; anAug = anAug.next) {
+        if (augCan.addAugs[0] == anAug.Class.Name)
+            aug0 = anAug;
+        if (augCan.addAugs[1] == anAug.Class.Name)
+            aug1 = anAug;
+    }
+
+    strInfo = augCan.ItemName;
+    if (aug0 != None)
+        strInfo = strInfo $ CR() $ "  " $ aug0.AugmentationName $ " (" $ aug0.AugLocsText[aug0.AugmentationLocation] $ ")";
+    if (aug1 != None)
+        strInfo = strInfo $ CR() $ "  " $ aug1.AugmentationName $ " (" $ aug1.AugLocsText[aug1.AugmentationLocation] $ ")";
+
+    return strInfo;
+}
 
 function bool WeaponModAutoApply(WeaponMod wm)
 {
@@ -672,7 +696,6 @@ function bool WeaponModAutoApply(WeaponMod wm)
     return True;
 
 }
-
 
 function string OtherStrInfo(Actor frobTarget, out int numLines)
 {

--- a/GUI/DeusEx/Classes/MenuChoice_AccordingToGameMode.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_AccordingToGameMode.uc
@@ -3,7 +3,7 @@ class MenuChoice_AccordingToGameMode extends DXRMenuUIChoiceInt;
 // works fine in BeginPlay because that only happens when traveling, but flags aren't loaded quickly enough for PostPostBeginPlay when loading a save and the game mode of the title screen was different from the save game
 static function bool IsEnabled()
 {
-    return (default.value==2) || (default.value==1 && !class'DXRFlags'.default.bZeroRandoPure);
+    return (default.value>=2) || (default.value==1 && !class'DXRFlags'.default.bZeroRandoPure);
 }
 
 static function bool IsDisabled()

--- a/GUI/DeusEx/Classes/MenuChoice_AccordingToGameMode.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_AccordingToGameMode.uc
@@ -1,0 +1,26 @@
+class MenuChoice_AccordingToGameMode extends DXRMenuUIChoiceInt;
+
+// works fine in BeginPlay because that only happens when traveling, but flags aren't loaded quickly enough for PostPostBeginPlay when loading a save and the game mode of the title screen was different from the save game
+static function bool IsEnabled()
+{
+    return (default.value==2) || (default.value==1 && !class'DXRFlags'.default.bZeroRandoPure);
+}
+
+static function bool IsDisabled()
+{
+    return !IsEnabled();
+}
+
+defaultproperties
+{
+    value=1
+    defaultvalue=1
+    defaultInfoWidth=243
+    defaultInfoPosX=203
+    HelpText=""
+    actionText=""
+    enumText(0)="Disabled"
+    enumText(1)="According to Game Mode"
+    enumText(2)="Enabled"
+}
+

--- a/GUI/DeusEx/Classes/MenuChoice_AutoAugs.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_AutoAugs.uc
@@ -1,4 +1,4 @@
-class MenuChoice_AutoAugs extends DXRMenuUIChoiceBool;
+class MenuChoice_AutoAugs extends MenuChoice_AccordingToGameMode;
 
 #ifdef injections
 function SaveSetting()
@@ -14,10 +14,8 @@ function SaveSetting()
 
 defaultproperties
 {
-    enabled=True
-    defaultvalue=True
     HelpText="Some augmentations will only use energy while in effect."
     actionText="Semi-Automatic Augs"
     enumText(0)="Manual Augs"
-    enumText(1)="Semi-Automatic Augs"
+    enumText(2)="Semi-Automatic Augs"
 }

--- a/GUI/DeusEx/Classes/MenuChoice_AutoLamps.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_AutoLamps.uc
@@ -1,11 +1,9 @@
-class MenuChoice_AutoLamps extends DXRMenuUIChoiceBool;
+class MenuChoice_AutoLamps extends MenuChoice_AccordingToGameMode;
 
 defaultproperties
 {
-    enabled=True
-    defaultvalue=True
     HelpText="Should lamps start turned on where it logically makes sense?"
     actionText="Lamps"
     enumText(0)="On/Off As In the Original Game"
-    enumText(1)="Most Start On"
+    enumText(2)="Most Start On"
 }

--- a/GUI/DeusEx/Classes/MenuChoice_BalanceEtc.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_BalanceEtc.uc
@@ -1,15 +1,4 @@
-class MenuChoice_BalanceEtc extends DXRMenuUIChoiceInt;
-
-// works fine in BeginPlay because that only happens when traveling, but flags aren't loaded quickly enough for PostPostBeginPlay when loading a save and the game mode of the title screen was different from the save game
-static function bool IsEnabled()
-{
-    return (default.value==2) || (default.value==1 && !class'DXRFlags'.default.bZeroRandoPure);
-}
-
-static function bool IsDisabled()
-{
-    return !IsEnabled();
-}
+class MenuChoice_BalanceEtc extends MenuChoice_AccordingToGameMode;
 
 event InitWindow()
 {
@@ -24,13 +13,8 @@ event InitWindow()
 
 defaultproperties
 {
-    value=1
-    defaultvalue=1
-    defaultInfoWidth=243
-    defaultInfoPosX=203
     HelpText="Miscellaneous balance changes."
     actionText="Other Balance Changes"
     enumText(0)="Disabled"
-    enumText(1)="According to Game Mode"
     enumText(2)="Enabled"
 }

--- a/GUI/DeusEx/Classes/MenuChoice_BalanceMaps.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_BalanceMaps.uc
@@ -1,22 +1,27 @@
 class MenuChoice_BalanceMaps extends MenuChoice_BalanceEtc;
 
-static function bool AnyEnabled()
+static function bool MinorEnabled()
 {
-    return (default.value==2) || (default.value==1 && !class'DXRFlags'.default.bZeroRandoPure);
+    return default.value>0;
 }
 
-static function bool ManyEnabled()
+static function bool ModerateEnabled()
 {
-    return (default.value==2) || (default.value==1 && !class'DXRFlags'.default.bZeroRando);
+    return (default.value>2) || (default.value==1 && !class'DXRFlags'.default.bZeroRando);
 }
 
-static function bool AllEnabled()
+static function bool MajorEnabled()
 {
-    return (default.value==2) || (default.value==1 && !class'DXRFlags'.default.bReducedRando);
+    return (default.value>3) || (default.value==1 && !class'DXRFlags'.default.bReducedRando);
 }
 
 defaultproperties
 {
     HelpText="Balance changes for maps."
     actionText="Maps Balance Changes"
+    enumText(0)="All Disabled"
+    enumText(1)="According to Game Mode"
+    enumText(2)="Minor Enabled"
+    enumText(3)="Moderate Enabled"
+    enumText(4)="All Enabled"
 }

--- a/GUI/DeusEx/Classes/MenuChoice_NewGamePlus.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_NewGamePlus.uc
@@ -1,4 +1,4 @@
-class MenuChoice_NewGamePlus extends DXRMenuUIChoiceInt;
+class MenuChoice_NewGamePlus extends MenuChoice_AccordingToGameMode;
 
 /* just let DXRFlags take care of this directly
 static function bool IsEnabled(DXRFlags f)
@@ -9,13 +9,8 @@ static function bool IsEnabled(DXRFlags f)
 
 defaultproperties
 {
-    value=1
-    defaultvalue=1
-    defaultInfoWidth=243
-    defaultInfoPosX=203
     HelpText="Should New Game+ be enabled by default? Also adjustable inside Advanced settings via New Game+ Scaling %."
     actionText="New Game+"
     enumText(0)="Disabled"
-    enumText(1)="According to Game Mode"
     enumText(2)="Enabled"
 }

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
@@ -36,7 +36,7 @@ function CreateChoices()
     CreateChoice(class'MenuChoice_BalanceAugs');
     CreateChoice(class'MenuChoice_BalanceSkills');
     CreateChoice(class'MenuChoice_BalanceItems');
-    //CreateChoice(class'MenuChoice_BalanceMaps');// TODO: change everything in DXRMapFixups to use this, most can be done with find/replace
+    CreateChoice(class'MenuChoice_BalanceMaps');
     CreateChoice(class'MenuChoice_BalanceEtc');
 #endif
 }

--- a/GUI/DeusEx/Classes/PersonaScreenBingo.uc
+++ b/GUI/DeusEx/Classes/PersonaScreenBingo.uc
@@ -105,7 +105,6 @@ function bool ResetBingoBoard()
 function ShowBingoGoalHelp( Window bingoTile )
 {
     local BingoTile bt;
-    local BingoHintMsgBox msgbox;
 
     bt=BingoTile(bingoTile);
 
@@ -114,33 +113,23 @@ function ShowBingoGoalHelp( Window bingoTile )
         return;
     }
 
-    msgbox = BingoHintMsgBox(root.PushWindow(class'BingoHintMsgBox',False));
+    class'BingoHintMsgBox'.static.Create(root, bt.GetText(), bt.GetHelpText(), 1, False, self);
     if(#defined(bingocheat)) {
         class'DXREvents'.static.MarkBingo(bt.event);
         bt.progress++;
     }
-    msgbox.SetTitle(bt.GetText());
-    msgbox.SetMessageText(bt.GetHelpText());
-    msgbox.SetNotifyWindow(Self);
 }
 
 function bool ButtonActivated( Window buttonPressed )
 {
     local int val;
-    local BingoHintMsgBox msgbox;
 
     if(buttonPressed == btnReset) {
         root.MessageBox(ResetWindowHeader,ResetWindowText,0,False,Self);
-
         return true;
     }
     else if(buttonPressed == btnBingoInfo) {
-        //root.MessageBox(InfoWindowHeader,InfoWindowText,0,False,Self);
-        msgbox = BingoHintMsgBox(root.PushWindow(class'BingoHintMsgBox',False));
-        msgbox.SetTitle(InfoWindowHeader);
-        msgbox.SetMessageText(InfoWindowText);
-        msgbox.SetNotifyWindow(Self);
-
+        class'BingoHintMsgBox'.static.Create(root, InfoWindowHeader, InfoWindowText, 1, False, self);
         return true;
     }
     else if(BingoTile(buttonPressed)!=None){


### PR DESCRIPTION
# v3.3.2.5 Alpha

- # renamed Normal Randomizer to Full Randomizer, new default game mode is called Normal Randomizer and tones some things down for new players
- some more balance changes removed from Zero Rando 
- slightly reduce knockback, fix knockback causing enemies in water to get stuck or frozen
- Morgan Everett turns to face the player as they enter his lab
- Area 51 Reactor Mechanic now turns to face the player and goes hostile instead of directly attacking the player (so that he doesn't break stealth)
- fixed Zero Rando ScaleZoneDamage() 
- Zero Rando removed aug/skill description stats
- Zero Rando fixed max ammo and maxCopies for items
- "According to Game Mode" option for lamps and auto augs
- Stealth fixes for M05 Anna and Manderley, Ocean Lab muncher karkian turns to face instead of attacking.
- Leo Gold, El Rey, and the terrorist guarding Gilbert in the hotel no longer receive Attacking orders (and are made hostile instead) 
- setting game mode to Zero Rando instantly changes mirrored maps to 0%
- warnings for new player trying difficult game mode or autosave setting
- Show augmentation slorts in aug highlight text
- Fixed position of M08 Basketball Court MJ12 Troops, so that they all have a path out of the court

### previously in v3.3.2.4 Alpha: https://github.com/Die4Ever/deus-ex-randomizer/pull/1108

### Previously in v3.3.2.3 Alpha: https://github.com/Die4Ever/deus-ex-randomizer/pull/1101

### Previously in v3.3.2.2 Alpha: https://github.com/Die4Ever/deus-ex-randomizer/pull/1096

### Previously in v3.3.2.1 Alpha: https://github.com/Die4Ever/deus-ex-randomizer/pull/1091 (only minor changes)