### PR TITLE
Change SkillAwardCrate mass to 35 (redux)

### DIFF
--- a/src/DXRando/DeusEx/Classes/SkillAwardCrate.uc
+++ b/src/DXRando/DeusEx/Classes/SkillAwardCrate.uc
@@ -38,6 +38,6 @@ defaultproperties
     Mesh=LodMesh'DeusExDeco.CrateBreakableMed'
     CollisionRadius=34.000000
     CollisionHeight=24.000000
-    Mass=50.000000
+    Mass=35.000000
     Buoyancy=60.000000
 }


### PR DESCRIPTION
Breakable medium crates all, as far as I can tell, have a mass of 35, even though their default mass is 50. A mass of 50 makes it impossible to break a SkillAwardCrate by throwing it in the air.