### PR TITLE
DestroyTrigger and Nicolette

### DIFF
--- a/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -27,6 +27,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)NanoKey k;
     local DXRMoverSequenceTrigger elevatortrig;
     local #var(injectsprefix)OrdersTrigger ot;
+    local DestroyTrigger desTrig;
     local #var(injectsprefix)AllianceTrigger at;
     local Actor a;
 
@@ -201,10 +202,9 @@ function PreFirstEntryMapFixes()
             RemoveFears(j);
         }
 
-        ot = Spawn(class'#var(injectsprefix)OrdersTrigger',, 'NicoLeaving');
-        ot.Orders = 'Leaving';
-        ot.Event = '#var(prefix)NicoletteDuClare';
-        ot.SetCollision(false, false, false);
+        desTrig = Spawn(class'DestroyTrigger',, 'NicoLeaving');
+        desTrig.Event = 'NicoletteDuClare';
+        desTrig.SetCollision(false, false, false);
 
         break;
 

--- a/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -203,7 +203,7 @@ function PreFirstEntryMapFixes()
         }
 
         desTrig = Spawn(class'DestroyTrigger',, 'NicoLeaving');
-        desTrig.Event = 'NicoletteDuClare';
+        desTrig.Event = '#var(prefix)NicoletteDuClare';
         desTrig.SetCollision(false, false, false);
 
         break;

--- a/DXRModules/DeusEx/Classes/DXRBacktracking.uc
+++ b/DXRModules/DeusEx/Classes/DXRBacktracking.uc
@@ -366,11 +366,6 @@ function ParisMetroAnyEntry()
 
         RebindChopperHoverHint('ChopperExit',chopper);
     }
-
-    /*if( flags.GetBool('ClubComplete') ) {
-        // switch back to her dialog when she's ready to get in the chopper
-        flags.SetBool('ClubComplete', false,, 12);
-    }*/
 }
 
 function ParisChateauAnyEntry()

--- a/DXRando/DeusEx/Classes/DestroyTrigger.uc
+++ b/DXRando/DeusEx/Classes/DestroyTrigger.uc
@@ -1,0 +1,12 @@
+class DestroyTrigger extends Trigger;
+
+function Trigger(Actor Other, Pawn Instigator)
+{
+    local Actor a;
+
+    Super.Trigger(Other, Instigator);
+
+    foreach AllActors(class'Actor', a, Event) {
+        a.Destroy();
+    }
+}


### PR DESCRIPTION
This adds a `DestroyTrigger` class, which is exactly what it sounds like. It's used to make Nicolette go away when you leave for Chateau instead of setting her orders to 'Leaving' (as is currently done) because the latter has two problems if you leave before she's done jogging around Jock.

1) You can see Nicolette as you fly away, which of course makes no sense.
2) If you backtrack, she's still there.

Using a similar `LeaveWorldTrigger` fixes problem 1 but not problem 2. Simply destroying her fixes both.