### PR TITLE
v3.5 Alpha before src folder migration

### DIFF
--- a/DXRCore/DeusEx/Classes/DXRMenuBase.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuBase.uc
@@ -7,8 +7,10 @@ struct EnumBtn {
 
 #ifdef allstarts
     var string values[64];
+    var string helpTexts[64];
 #else
     var string values[32];
+    var string helpTexts[32];
 #endif
 
     var int value;
@@ -201,7 +203,7 @@ function NewGroup(string text)
     BreakLine();
 }
 
-function bool EnumOption(string label, int value, optional out int output)
+function bool EnumOption(string label, int value, optional out int output, optional string helpText)
 {
     local int i;
     local string s;
@@ -219,6 +221,7 @@ function bool EnumOption(string label, int value, optional out int output)
                 break;
             } else if( enums[id].values[i] == "" ) {
                 enums[id].values[i] = label;
+                enums[id].helpTexts[i] = helpText;
                 break;
             }
         }
@@ -652,16 +655,16 @@ function OpenEnumList(int iEnum)
     list.Init(self, iEnum, labels[iEnum], helptexts[iEnum], e.values[e.value]);
     for(i=0; i<ArrayCount(e.values); i++) {
         if(e.values[i] != "") {
-            EnumListAddButton(list, labels[iEnum], e.values[i], prev);
+            EnumListAddButton(list, labels[iEnum], e.values[i], e.helpTexts[i], prev);
             prev = e.values[i];
         }
     }
     list.Finalize();
 }
 
-function EnumListAddButton(DXREnumList list, string title, string val, string prev)
+function EnumListAddButton(DXREnumList list, string title, string val, string help, string prev)
 {
-    list.AddButton(val);
+    list.AddButton(val,help);
 }
 
 function int GetSliderValue(MenuUIEditWindow w)

--- a/DXRCore/DeusEx/Classes/DXRMenuReSetupRando.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuReSetupRando.uc
@@ -15,6 +15,19 @@ function DXRando GetDxr()
     return dxr;
 }
 
+// just in case, make sure DXR is never cleaned up
+event DestroyWindow()
+{
+    dxr = None;
+    Super.DestroyWindow();
+}
+
+function CancelScreen()
+{
+    dxr = None;
+    Super.CancelScreen();
+}
+
 //If changing ranges in this menu, make sure to update any clamped ranges in DXRFlags ScoreFlags function to match
 function BindControls(optional string action)
 {

--- a/DXRCore/DeusEx/Classes/DXRMenuReSetupRando.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuReSetupRando.uc
@@ -23,7 +23,7 @@ function BindControls(optional string action)
     local DXRTelemetry t;
     local DXRCrowdControl cc;
     local int temp, i;
-    local string ts;
+    local string ts,tht;
 #ifdef injections
     local DXRAutosave autosave;
     local bool mirrored_maps_files_found;
@@ -43,8 +43,9 @@ function BindControls(optional string action)
         for(i=0; i < 20; i++) {
             temp = loadout.GetIdForSlot(i);
             ts = loadout.GetName(temp);
+            tht = loadout.LoadoutHelpText(temp);
             if( ts == "" ) continue;
-            EnumOption(ts, temp, f.loadout);
+            EnumOption(ts, temp, f.loadout, tht);
         }
     }
 
@@ -52,15 +53,15 @@ function BindControls(optional string action)
     // KEEP IN SYNC WITH DXRMenuSelectDifficulty.uc
     foreach f.AllActors(class'DXRAutosave', autosave) { break; }// need an object to access consts
     NewMenuItem("Save Behavior", "Saves the game in case you die!");
-    EnumOption("Autosave Every Entry", autosave.EveryEntry, f.autosave);
-    EnumOption("Autosave First Entry", autosave.FirstEntry, f.autosave);
-    EnumOption("Autosaves-Only (Hardcore)", autosave.Hardcore, f.autosave);
-    EnumOption("Extra Safe (1+GB per playthrough)", autosave.ExtraSafe, f.autosave);
-    EnumOption("Limited Saves", autosave.LimitedSaves, f.autosave);
-    EnumOption("Limited Fixed Saves", autosave.FixedSaves, f.autosave);
-    EnumOption("Unlimited Fixed Saves", autosave.UnlimitedFixedSaves, f.autosave);
-    EnumOption("Extreme Limited Fixed Saves", autosave.FixedSavesExtreme, f.autosave);
-    EnumOption("Autosaves Disabled", autosave.Disabled, f.autosave);
+    EnumOption("Autosave Every Entry", autosave.EveryEntry, f.autosave, class'DXRMenuSelectDifficulty'.static.GetAutoSaveHelpText(autosave,autosave.EveryEntry));
+    EnumOption("Autosave First Entry", autosave.FirstEntry, f.autosave, class'DXRMenuSelectDifficulty'.static.GetAutoSaveHelpText(autosave,autosave.FirstEntry));
+    EnumOption("Autosaves-Only (Hardcore)", autosave.Hardcore, f.autosave, class'DXRMenuSelectDifficulty'.static.GetAutoSaveHelpText(autosave,autosave.Hardcore));
+    EnumOption("Extra Safe (1+GB per playthrough)", autosave.ExtraSafe, f.autosave, class'DXRMenuSelectDifficulty'.static.GetAutoSaveHelpText(autosave,autosave.ExtraSafe));
+    EnumOption("Limited Saves", autosave.LimitedSaves, f.autosave, class'DXRMenuSelectDifficulty'.static.GetAutoSaveHelpText(autosave,autosave.LimitedSaves));
+    EnumOption("Limited Fixed Saves", autosave.FixedSaves, f.autosave, class'DXRMenuSelectDifficulty'.static.GetAutoSaveHelpText(autosave,autosave.FixedSaves));
+    EnumOption("Unlimited Fixed Saves", autosave.UnlimitedFixedSaves, f.autosave, class'DXRMenuSelectDifficulty'.static.GetAutoSaveHelpText(autosave,autosave.UnlimitedFixedSaves));
+    EnumOption("Extreme Limited Fixed Saves", autosave.FixedSavesExtreme, f.autosave, class'DXRMenuSelectDifficulty'.static.GetAutoSaveHelpText(autosave,autosave.FixedSavesExtreme));
+    EnumOption("Autosaves Disabled", autosave.Disabled, f.autosave, class'DXRMenuSelectDifficulty'.static.GetAutoSaveHelpText(autosave,autosave.Disabled));
 #endif
 
     // KEEP IN SYNC WITH DXRMenuSelectDifficulty.uc

--- a/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -29,7 +29,7 @@ function BindControls(optional string action)
 {
     local float difficulty;
     local DXRFlags f;
-    local string sseed, ts;
+    local string sseed, ts, tht;
     local DXRLoadouts loadout;
     local DXRTelemetry t;
     local DXRCrowdControl cc;
@@ -62,8 +62,9 @@ function BindControls(optional string action)
         for(i=0; i < 20; i++) {
             temp = loadout.GetIdForSlot(i);
             ts = loadout.GetName(temp);
+            tht = loadout.LoadoutHelpText(temp);
             if( ts == "" ) continue;
-            EnumOption(ts, temp, f.loadout);
+            EnumOption(ts, temp, f.loadout, tht);
         }
     }
 
@@ -90,15 +91,15 @@ function BindControls(optional string action)
     // KEEP IN SYNC WITH DXRMenuReSetupRando.uc
     foreach f.AllActors(class'DXRAutosave', autosave) { break; }// need an object to access consts
     autosave_enum = NewMenuItem("Save Behavior", "Saves the game in case you die!");
-    EnumOption("Autosave Every Entry", autosave.EveryEntry, f.autosave);
-    EnumOption("Autosave First Entry", autosave.FirstEntry, f.autosave);
-    EnumOption("Autosaves-Only (Hardcore)", autosave.Hardcore, f.autosave);
-    EnumOption("Extra Safe (1+GB per playthrough)", autosave.ExtraSafe, f.autosave);
-    EnumOption("Limited Saves", autosave.LimitedSaves, f.autosave);
-    EnumOption("Limited Fixed Saves", autosave.FixedSaves, f.autosave);
-    EnumOption("Unlimited Fixed Saves", autosave.UnlimitedFixedSaves, f.autosave);
-    EnumOption("Extreme Limited Fixed Saves", autosave.FixedSavesExtreme, f.autosave);
-    EnumOption("Autosaves Disabled", autosave.Disabled, f.autosave);
+    EnumOption("Autosave Every Entry", autosave.EveryEntry, f.autosave, GetAutoSaveHelpText(autosave,autosave.EveryEntry));
+    EnumOption("Autosave First Entry", autosave.FirstEntry, f.autosave, GetAutoSaveHelpText(autosave,autosave.FirstEntry));
+    EnumOption("Autosaves-Only (Hardcore)", autosave.Hardcore, f.autosave, GetAutoSaveHelpText(autosave,autosave.Hardcore));
+    EnumOption("Extra Safe (1+GB per playthrough)", autosave.ExtraSafe, f.autosave, GetAutoSaveHelpText(autosave,autosave.ExtraSafe));
+    EnumOption("Limited Saves", autosave.LimitedSaves, f.autosave, GetAutoSaveHelpText(autosave,autosave.LimitedSaves));
+    EnumOption("Limited Fixed Saves", autosave.FixedSaves, f.autosave, GetAutoSaveHelpText(autosave,autosave.FixedSaves));
+    EnumOption("Unlimited Fixed Saves", autosave.UnlimitedFixedSaves, f.autosave, GetAutoSaveHelpText(autosave,autosave.UnlimitedFixedSaves));
+    EnumOption("Extreme Limited Fixed Saves", autosave.FixedSavesExtreme, f.autosave, GetAutoSaveHelpText(autosave,autosave.FixedSavesExtreme));
+    EnumOption("Autosaves Disabled", autosave.Disabled, f.autosave, GetAutoSaveHelpText(autosave,autosave.Disabled));
 #endif
 
     // KEEP IN SYNC WITH DXRMenuReSetupRando.uc
@@ -225,7 +226,7 @@ function string SetEnumValue(int e, string text)
     return old;
 }
 
-function EnumListAddButton(DXREnumList list, string title, string val, string prev)
+function EnumListAddButton(DXREnumList list, string title, string val, string help, string prev)
 {
     if(title == "Game Mode") {
         if(InStr(prev, "WaltonWare")==-1 && InStr(val, "WaltonWare")!=-1) {
@@ -237,7 +238,7 @@ function EnumListAddButton(DXREnumList list, string title, string val, string pr
             list.CreateLabel("Other game modes");
         }
     }
-    list.AddButton(val);
+    list.AddButton(val, help);
 }
 
 function HandleNewGameButton()
@@ -364,6 +365,35 @@ function NewGameSetup(float difficulty)
         newGame.Init(dxr);
     }
 }
+
+#ifdef injections
+static function string GetAutoSaveHelpText(DXRAutosave autosave, coerce int choice)
+{
+    switch (choice)
+    {
+        case autosave.EveryEntry:
+            return "The game will automatically save after every level transition.  You are allowed to save manually whenever you would like.  Autosaves are cleared when you progress to the next mission.";
+        case autosave.FirstEntry:
+            return "The game will only automatically save the first time you enter a new level.  You are allowed to save manually whenever you would like.  Autosaves are cleared when you progress to the next mission.";
+        case autosave.Hardcore:
+            return "The game will automatically save the first time you enter a level.  No manual saves are allowed.  Autosaves are cleared when you progress to the next mission.";
+        case autosave.ExtraSafe:
+            return "The game will automatically save after every level transition.  You are allowed to save manually whenever you would like.  Autosaves are never cleared.";
+        case autosave.LimitedSaves:
+            return "The game will only autosave once at the start of the game.  Manual saves are allowed at any time, but require a Memory Containment Unit.  Memory Containment Units can be found randomly placed around levels.";
+        case autosave.FixedSaves:
+            return "The game will only autosave once at the start of the game.  Manual saves are only allowed when looking at a computer and require a Memory Containment Unit.  Memory Containment Units can be found randomly placed around levels.";
+        case autosave.UnlimitedFixedSaves:
+            return "The game will only autosave once at the start of the game.  Manual saves are only allowed when looking at a computer, but you are allowed to save as much as you would like.";
+        case autosave.FixedSavesExtreme:
+            return "The game will only autosave once at the start of the game.  Manual saves are only allowed when looking at a computer and require two(?) Memory Containment Units.  Memory Containment Units can be found randomly placed around levels.";
+        case autosave.Disabled:
+            return "The game will not automatically save.  You are allowed to save manually whenever you would like.";
+        default:
+            return ""; //This will mean the help button won't appear
+    }
+}
+#endif
 
 defaultproperties
 {

--- a/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -360,6 +360,18 @@ event DestroyWindow()
     }
 }
 
+function CancelScreen()
+{
+    log(self $ " CancelScreen() " $ dxr);
+    if(dxr != None) {
+        GetFlags().Destroy();
+        flags = None;
+        dxr.Destroy();
+        dxr = None;
+    }
+    Super.CancelScreen();
+}
+
 function NewGameSetup(float difficulty)
 {
     local DXRMenuSetupRando newGame;

--- a/DXRCore/DeusEx/Classes/DXRando.uc
+++ b/DXRCore/DeusEx/Classes/DXRando.uc
@@ -165,7 +165,9 @@ simulated event PreTravel()
 
 simulated event Destroyed()
 {
-    default.dxr = None;// clear the singleton reference
+    if(default.dxr == self) {
+        default.dxr = None;// clear the singleton reference
+    }
 }
 
 function CheckConfig()

--- a/DXRModules/DeusEx/Classes/DXRAugmentations.uc
+++ b/DXRModules/DeusEx/Classes/DXRAugmentations.uc
@@ -391,9 +391,8 @@ simulated function RandoAug(Augmentation a)
         a.Description = add_desc $ "|n|n" $ a.Description;
     }
 
-    if( #var(prefix)AugSpeed(a) != None || #var(prefix)AugLight(a) != None
-    || #var(prefix)AugIFF(a) != None || #var(prefix)AugDatalink(a) != None || AugNinja(a) != None )
-        return;
+    if(#var(prefix)AugLight(a) != None || #var(prefix)AugIFF(a) != None || #var(prefix)AugDatalink(a) != None )
+        return; // default augs
 
     aug_value_wet_dry = float(dxr.flags.settings.aug_value_rando) / 100.0;
     if(( aug_value_wet_dry > 0
@@ -409,10 +408,15 @@ simulated function RandoAug(Augmentation a)
         aug_value_wet_dry = 0;
         add_desc = add_desc $ "Energy Rate: "$int(a.energyRate)$" Units/Minute";
     }
-    if(dxr.flags.IsStrongAugsMode())
+
+    if(dxr.flags.IsStrongAugsMode()) {
         RandoLevelValues(a, -2, 3, aug_value_wet_dry, a.Description, add_desc);
-    else
+    } else {
+        if(#var(prefix)AugSpeed(a) != None || AugNinja(a) != None || AugOnlySpeed(a) != None || AugJump(a) != None) {
+            aug_value_wet_dry = 0;
+        }
         RandoLevelValues(a, min_aug_weaken, max_aug_str, aug_value_wet_dry, a.Description, add_desc);
+    }
 }
 
 static simulated function string DescriptionLevelExtended(Actor act, int i, out string word, out float val, float defaultval, out string shortDisplay)

--- a/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -757,6 +757,8 @@ function FlagsSettings SetDifficulty(int new_difficulty)
     if(class'MenuChoice_NewGamePlus'.default.value == 0 && !IsWaltonWare())
         moresettings.newgameplus_curve_scalar = -1;
 
+    class'DXRLoadouts'.static.AdjustFlags(self, loadout); // new game menu doesn't initialize its own DXRLoadouts
+
     return settings;
 }
 

--- a/DXRModules/DeusEx/Classes/DXRHints.uc
+++ b/DXRModules/DeusEx/Classes/DXRHints.uc
@@ -388,6 +388,8 @@ simulated function InitHints()
                     AddHint("The map of the island can show possible goal locations.", "Give it a try!");
                 }
             }
+            AddHint("Harley Filben has the key that opens doors in the statue.", "Be nice to him!");
+            AddHint("The key that opens the front doors of the statue also opens", "the cell Gunther is being held in.  Walk right in!");
         }
         break;
 

--- a/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -462,6 +462,24 @@ function string LoadoutInfo(int loadout, optional bool get_name)
     return "";
 }
 
+//#region AdjustFlags
+
+static function AdjustFlags(DXRFlags flags, int loadout)
+{
+    switch(loadout) {
+    case 15:
+        //The Three Leg Augs
+        flags.moresettings.aug_loc_rando = 100;
+        break;
+    case 17:
+        //My Vision Is Augmented
+        flags.moresettings.aug_loc_rando = 100;
+        break;
+    }
+}
+
+//#endregion
+
 //#region Loadout Help
 function string LoadoutHelpText(int loadout)
 {
@@ -534,14 +552,14 @@ function string LoadoutHelpText(int loadout)
         return "All items are allowed.  Six randomly selected augs are banned, and you start with a randomly selected augmentation.";
     case 15:
         //The Three Leg Augs
-        return "All items are allowed.  Speed Enhancement and six randomly selected augs are banned.  You start with one of the Running Enhancement, Jump Enhancement, or Run Silent augmentations.";
+        return "All items are allowed.  Speed Enhancement and six randomly selected augs are banned.  You start with one of the Running Enhancement, Jump Enhancement, or Run Silent augmentations." $ CR() $ CR() $ "Enables Aug Slot Rando by default.";
     case 16:
         //Speed Enhancement
         return "The old-fashioned DXRando experience!  All items and augs are allowed.  You start with the Speed Enhancement augmentation.";
     #ifdef injections
     case 17:
         //My Vision Is Augmented
-        return "All items are allowed.  Six randomly selected augs are banned.  You start with one of the Short Vision Enhancement, InfraVision, or Motion Sensor augmentations.  "$"Running Enhancement and Jump Enhancement augs are also available.";
+        return "All items are allowed.  Six randomly selected augs are banned.  You start with one of the Short Vision Enhancement, InfraVision, or Motion Sensor augmentations.  "$"Running Enhancement and Jump Enhancement augs are also available." $ CR() $ CR() $ "Enables Aug Slot Rando by default.";
     #endif
     }
 

--- a/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -462,6 +462,93 @@ function string LoadoutInfo(int loadout, optional bool get_name)
     return "";
 }
 
+//#region Loadout Help
+function string LoadoutHelpText(int loadout)
+{
+    local string helpText;
+
+    switch(loadout) {
+    case 0:
+        //All Items Allowed
+        return "All items and augs are allowed.  You start with the Running Enhancement augmentation, and the Jump Enhancement aug is also available.";
+    case 1:
+        //SWTP Pure
+        helpText = "The only weapon allowed is the Riot Prod and the Rubber Baton (which is unable to deal damage to anything but the environment).  ";
+        #ifdef injections
+        helpText = helpText $ "You start with Run Silent, Microfibral Muscle, and Infravision augmentations.  ";
+        #else
+        helpText = helpText $ "You start with Run Silent and Microfibral Muscle augmentations.  ";
+        #endif
+        helpText = helpText $ "Speed Enhancement augmentation is banned.  Running Enhancement and Jump Enhancement augs are available.";
+        return helpText;
+    case 2:
+        //SWTP Plus
+        helpText = "The only weapons allowed are the Riot Prod, mini-crossbow (with tranquilizer darts), EMP Grenades, Gas Grenades, Scrambler Grenades, Pepper Spray, and the Rubber Baton (which is unable to deal damage to anything but the environment).  ";
+        #ifdef injections
+        helpText = helpText $ "You start with Run Silent, Microfibral Muscle, and Infravision augmentations.  ";
+        #else
+        helpText = helpText $ "You start with Run Silent and Microfibral Muscle augmentations.  ";
+        #endif
+        helpText = helpText $ "Speed Enhancement augmentation is banned.  Running Enhancement and Jump Enhancement augs are available.";
+        return helpText;
+    case 3:
+        //Ninja JC
+        helpText = "Become the ninja!  Use throwing knives, swords, mini-crossbows, and grenades to bypass and eliminate your enemies!  ";
+        helpText = helpText $ "Speed Enhancement and Run Silent augmentations are banned, but you start with the Ninja augmentation instead, which combines the functionality of both!";
+        return helpText;
+    case 4:
+        //Don't give me the GEP Gun
+        return "All items and augs are allowed except for the GEP Gun.  You start with the Running Enhancement augmentation, and the Jump Enhancement aug is also available.";
+    case 5:
+        //Freeman Mode
+        return "The only weapon allowed is the Crowbar.  You start with the Running Enhancement augmentation, and the Jump Enhancement aug is also available.";
+    case 6:
+        //Grenades Only
+        return "The only weapons allowed are grenades and the Rubber Baton (which is unable to deal damage to anything but the environment).  You start with the Running Enhancement augmentation, and the Jump Enhancement aug is also available.";
+    case 7:
+        //No Pistols
+        return "All items and augs are allowed except for the Pistol and Stealth Pistol.  You start with the Running Enhancement augmentation, and the Jump Enhancement aug is also available.";
+    case 8:
+        //No Swords
+        return "All items and augs are allowed except for the Sword and Dragon Tooth Sword.  You start with the Running Enhancement augmentation, and the Jump Enhancement aug is also available.";
+    case 9:
+        //Hipster JC
+        helpText = "JC used things before they were cool, so he doesn't want to use them any more.  In terms of weapons, JC won't use the Dragon Tooth Sword, Pistol, Stealth Pistol, GEP Gun, or Laser Modifications.  ";
+        helpText = helpText $ "JC also won't use the Speed Enhancement, Power Recirculator, or Regeneration augmentations.  ";
+        helpText = helpText $ "You start with the EMP Shield augmentation (JC is using it before it gets cool).";
+        return helpText;
+    case 10:
+        //By the Book
+        return "Follow UNATCO protocol!  All items and augs are allowed except for the Lockpick and Multitool.  The Computers skill is banned to prevent hacking.  You start with the Run Silent augmentation.";
+    case 11:
+        //Explosives Only
+        return "The only weapons allowed are grenades, GEP Gun, Assault Rifle with 20mm ammo, and the Rubber Baton (which is unable to deal damage to anything but the environment).  "$"You start with the Running Enhancement augmentation, and the Jump Enhancement aug is also available.";
+    case 12:
+        //Random Starting Aug
+        return "All items and augs are allowed.  You start with a randomly selected augmentation.";
+    case 13:
+        //Straight Edge
+        return "All items and augs are allowed except for alcohol, cigarettes, and zyme.  You start with the Running Enhancement augmentation, and the Jump Enhancement aug is also available.";
+    case 14:
+        //Reduced Aug Set
+        return "All items are allowed.  Six randomly selected augs are banned, and you start with a randomly selected augmentation.";
+    case 15:
+        //The Three Leg Augs
+        return "All items are allowed.  Speed Enhancement and six randomly selected augs are banned.  You start with one of the Running Enhancement, Jump Enhancement, or Run Silent augmentations.";
+    case 16:
+        //Speed Enhancement
+        return "The old-fashioned DXRando experience!  All items and augs are allowed.  You start with the Speed Enhancement augmentation.";
+    #ifdef injections
+    case 17:
+        //My Vision Is Augmented
+        return "All items are allowed.  Six randomly selected augs are banned.  You start with one of the Short Vision Enhancement, InfraVision, or Motion Sensor augmentations.  "$"Running Enhancement and Jump Enhancement augs are also available.";
+    #endif
+    }
+
+    return "";
+}
+//#endregion
+
 function AddStandardAugSet()
 {
     AddStartAug(class'AugOnlySpeed');

--- a/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/DXRVanilla/DeusEx/Classes/Player.uc
@@ -2296,6 +2296,16 @@ function PreTravel()
         root.ClearWindowStack();
     }
 
+    if (inHand!=None && inHand.IsA('DeusExWeapon'))
+    {
+        //Turn the laser off to prevent the laser spot from sticking around
+        //when you come back.  Maybe it would be better to just directly
+        //remove the LaserSpot's, but this is a simple solution for now.
+        if (class'MenuChoice_AutoLaser'.default.enabled){
+            DeusExWeapon(inHand).LaserOff();
+        }
+    }
+
     Super.PreTravel();
 }
 

--- a/GUI/DeusEx/Classes/AugDisplayWindow.uc
+++ b/GUI/DeusEx/Classes/AugDisplayWindow.uc
@@ -125,6 +125,9 @@ function bool ShouldDrawActor(Actor A)
     }
     if(bMotionSensor) {
         return !A.bHidden && A != Player && VSize(A.Velocity)>1;
+        if(Mover(A) != None) return false;
+        if(Cloud(A) != None) return false;
+        if(A.Mesh == None) return false;
     }
 
     if(class'MenuChoice_BalanceAugs'.static.IsEnabled()) {
@@ -217,15 +220,12 @@ function _DrawActor(GC gc, Actor A, float DrawGlow)
         }
     }
 
-    if(A.Mesh == None) {
-        DrawBrush(gc, A);
-    }
-    else {
+    if(A.Mesh != None) {
         SetSkins(A, oldSkins);
         gc.DrawActor(A, False, False, True, 1.0, DrawGlow/4, None);
 
         c = #var(prefix)Containers(A);
-        if(c != None) {
+        if(c != None && !bThermalVision && !bMotionSensor) {
             i = c.Contents;
             if(i == None) i = c.Content2;
             if(i == None) i = c.Content3;
@@ -237,6 +237,8 @@ function _DrawActor(GC gc, Actor A, float DrawGlow)
             }
         }
         ResetSkins(A, oldSkins);
+    } else if(Brush(A) != None) {
+        DrawBrush(gc, A);
     }
 }
 

--- a/GUI/DeusEx/Classes/DXRMenuScreenNewGame.uc
+++ b/GUI/DeusEx/Classes/DXRMenuScreenNewGame.uc
@@ -7,6 +7,7 @@ class DXRMenuScreenNewGame extends MenuScreenNewGame;
 var DXRando dxr;
 var DXRFlags flags;
 var config string last_player_name;
+var config int last_portrait;
 var bool hasCheckedLDDP;
 var MenuUIActionButtonWindow btnRandomPortrait;
 #ifndef injections
@@ -63,6 +64,13 @@ event InitWindow()
 
     SaveSkillPoints();
     ResetToDefaults();
+
+    //Pick a random portrait
+    if (class'MenuChoice_JCGenderSkin'.static.IsRandom()){
+        SelectRandomPortrait(false); //Randomly select one of the portraits
+    } else if (class'MenuChoice_JCGenderSkin'.static.IsRemember()) {
+        SelectPortrait(last_portrait); //Select the last portrait used
+    }
 
     // Need to do this because of the edit control used for
     // saving games.
@@ -190,6 +198,7 @@ function SaveSettings()
         dxr.Destroy();
     player.ServerSetSloMo(1);//reset game speed to prevent crashes
     last_player_name = player.TruePlayerName;
+    last_portrait = portraitIndex;
     SaveConfig();
 }
 
@@ -273,13 +282,19 @@ function CreateActionButtons()
 function bool ButtonActivated( Window buttonPressed )
 {
     if (buttonPressed==btnRandomPortrait){
-        SelectRandomPortrait();
+        SelectRandomPortrait(true);
         return true;
     }
     return Super.ButtonActivated(buttonPressed);
 }
 
-function SelectRandomPortrait()
+function SelectPortrait(int portraitNum)
+{
+    portraitIndex=portraitNum;
+    btnPortrait.SetBackground(texPortraits[portraitIndex]);
+}
+
+function SelectRandomPortrait(bool noRepeat)
 {
     local int numPortraits;
 
@@ -292,9 +307,13 @@ function SelectRandomPortrait()
         numPortraits=5;
     }
 
-    //This shouldn't ever pick the same portrait twice in a row,
-    //since it can't roll *all* the way around
-    portraitIndex=(portraitIndex+Rand(numPortraits-1)+1) % numPortraits;
+    if (noRepeat){
+        //This shouldn't ever pick the same portrait twice in a row,
+        //since it can't roll *all* the way around
+        portraitIndex=(portraitIndex+Rand(numPortraits-1)+1) % numPortraits;
+    } else {
+        portraitIndex=(portraitIndex+Rand(numPortraits)) % numPortraits;
+    }
     btnPortrait.SetBackground(texPortraits[portraitIndex]);
 }
 

--- a/GUI/DeusEx/Classes/DXRMenuUIHelpButtonWindow.uc
+++ b/GUI/DeusEx/Classes/DXRMenuUIHelpButtonWindow.uc
@@ -1,0 +1,23 @@
+class DXRMenuUIHelpButtonWindow extends MenuUIActionButtonWindow;
+
+var string HelpTitle,HelpText;
+
+function SetHelpTitle(string title)
+{
+    HelpTitle = title;
+}
+
+function string GetHelpTitle()
+{
+    return HelpTitle;
+}
+
+function SetHelpText(string help)
+{
+    HelpText = help;
+}
+
+function string GetHelpText()
+{
+    return HelpText;
+}

--- a/GUI/DeusEx/Classes/MenuChoice_JCGenderSkin.uc
+++ b/GUI/DeusEx/Classes/MenuChoice_JCGenderSkin.uc
@@ -1,0 +1,32 @@
+//=============================================================================
+// MenuChoice_ShowHints
+//=============================================================================
+
+class MenuChoice_JCGenderSkin extends DXRMenuUIChoiceInt;
+
+// ----------------------------------------------------------------------
+// SaveSetting()
+// ----------------------------------------------------------------------
+
+static function bool IsRandom()
+{
+    return (default.value==1);
+}
+
+static function bool IsRemember()
+{
+    return (default.value==2);
+}
+
+defaultproperties
+{
+    value=1
+    defaultvalue=1
+    defaultInfoWidth=243
+    defaultInfoPosX=203
+    HelpText="What gender and skin of JC should be selected on the new game screen?"
+    actionText="JC Gender/Skin"
+    enumText(0)="Default"
+    enumText(1)="Random"
+    enumText(2)="Last Used"
+}

--- a/GUI/DeusEx/Classes/MenuScreenRandoOptionsRandomizer.uc
+++ b/GUI/DeusEx/Classes/MenuScreenRandoOptionsRandomizer.uc
@@ -18,6 +18,7 @@ function CreateChoices()
     CreateChoice(class'MenuChoice_ToggleMemes');
     CreateChoice(class'MenuChoice_OctoberCosmetics');
     CreateChoice(class'MenuChoice_ShowHints');
+    CreateChoice(class'MenuChoice_JCGenderSkin');
 }
 
 


### PR DESCRIPTION
- Minimize leftover laser sight dots at level transitions when autolaser is enabled
- Add hints about the statue key on Liberty Island
- New option to either pick the last used JC skin or randomly select one every time you load the new game menu (or continue to default JC every time).
- In-Game help buttons for loadouts and autosave settings!
- Fixed Infravision highlighting movers and clouds
- Fixed leg augs being randomized, but randomized in Strong Augs mode
- Speedrun mode now auto selects Speed Enhancement (if the selected loadout was All Items Allowed)
- Loadouts AdjustFlags to set aug slot rando for MVIA and TTLA
- DXRMenuSelectDifficulty cleanup DXRando and DXRFlags that it spawned

Previously: https://github.com/Die4Ever/deus-ex-randomizer/pull/1172