### PR TITLE
v3.5.0.3 Alpha

### DIFF
--- a/src/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -2057,6 +2057,15 @@ static function string GetDistanceUnit()
     }
 }
 
+static function string GetDistanceUnitLong()
+{
+    if (class'MenuChoice_MeasureUnits'.static.IsImperial()){
+        return "feet";
+    } else {
+        return "meters";
+    }
+}
+
 //Speed is in unreal units per second
 static function float GetRealSpeed(float speed){
     if (class'MenuChoice_MeasureUnits'.static.IsImperial()){

--- a/src/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -1055,19 +1055,19 @@ static function string GetActorName(Actor a)
     return string(a.class.name);
 }
 
-static function DeusExDecoration _AddSwitch(Actor a, vector loc, rotator rotate, name Event, optional string description)
+static function #var(DeusExPrefix)Decoration _AddSwitch(Actor a, vector loc, rotator rotate, name Event, optional string description)
 {
-    local DeusExDecoration d;
-    d = DeusExDecoration( _AddActor(a, class'Switch2', loc, rotate) );
-    d.Buoyancy = 0;
-    d.Event = Event;
-    d.FamiliarName=description;
-    d.UnfamiliarName=description;
-    return d;
+    local #var(prefix)Switch2 s;
+    s = #var(prefix)Switch2(_AddActor(a, class'#var(prefix)Switch2', loc, rotate));
+    s.Buoyancy = 0;
+    s.Event = Event;
+    s.FamiliarName=description;
+    s.UnfamiliarName=description;
+    return s;
 }
 
 // DON'T PASS A VECTM OR ROTM TO THIS FUNCTION! PASS A PLAIN VECT AND ROT!
-function DeusExDecoration AddSwitch(vector loc, rotator rotate, name Event, optional string description)
+function #var(DeusExPrefix)Decoration AddSwitch(vector loc, rotator rotate, name Event, optional string description)
 {
     loc = vectm(loc.X, loc.Y, loc.Z);
     rotate = rotm(rotate.pitch, rotate.yaw, rotate.roll, 16384);

--- a/src/DXRCore/DeusEx/Classes/DXRInfo.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRInfo.uc
@@ -361,22 +361,20 @@ simulated static function string FloatToString(float f, int decimal_places)
     return s;
 }
 
-simulated static function String TruncateFloat(float val, int numDec)
+simulated static function String TruncateFloat(coerce string val, int numDec)
 {
-    local string trunc;
     local int truncPoint;
 
-    trunc = string(val);
-    truncPoint = InStr(trunc,".");
+    truncPoint = InStr(val,".");
 
     if (truncPoint==-1){
-        return trunc;
+        return val;
     }
 
     truncPoint++; //include the decimal point...
     truncPoint+=numDec;
 
-    return Left(trunc,truncPoint);
+    return Left(val,truncPoint);
 }
 
 simulated static function string TrimTrailingZeros(coerce string s)

--- a/src/DXRCore/DeusEx/Classes/DXRMenuBase.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuBase.uc
@@ -721,10 +721,15 @@ function bool CheckClickHelpBtn( Window buttonPressed )
     if (helpButton==None) return false;
 
     if (helpButton.GetHelpText()!=""){
-        class'BingoHintMsgBox'.static.Create(root, "Help: "$helpButton.GetHelpTitle(), helpButton.GetHelpText(), 1, False, self);
+        class'BingoHintMsgBox'.static.Create(root, "Help: "$helpButton.GetHelpTitle(), GetHelpText(helpButton), 1, False, self);
     }
 
     return true;
+}
+
+function string GetHelpText(DXRMenuUIHelpButtonWindow helpButton)
+{
+    return helpButton.GetHelpText();
 }
 
 function ClickEnum(int iEnum, bool rightClick)

--- a/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -148,11 +148,11 @@ static function int CreateCrowdControlEnum(DXRMenuBase slf, DXRFlags f)
     local int e;
 
     e = slf.NewMenuItem("Crowd Control", "Let your Twitch/YouTube/Discord viewers troll you or help you!" $Chr(10)$ "See their website crowdcontrol.live");
-    //EnumOption("Enabled (Anonymous)", 2, f.crowdcontrol);
-    slf.EnumOption("Enabled (Streaming)", 1, f.crowdcontrol);
-    slf.EnumOption("Offline Simulated", 3, f.crowdcontrol);
-    slf.EnumOption("Streaming and Simulated", 4, f.crowdcontrol);
-    slf.EnumOption("Disabled", 0, f.crowdcontrol);
+    //EnumOption("Enabled (Anonymous)", 2, f.crowdcontrol, GetCrowdControlHelpText(2));
+    slf.EnumOption("Enabled (Streaming)", 1, f.crowdcontrol, GetCrowdControlHelpText(1));
+    slf.EnumOption("Offline Simulated", 3, f.crowdcontrol, GetCrowdControlHelpText(3));
+    slf.EnumOption("Streaming and Simulated", 4, f.crowdcontrol, GetCrowdControlHelpText(4));
+    slf.EnumOption("Disabled", 0, f.crowdcontrol, GetCrowdControlHelpText(0));
     return e;
 }
 
@@ -197,12 +197,12 @@ static function int CreateMirroredMapsSlider(DXRMenuBase slf, DXRFlags f)
         } else if(f.mirroredmaps == -1) {
             f.mirroredmaps = 50; // default to 50% when the files are installed
         }
-        slf.Slider(f.mirroredmaps, 0, 100);
+        slf.Slider(f.mirroredmaps, 0, 100,GetMirroredMapsHelpText(true));
     } else {
         // use -1 to indicate not installed, because this gets saved to the config
         f.mirroredmaps = -1;
         slf.NewMenuItem("", "Use the installer to download the mirrored map files, or go to the unreal-map-flipper Releases page on Github");
-        slf.EnumOption("Mirror Map Files Not Found", -1, f.mirroredmaps);
+        slf.EnumOption("Mirror Map Files Not Found", -1, f.mirroredmaps, GetMirroredMapsHelpText(false));
     }
 #else
     //Disable mirrored maps entirely if map variants aren't supported
@@ -440,7 +440,7 @@ function NewGameSetup(float difficulty)
     }
 }
 
-function string GetSeedHelpText()
+static function string GetSeedHelpText()
 {
     local string msg;
 
@@ -467,6 +467,51 @@ static function string GetOnlineFeaturesHelpText(int mode)
         case 2: //Enabled
             msg = msg $ "The game will occasionally send messages to the Deus Ex Randomizer server to log deaths and certain actions.  Death messages will be posted on the DX Rando Activity Mastodon feed,"$" along with posts about certain things that the player does.  Death markers will show up in game where players have recently died.";
             break;
+    }
+
+    return msg;
+}
+
+static function string GetCrowdControlHelpText(int mode)
+{
+    local string msg;
+
+    msg = "";
+
+    switch(mode){
+        case 0: //Disabled
+            msg = msg $ "Crowd Control is entirely disabled.  The Crowd Control client will not be able to connect to your game and effects will not occur.";
+            break;
+        case 1: //Enabled (Streaming)
+            msg = msg $ "Crowd Control will be enabled in your game.  Connect using the Crowd Control app on your computer so that people viewing your stream will be able to interact with you.|n";
+            msg = msg $ "|n";
+            msg = msg $ "See CrowdControl.Live for more details about the Crowd Control app.";
+            break;
+        case 2: //Enabled (Anonymous) (not actually available)
+            msg = msg $ "";
+            break;
+        case 3: //Offline Simulated
+            msg = msg $ "Simulated Crowd Control will be enabled in your game.  Instead of using the Crowd Control app, the game will randomly select effects and inflict them upon you.";
+            break;
+        case 4: //Streaming and Simulated
+            msg = msg $ "Both real and simulated Crowd Control will be enabled in your game.  You can connect using the Crowd Control app on your computer so that people viewing your stream will be able to interact with you.  "$"In addition, the game will randomly select effects and inflict them upon you.|n";
+            msg = msg $ "|n";
+            msg = msg $ "See CrowdControl.Live for more details about the Crowd Control app.";
+            break;
+    }
+
+    return msg;
+}
+
+static function string GetMirroredMapsHelpText(bool installed)
+{
+    local string msg;
+
+    msg = "The chances of each map being a mirrored version instead of the original.  Mirrored maps are horizontally mirrored (so left is right and right is left).  "$"Trick your mind into experiencing the original maps for the very first time again!|n|n";
+    if (installed){
+        msg = msg $ "Please note that any directions given (eg. 'to the East') will not be accurately reflected on the compass in mirrored maps.";
+    } else {
+        msg = msg $ "Mirrored Maps are not installed!  Run the Deus Ex Randomizer installer again to download them if you want to try them out!";
     }
 
     return msg;

--- a/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -66,7 +66,7 @@ function BindControls(optional string action)
     }
 
     for( i=i; i < ArrayCount(f.difficulty_names); i++ ) {
-        EnumOption(f.DifficultyName(i), i, f.difficulty);
+        EnumOption(f.DifficultyName(i), i, f.difficulty, f.DifficultyDesc(i));
     }// we call SetDifficulty to apply the difficulty and game mode after setting the seed, below
 
     autosave_enum = CreateAutosaveEnum(self, f);

--- a/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -139,6 +139,10 @@ static function int CreateAutosaveEnum(DXRMenuBase slf, DXRFlags f)
     slf.EnumOption("Unlimited Fixed Saves", autosave.UnlimitedFixedSaves, f.autosave, autosave.GetAutoSaveHelpText(autosave.UnlimitedFixedSaves));
     slf.EnumOption("Extreme Limited Fixed Saves", autosave.FixedSavesExtreme, f.autosave, autosave.GetAutoSaveHelpText(autosave.FixedSavesExtreme));
     slf.EnumOption("Autosaves Disabled", autosave.Disabled, f.autosave, autosave.GetAutoSaveHelpText(autosave.Disabled));
+    if(f.autosave == autosave.Ironman) { //Don't make this accessible unless it's your currently set value
+        slf.EnumOption("All Saves Disabled", autosave.Ironman, f.autosave, autosave.GetAutoSaveHelpText(autosave.Ironman));
+    }
+
     return in_autosave_enum;
 #endif
 }

--- a/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -66,7 +66,7 @@ function BindControls(optional string action)
     }
 
     for( i=i; i < ArrayCount(f.difficulty_names); i++ ) {
-        EnumOption(f.DifficultyName(i), i, f.difficulty, f.DifficultyDesc(i));
+        EnumOption(f.DifficultyName(i), i, f.difficulty, "placeholder so the ? button gets created");
     }// we call SetDifficulty to apply the difficulty and game mode after setting the seed, below
 
     autosave_enum = CreateAutosaveEnum(self, f);
@@ -215,6 +215,26 @@ static function int CreateMirroredMapsSlider(DXRMenuBase slf, DXRFlags f)
     return mirroredmaps_wnd;
 }
 
+function string GetHelpText(DXRMenuUIHelpButtonWindow helpButton)
+{
+    local DXRFlags f;
+    local int i;
+    local string s;
+
+    if(helpButton.row == difficulty_enum) {
+        s = GetEnumValue(difficulty_enum);
+        f = GetFlags();
+        for( i=0; i < ArrayCount(f.difficulty_names); i++ ) {
+            if(s == f.DifficultyName(i)) {
+                f.SetDifficulty(i);
+                break;
+            }
+        }
+        return f.DifficultyDesc(f.difficulty);
+    }
+    return helpButton.GetHelpText();
+}
+
 function string SetEnumValue(int e, string text)
 {
     local int i, temp;
@@ -255,14 +275,25 @@ function string SetEnumValue(int e, string text)
                 enums[difficulty_enum].values[i] = f.DifficultyName(i);
             }
             Super.SetEnumValue(difficulty_enum, f.DifficultyName(1));
+            f.difficulty = 1;
 
             if(f.IsZeroRando() && mirroredmaps_wnd>0) {
                 MenuUIEditWindow(wnds[mirroredmaps_wnd]).SetText("0");
             }
         }
+        f.SetDifficulty(f.difficulty);
         if(f.IsSpeedrunMode() && InStr(GetEnumValue(loadout_enum), "All Items Allowed")!=-1)
         {
             Super.SetEnumValue(loadout_enum, "Speed Enhancement");
+        }
+    }
+    if(e == difficulty_enum) {
+        f = GetFlags();
+        for( i=0; i < ArrayCount(f.difficulty_names); i++ ) {
+            if(text == f.DifficultyName(i)) {
+                f.SetDifficulty(i);
+                break;
+            }
         }
     }
 

--- a/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -511,11 +511,9 @@ static function string GetMirroredMapsHelpText(bool installed)
 {
     local string msg;
 
-    msg = "The chances of each map being a mirrored version instead of the original.  Mirrored maps are horizontally mirrored (so left is right and right is left).  "$"Trick your mind into experiencing the original maps for the very first time again!|n|n";
-    if (installed){
-        msg = msg $ "Please note that any directions given (eg. 'to the East') will not be accurately reflected on the compass in mirrored maps.";
-    } else {
-        msg = msg $ "Mirrored Maps are not installed!  Run the Deus Ex Randomizer installer again to download them if you want to try them out!";
+    msg = "The chances of each map being a mirrored version instead of the original.  Mirrored maps are horizontally mirrored (so left is right and right is left).  "$"Trick your mind into experiencing the original maps for the very first time again!";
+    if (!installed){
+        msg = msg $ "|n|nMirrored Maps are not installed!  Run the Deus Ex Randomizer installer again to download them if you want to try them out!";
     }
 
     return msg;

--- a/src/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
@@ -340,9 +340,9 @@ function BindControls(optional string action)
     Slider(f.settings.max_weapon_shottime, 0, 500, GetShotTimeHelpText(true));
 
     NewMenuItem("JC's Prison Pocket", "Keep all your items when getting captured.");
-    EnumOption("Disabled", 0, f.settings.prison_pocket);
-    //EnumOption("Unaugmented", 1, f.settings.prison_pocket);// TODO: can keep the item in the top left inventory slot, if it's 1 slot
-    EnumOption("Augmented", 100, f.settings.prison_pocket);// maybe the number could be set to the number of items to keep?
+    EnumOption("Disabled", 0, f.settings.prison_pocket,GetPrisonPocketHelpText(0));
+    EnumOption("Unaugmented", 1, f.settings.prison_pocket,GetPrisonPocketHelpText(1));// Keep the first single-slot item in your belt
+    EnumOption("Augmented", 100, f.settings.prison_pocket,GetPrisonPocketHelpText(100));// maybe the number could be set to the number of items to keep?
 
     NewGroup("Augmentations");
 
@@ -715,6 +715,20 @@ function string GetShotTimeHelpText(bool max)
     msg = msg $ "The 'shot time' is the amount of time it takes for a weapon to fire a single shot.  A lower shot time means the weapon fires more quickly (ie. has a faster fire rate).  A higher shot time means it fires slower (lower fire rate)";
 
     return msg;
+}
+
+function string GetPrisonPocketHelpText(int val)
+{
+    switch (val)
+    {
+        case 0: //Disabled
+            return "If taken to prison, all of your items will be taken away from you.";
+        case 1: //Unaugmented
+            return "If taken to prison, all items will be taken away from you except for the first single slot item in your belt.";
+        case 100: //Augmented
+            return "If taken to prison, you will keep all of your items.";
+    }
+    return "";
 }
 
 //#endregion

--- a/src/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -6,7 +6,7 @@ simulated static function CurrentVersion(optional out int major, optional out in
     major=3;
     minor=5;
     patch=0;
-    build=2;//build can't be higher than 99
+    build=3;//build can't be higher than 99
 }
 
 simulated static function bool VersionIsStable()

--- a/src/DXRCore/DeusEx/Classes/DXRandoTests.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRandoTests.uc
@@ -1,10 +1,4 @@
-#ifdef hx
-class DXRandoTests extends HXRandoGameInfo;
-#elseif vanilla
-class DXRandoTests extends DeusExGameInfo;
-#else
-class DXRandoTests extends DXRandoGameInfo;
-#endif
+class DXRandoTests extends #switch(hx: HXRandoGameInfo, vanilla: DeusExGameInfo, else: DXRandoGameInfo);
 
 event playerpawn Login
 (

--- a/src/DXRFixes/DeusEx/Classes/ActorDisplayWindow.uc
+++ b/src/DXRFixes/DeusEx/Classes/ActorDisplayWindow.uc
@@ -253,6 +253,7 @@ function DrawWindow(GC gc)
     local Inventory item;
     local name filter;
     local int radius;
+    local FakeMirrorInfo fmi;
     local class<Actor> classToShow;
 
     minpos = vect(999999, 999999, 999999);
@@ -430,13 +431,24 @@ function DrawWindow(GC gc)
                 r=0;
                 g=0;
                 b=0;
-                if (trackActor.bCollideActors){
-                    g=255;
-                } else {
+                if (FakeMirrorInfo(trackActor)!=None){
                     r=255;
+                    g=255;
+                    b=255;
+
+                    fmi = FakeMirrorInfo(trackActor);
+
+                    DrawCube(gc, fmi.min_pos, fmi.max_pos, r, g, b);
+
+                } else {
+                    if (trackActor.bCollideActors){
+                        g=255;
+                    } else {
+                        r=255;
+                    }
+                    DrawColourCylinder(gc, trackActor, r, g, b);
+                    //DrawCylinder(gc, trackActor);
                 }
-                DrawColourCylinder(gc, trackActor, r, g, b);
-                //DrawCylinder(gc, trackActor);
             }
 
             if (trackActor.InStasis())
@@ -954,6 +966,45 @@ function DrawColourCylinder(GC gc, actor trackActor, int r, int g, int b)
     }
     DrawColourLine(gc, topCircle[i], topCircle[0],r,g,b);
     DrawColourLine(gc, bottomCircle[i], bottomCircle[0],r,g,b);
+}
+
+function vector CreateCubeCorner(float x, float y, float z)
+{
+    local vector v;
+
+    v.X = x;
+    v.Y = y;
+    v.Z = z;
+
+    return v;
+}
+
+function DrawCube(GC gc, vector c1, vector c2, int r, int g, int b)
+{
+    local vector corners[8];
+
+    corners[0]=CreateCubeCorner(c1.X,c1.Y,c1.Z); //c1
+    corners[1]=CreateCubeCorner(c2.X,c1.Y,c1.Z);
+    corners[2]=CreateCubeCorner(c2.X,c2.Y,c1.Z);
+    corners[3]=CreateCubeCorner(c1.X,c2.Y,c1.Z);
+    corners[4]=CreateCubeCorner(c1.X,c1.Y,c2.Z);
+    corners[5]=CreateCubeCorner(c2.X,c1.Y,c2.Z);
+    corners[6]=CreateCubeCorner(c2.X,c2.Y,c2.Z); //c2
+    corners[7]=CreateCubeCorner(c1.X,c2.Y,c2.Z);
+
+    DrawColourLine(gc,corners[0],corners[1],r,g,b); //Top square
+    DrawColourLine(gc,corners[1],corners[2],r,g,b); //Top square
+    DrawColourLine(gc,corners[2],corners[3],r,g,b); //Top square
+    DrawColourLine(gc,corners[3],corners[0],r,g,b); //Top square
+    DrawColourLine(gc,corners[0],corners[4],r,g,b); //Verticals
+    DrawColourLine(gc,corners[1],corners[5],r,g,b); //Verticals
+    DrawColourLine(gc,corners[2],corners[6],r,g,b); //Verticals
+    DrawColourLine(gc,corners[3],corners[7],r,g,b); //Verticals
+    DrawColourLine(gc,corners[4],corners[5],r,g,b); //Bottom Square
+    DrawColourLine(gc,corners[5],corners[6],r,g,b); //Bottom Square
+    DrawColourLine(gc,corners[6],corners[7],r,g,b); //Bottom Square
+    DrawColourLine(gc,corners[7],corners[4],r,g,b); //Bottom Square
+
 }
 
 defaultproperties

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
@@ -42,7 +42,6 @@ function PreFirstEntryMapFixes()
 {
     local #var(prefix)MapExit exit;
     local #var(prefix)NYPoliceBoat b;
-    local #var(prefix)HarleyFilben harley;
     local #var(prefix)GuntherHermann gunther;
     local #var(prefix)HumanCivilian hc;
     local #var(prefix)OrdersTrigger ot;
@@ -67,9 +66,8 @@ function PreFirstEntryMapFixes()
     switch(dxr.localURL) {
     //#region UNATCO Island
     case "01_NYC_UNATCOISLAND":
-        foreach AllActors(class'#var(prefix)HarleyFilben', harley) {
-            harley.bImportant = true;
-        }
+        FixHarleyFilben();
+
         //Move this Joe Greene article from inside HQ to outside on the island
         npClass.static.SpawnInfoDevice(self,class'#var(prefix)NewspaperOpen',vectm(7297,-3204.5,-373),rotm(0,0,0,0),'01_Newspaper06');//Forklift in bunker
         npClass.static.SpawnInfoDevice(self,class'#var(prefix)NewspaperOpen',vectm(3163,-1298,-207),rotm(0,0,0,0),'01_Newspaper06');//Backroom near jail

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
@@ -167,11 +167,7 @@ function PreFirstEntryMapFixes()
         MakeTurretsNonHostile(); //Revision has hostile turrets near jail
         SpeedUpUNATCOFurnaceVent();
 
-#ifdef injections
-        foreach AllActors(class'#var(prefix)Newspaper',np)
-#else
-        foreach AllActors(class'DXRInformationDevices',np)
-#endif
+        foreach AllActors(#switch(injections: class'Newspaper', class'DXRInformationDevices'), np)
         {
             //Make both Joe Greene articles in HQ the same one
             if (np.textTag=='01_Newspaper06'){

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
@@ -198,6 +198,7 @@ function PreFirstEntryMapFixes()
             foreach AllActors(class'#var(prefix)WeaponShuriken',tk){
                 tk.bIsSecretGoal=true; //Keep the throwing knives in Anna's mannequin
             }
+            class'FakeMirrorInfo'.static.Create(self,vectm(2475,1872,-80),vectm(2450,2064,-16)); //Mirror window at level 4 entrance
         }
 
         //Spawn some placeholders for new item locations

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
@@ -193,6 +193,7 @@ function PreFirstEntryMapFixes()
                 compublic.BulletinTag = '01_BulletinMenu';
                 break;
             }
+            class'FakeMirrorInfo'.static.Create(self,vectm(2430,1872,-80),vectm(2450,2060,-16)); //Mirror window at level 4 entrance
         } else {
             foreach AllActors(class'#var(prefix)WeaponShuriken',tk){
                 tk.bIsSecretGoal=true; //Keep the throwing knives in Anna's mannequin

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
@@ -168,7 +168,6 @@ function PreFirstEntryMapFixes()
         FixUNATCOCarterCloset();
         MakeTurretsNonHostile(); //Revision has hostile turrets near jail
         SpeedUpUNATCOFurnaceVent();
-        RemoveStopWhenEncroach();
 
 #ifdef injections
         foreach AllActors(class'#var(prefix)Newspaper',np)

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
@@ -494,6 +494,11 @@ function PreFirstEntryMapFixes()
             class'MoverToggleTrigger'.static.CreateMTT(self, 'DXRSmugglerElevatorUsed', 'elevatorbutton', 1, 0, 0.0, 3);
         }
 
+        if (VanillaMaps){
+            foreach AllActors(class'#var(DeusExPrefix)Mover', d,'mirrordoor'){break;}
+            class'FakeMirrorInfo'.static.Create(self,vectm(-527,1660,348),vectm(-627,1655,220),d); //Mirror in front of Smuggler's Stash
+        }
+
         break;
     //#endregion
 

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
@@ -494,10 +494,9 @@ function PreFirstEntryMapFixes()
             class'MoverToggleTrigger'.static.CreateMTT(self, 'DXRSmugglerElevatorUsed', 'elevatorbutton', 1, 0, 0.0, 3);
         }
 
-        if (VanillaMaps){
-            foreach AllActors(class'#var(DeusExPrefix)Mover', d,'mirrordoor'){break;}
-            class'FakeMirrorInfo'.static.Create(self,vectm(-527,1660,348),vectm(-627,1655,220),d); //Mirror in front of Smuggler's Stash
-        }
+        //Verified in both vanilla and Revision
+        foreach AllActors(class'#var(DeusExPrefix)Mover', d,'mirrordoor'){break;}
+        class'FakeMirrorInfo'.static.Create(self,vectm(-527,1660,348),vectm(-627,1655,220),d); //Mirror in front of Smuggler's Stash
 
         break;
     //#endregion

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -502,6 +502,7 @@ function PreFirstEntryMapFixes()
                 compublic.BulletinTag = '03_BulletinMenu';
                 break;
             }
+            class'FakeMirrorInfo'.static.Create(self,vectm(2430,1872,-80),vectm(2450,2060,-16)); //Mirror window at level 4 entrance
         } else {
             foreach AllActors(class'#var(prefix)WeaponShuriken',tk){
                 tk.bIsSecretGoal=true; //Keep the throwing knives in Anna's mannequin

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -347,7 +347,8 @@ function PreFirstEntryMapFixes()
             class'FakeMirrorInfo'.static.Create(self,vectm(-1456,-1645,186),vectm(-1368,-1660,130)); //Women's Bathroom Mirror
             class'FakeMirrorInfo'.static.Create(self,vectm(-1343,-2935,186),vectm(-1256,-2950,130)); //Men's Bathroom Mirror
             class'FakeMirrorInfo'.static.Create(self,vectm(-1455,-2935,186),vectm(-1367,-2950,130)); //Men's Bathroom Mirror
-
+        } else {
+            //These mirrors actually work in Revision, so no FakeMirrorInfo required
         }
         break;
     //#endregion
@@ -398,6 +399,7 @@ function PreFirstEntryMapFixes()
         } else {
             //Revision
             AddSwitch( vect(3745,-2592,140), rot(0, 0, 0), 'BathroomDoor' );
+            //These mirrors actually work in Revision, so no FakeMirrorInfo required
         }
 
         // change "MolePerson" (un)familiarNames to "Mole Person". he's in the wood shack near the Terrorist Leader
@@ -518,6 +520,7 @@ function PreFirstEntryMapFixes()
             foreach AllActors(class'#var(prefix)WeaponShuriken',tk){
                 tk.bIsSecretGoal=true; //Keep the throwing knives in Anna's mannequin
             }
+            class'FakeMirrorInfo'.static.Create(self,vectm(2475,1872,-80),vectm(2450,2064,-16)); //Mirror window at level 4 entrance
         }
 
         SetAllLampsState(true, false, true); // alex isn't in his office

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -106,6 +106,8 @@ function PreFirstEntryMapFixes()
     {
     //#region Battery Park
     case "03_NYC_BATTERYPARK":
+        FixHarleyFilben();
+
         foreach AllActors(class'#var(prefix)NanoKey', k) {
             // unnamed key normally unreachable
             if( k.KeyID == '' || k.KeyID == 'KioskDoors' ) {

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -470,7 +470,6 @@ function PreFirstEntryMapFixes()
         FixAlexsEmail();
         MakeTurretsNonHostile(); //Revision has hostile turrets near jail
         SpeedUpUNATCOFurnaceVent();
-        RemoveStopWhenEncroach();
 
         if(class'MenuChoice_BalanceMaps'.static.MajorEnabled()) {
             k = Spawn(class'#var(prefix)NanoKey',,, vectm(965,900,-28));

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -342,6 +342,12 @@ function PreFirstEntryMapFixes()
             //Mostly for entrance rando, but just in case
             //Revision already has a switch here (although it's small and hard to see)
             AddSwitch( vect(-1673, -1319.913574, 130.813538), rot(0, 32767, 0), 'MoleHideoutOpened' );
+
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1344,-1645,186),vectm(-1256,-1660,130)); //Women's Bathroom Mirror
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1456,-1645,186),vectm(-1368,-1660,130)); //Women's Bathroom Mirror
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1343,-2935,186),vectm(-1256,-2950,130)); //Men's Bathroom Mirror
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1455,-2935,186),vectm(-1367,-2950,130)); //Men's Bathroom Mirror
+
         }
         break;
     //#endregion
@@ -383,6 +389,11 @@ function PreFirstEntryMapFixes()
             }
 
             class'PlaceholderEnemy'.static.Create(self,vectm(4030,-2958,112),,'Shitting');
+
+            class'FakeMirrorInfo'.static.Create(self,vectm(3895,-2730,186),vectm(3808,-2710,130)); //Women's Bathroom Mirror
+            class'FakeMirrorInfo'.static.Create(self,vectm(4007,-2730,186),vectm(3920,-2710,130)); //Women's Bathroom Mirror
+            class'FakeMirrorInfo'.static.Create(self,vectm(3895,-2395,186),vectm(3808,-2375,130)); //Men's Bathroom Mirror
+            class'FakeMirrorInfo'.static.Create(self,vectm(4007,-2395,186),vectm(3920,-2375,130)); //Men's Bathroom Mirror
 
         } else {
             //Revision

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -134,6 +134,15 @@ function PreFirstEntryMapFixes()
             jojo.BarkBindName="JoJoFine";
         }
 
+        if(class'MenuChoice_BalanceMaps'.static.MinorEnabled()) {
+            //Make Paul's door a toggle door instead of TriggerOpenTimed (so you can close it again)
+            foreach AllActors(class'#var(DeusExPrefix)Mover', door){
+                if (door.KeyIDNeeded!='Apartment') continue;
+
+                door.GoToState('TriggerToggle');
+            }
+        }
+
         if (VanillaMaps){
             Spawn(class'#var(prefix)Binoculars',,, vectm(-610.374573,-3221.998779,94.160065)); //Paul's bedside table
 

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -389,7 +389,6 @@ function PreFirstEntryMapFixes()
         FixAlexsEmail();
         MakeTurretsNonHostile(); //Revision has hostile turrets near jail
         SpeedUpUNATCOFurnaceVent();
-        RemoveStopWhenEncroach();
 
         if(class'MenuChoice_BalanceMaps'.static.MajorEnabled()) {
             key = Spawn(class'#var(prefix)NanoKey',,, vectm(965,900,-28));

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -584,6 +584,11 @@ function PreFirstEntryMapFixes()
         SetAllLampsState(false, true, true); // smuggler has one table lamp, upstairs where no one is
         class'MoverToggleTrigger'.static.CreateMTT(self, 'DXRSmugglerElevatorUsed', 'elevatorbutton', 1, 0, 0.0, 5);
 
+        if (VanillaMaps){
+            foreach AllActors(class'#var(DeusExPrefix)Mover', door,'mirrordoor'){break;}
+            class'FakeMirrorInfo'.static.Create(self,vectm(-527,1660,348),vectm(-627,1655,220),door); //Mirror in front of Smuggler's Stash
+        }
+
         break;
     //#endregion
 

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -499,6 +499,7 @@ function PreFirstEntryMapFixes()
 
     //#region Bar
     case "04_NYC_BAR":
+        FixHarleyFilben();
         if (class'MenuChoice_ToggleMemes'.static.IsEnabled(dxr.flags)){
             Spawnm(class'BarDancer',,,vect(-1440,340,48),rot(0,-16348,0));
         } else {

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -416,6 +416,8 @@ function PreFirstEntryMapFixes()
                 }
             }
             class'FakeMirrorInfo'.static.Create(self,vectm(2430,1872,-80),vectm(2450,2060,-16)); //Mirror window at level 4 entrance
+        } else {
+            class'FakeMirrorInfo'.static.Create(self,vectm(2475,1872,-80),vectm(2450,2064,-16)); //Mirror window at level 4 entrance
         }
 
         //Spawn some placeholders for new item locations
@@ -585,10 +587,9 @@ function PreFirstEntryMapFixes()
         SetAllLampsState(false, true, true); // smuggler has one table lamp, upstairs where no one is
         class'MoverToggleTrigger'.static.CreateMTT(self, 'DXRSmugglerElevatorUsed', 'elevatorbutton', 1, 0, 0.0, 5);
 
-        if (VanillaMaps){
-            foreach AllActors(class'#var(DeusExPrefix)Mover', door,'mirrordoor'){break;}
-            class'FakeMirrorInfo'.static.Create(self,vectm(-527,1660,348),vectm(-627,1655,220),door); //Mirror in front of Smuggler's Stash
-        }
+        //Verified in both vanilla and Revision
+        foreach AllActors(class'#var(DeusExPrefix)Mover', door,'mirrordoor'){break;}
+        class'FakeMirrorInfo'.static.Create(self,vectm(-527,1660,348),vectm(-627,1655,220),door); //Mirror in front of Smuggler's Stash
 
         break;
     //#endregion

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -415,6 +415,7 @@ function PreFirstEntryMapFixes()
                     troop.UnfamiliarName = "UNATCO Trooper";
                 }
             }
+            class'FakeMirrorInfo'.static.Create(self,vectm(2430,1872,-80),vectm(2450,2060,-16)); //Mirror window at level 4 entrance
         }
 
         //Spawn some placeholders for new item locations

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -125,6 +125,13 @@ function PreFirstEntryMapFixes()
                     cigs.Destroy();
                 }
             }
+
+            class'FakeMirrorInfo'.static.Create(self,vectm(-2840,1360,-64),vectm(-2875,1487,-160)); //Mirrors between cells
+            class'FakeMirrorInfo'.static.Create(self,vectm(-2875,848,-64),vectm(-2840,978,-160));   //Mirrors between cells
+            class'FakeMirrorInfo'.static.Create(self,vectm(-3010,1035,-64),vectm(-2877,1047,-160)); //Dead Body Cell
+            class'FakeMirrorInfo'.static.Create(self,vectm(-2542,1035,-64),vectm(-2672,1047,-160)); //Miguel Cell
+            class'FakeMirrorInfo'.static.Create(self,vectm(-2833,1300,-64),vectm(-2702,1290,-160)); //Empty Cell
+            //class'FakeMirrorInfo'.static.Create(self,vectm(-3168,1300,-64),vectm(-3039,1290,-160)); //JC's Cell (but we only want this while the window is reflective)
         } else {
             foreach AllActors(class'DeusExMover',dxm){
                 if (dxm.Name=='DeusExMover34'){

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -131,7 +131,9 @@ function PreFirstEntryMapFixes()
             class'FakeMirrorInfo'.static.Create(self,vectm(-3010,1035,-64),vectm(-2877,1047,-160)); //Dead Body Cell
             class'FakeMirrorInfo'.static.Create(self,vectm(-2542,1035,-64),vectm(-2672,1047,-160)); //Miguel Cell
             class'FakeMirrorInfo'.static.Create(self,vectm(-2833,1300,-64),vectm(-2702,1290,-160)); //Empty Cell
-            //class'FakeMirrorInfo'.static.Create(self,vectm(-3168,1300,-64),vectm(-3039,1290,-160)); //JC's Cell (but we only want this while the window is reflective)
+
+            foreach AllActors(class'DeusExMover',dxm,'Mirror'){break;}
+            class'FakeMirrorInfo'.static.Create(self,vectm(-3168,1300,-64),vectm(-3039,1290,-160),dxm); //JC's Cell (but we only want this while the window is reflective)
         } else {
             foreach AllActors(class'DeusExMover',dxm){
                 if (dxm.Name=='DeusExMover34'){

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -125,15 +125,6 @@ function PreFirstEntryMapFixes()
                     cigs.Destroy();
                 }
             }
-
-            class'FakeMirrorInfo'.static.Create(self,vectm(-2840,1360,-64),vectm(-2875,1487,-160)); //Mirrors between cells
-            class'FakeMirrorInfo'.static.Create(self,vectm(-2875,848,-64),vectm(-2840,978,-160));   //Mirrors between cells
-            class'FakeMirrorInfo'.static.Create(self,vectm(-3010,1035,-64),vectm(-2877,1047,-160)); //Dead Body Cell
-            class'FakeMirrorInfo'.static.Create(self,vectm(-2542,1035,-64),vectm(-2672,1047,-160)); //Miguel Cell
-            class'FakeMirrorInfo'.static.Create(self,vectm(-2833,1300,-64),vectm(-2702,1290,-160)); //Empty Cell
-
-            foreach AllActors(class'DeusExMover',dxm,'Mirror'){break;}
-            class'FakeMirrorInfo'.static.Create(self,vectm(-3168,1300,-64),vectm(-3039,1290,-160),dxm); //JC's Cell (but we only want this while the window is reflective)
         } else {
             foreach AllActors(class'DeusExMover',dxm){
                 if (dxm.Name=='DeusExMover34'){
@@ -145,6 +136,16 @@ function PreFirstEntryMapFixes()
 
             //Keypad10 fixed in Vanilla above is already fixed in Revision
         }
+
+        //Mirrors verified in vanilla and Revision
+        class'FakeMirrorInfo'.static.Create(self,vectm(-2840,1360,-64),vectm(-2875,1487,-160)); //Mirrors between cells
+        class'FakeMirrorInfo'.static.Create(self,vectm(-2875,848,-64),vectm(-2840,978,-160));   //Mirrors between cells
+        class'FakeMirrorInfo'.static.Create(self,vectm(-3010,1035,-64),vectm(-2877,1047,-160)); //Dead Body Cell
+        class'FakeMirrorInfo'.static.Create(self,vectm(-2542,1035,-64),vectm(-2672,1047,-160)); //Miguel Cell
+        class'FakeMirrorInfo'.static.Create(self,vectm(-2833,1300,-64),vectm(-2702,1290,-160)); //Empty Cell
+
+        foreach AllActors(class'DeusExMover',dxm,'Mirror'){break;}
+        class'FakeMirrorInfo'.static.Create(self,vectm(-3168,1300,-64),vectm(-3039,1290,-160),dxm); //JC's Cell (but we only want this while the window is reflective)
 
         class'PlaceholderEnemy'.static.Create(self,vectm(-5066,1368,208),,'Sitting');
         class'PlaceholderEnemy'.static.Create(self,vectm(-4981,1521,208),,'Sitting');
@@ -203,6 +204,8 @@ function PreFirstEntryMapFixes()
                 break;
             }
             class'FakeMirrorInfo'.static.Create(self,vectm(2430,1872,-80),vectm(2450,2060,-16)); //Mirror window at level 4 entrance
+        } else {
+            class'FakeMirrorInfo'.static.Create(self,vectm(2475,1872,-80),vectm(2450,2064,-16)); //Mirror window at level 4 entrance
         }
         SpeedUpUNATCOFurnaceVent();
 

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -195,7 +195,6 @@ function PreFirstEntryMapFixes()
             }
         }
         SpeedUpUNATCOFurnaceVent();
-        RemoveStopWhenEncroach();
 
         foreach AllActors(class'#var(prefix)Terrorist', miguel){
             miguel.bHateShot=False;

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -443,8 +443,8 @@ function Inventory FindPrisonPocketItem()
     }
 
     //Items are in slots 1-9, Keyring is in 0
-    for(i=0;i<9;i++){
-        beltItem=root.hud.belt.GetObjectFromBelt(i+1);
+    for(i=1; i<10; i++){
+        beltItem=root.hud.belt.GetObjectFromBelt(i);
 
         if (beltItem==None) continue;
 

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -202,6 +202,7 @@ function PreFirstEntryMapFixes()
                 compublic.SetRotation(rotm(0, -16384, 0, GetRotationOffset(class'#var(prefix)ComputerPublic')));
                 break;
             }
+            class'FakeMirrorInfo'.static.Create(self,vectm(2430,1872,-80),vectm(2450,2060,-16)); //Mirror window at level 4 entrance
         }
         SpeedUpUNATCOFurnaceVent();
 

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM05.uc
@@ -53,6 +53,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)AllianceTrigger at;
     local #var(prefix)CrateUnbreakableLarge crate;
     local #var(prefix)ThugMale2 thug;
+    local #var(prefix)Karkian kark;
 
     local DXREnemies dxre;
     local int i;
@@ -101,6 +102,11 @@ function PreFirstEntryMapFixes()
         foreach AllActors(class'#var(prefix)AnnaNavarre',anna){
             anna.bHateWeapon=False;
             anna.ResetReactions();
+        }
+
+        //Prevent the karkians from getting cloned (so they don't clone outside of the enclosure)
+        foreach AllActors(class'#var(prefix)Karkian', kark){
+            kark.bIsSecretGoal=true;
         }
 
         if (VanillaMaps){

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -95,6 +95,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)BeamTrigger bt;
     local #var(prefix)LaserTrigger lt;
     local #var(prefix)SpiderBot2 sb;
+    local #var(prefix)BreakableGlass bg;
     local DXRButtonHoverHint buttonHint;
     local DXRHoverHint hoverHint;
     local #var(prefix)MJ12Commando commando;
@@ -714,6 +715,19 @@ function PreFirstEntryMapFixes()
             ft.SetCollision(false,false,false);
 
             class'FakeMirrorInfo'.static.Create(self,vectm(-1840,-592,-255),vectm(-1860,-815,-320)); //Men's Bathroom
+
+            bg = None;
+            foreach RadiusActors(class'#var(prefix)BreakableGlass', bg, 10, vectm(-1216,-2048,-320)){break;}
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1152,-2056,-256),vectm(-1280,-2052.5,-382), bg); //Left Conference Window
+
+            bg = None;
+            foreach RadiusActors(class'#var(prefix)BreakableGlass', bg, 10, vectm(-1024,-2048,-320)){break;}
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1088,-2056,-256),vectm(-960,-2052.5,-382), bg); //Middle Conference Window
+
+            bg = None;
+            foreach RadiusActors(class'#var(prefix)BreakableGlass', bg, 10, vectm(-832,-2048,-320)){break;}
+            class'FakeMirrorInfo'.static.Create(self,vectm(-896,-2056,-256),vectm(-768,-2052.5,-382), bg); //Right Conference Window
+
         }
 
         break;
@@ -792,6 +806,10 @@ function PreFirstEntryMapFixes()
                 wc.SetRotation(rot);
                 break;
             }
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1152,425,-15),vectm(-1024,430,80)); //Security Window
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1008,425,-15),vectm(-880,430,80)); //Security Window
+            class'FakeMirrorInfo'.static.Create(self,vectm(-864,425,-15),vectm(-736,430,80)); //Security Window
+            class'FakeMirrorInfo'.static.Create(self,vectm(-720,400,-15),vectm(-710,256,80)); //Security Window
         }
 
         Spawn(class'PlaceholderItem',,, vectm(12.36,1556.5,-51)); //1st floor front cube
@@ -912,6 +930,11 @@ function PreFirstEntryMapFixes()
             ot.Event='SelfDestructSpiders';
             */
 
+        }
+
+        if (VanillaMaps){
+            foreach AllActors(class'#var(prefix)BreakableGlass', bg, 'BreakableGlass'){break;}
+            class'FakeMirrorInfo'.static.Create(self,vectm(121,-672,1086),vectm(63,-628,1146), bg); //Breakable Corner Mirror
         }
 
         Spawn(class'PlaceholderItem',,, vectm(-39.86,-542.35,570.3)); //Computer desk

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -412,6 +412,8 @@ function PreFirstEntryMapFixes()
             class'FakeMirrorInfo'.static.Create(self,vectm(-1195,-1065,2285),vectm(-1075,-1045,2245)); //Maggie's Guest Bathroom
             class'FakeMirrorInfo'.static.Create(self,vectm(-1060,-1415,2285),vectm(-1180,-1405,2240)); //Maggie's Master Bathroom
 
+        } else {
+            //These mirrors actually work in Revision, so no FakeMirrorInfo required
         }
 
         //behind Maggie's DispalyCase (sic), there is a Trigger to open it
@@ -728,6 +730,8 @@ function PreFirstEntryMapFixes()
             foreach RadiusActors(class'#var(prefix)BreakableGlass', bg, 10, vectm(-832,-2048,-320)){break;}
             class'FakeMirrorInfo'.static.Create(self,vectm(-896,-2056,-256),vectm(-768,-2052.5,-382), bg); //Right Conference Window
 
+        } else {
+            //These mirrors actually work in Revision, so no FakeMirrorInfo required
         }
 
         break;
@@ -806,11 +810,13 @@ function PreFirstEntryMapFixes()
                 wc.SetRotation(rot);
                 break;
             }
-            class'FakeMirrorInfo'.static.Create(self,vectm(-1152,425,-15),vectm(-1024,430,80)); //Security Window
-            class'FakeMirrorInfo'.static.Create(self,vectm(-1008,425,-15),vectm(-880,430,80)); //Security Window
-            class'FakeMirrorInfo'.static.Create(self,vectm(-864,425,-15),vectm(-736,430,80)); //Security Window
-            class'FakeMirrorInfo'.static.Create(self,vectm(-720,400,-15),vectm(-710,256,80)); //Security Window
         }
+
+        //Verified in both vanilla and Revision
+        class'FakeMirrorInfo'.static.Create(self,vectm(-1152,425,-15),vectm(-1024,430,80)); //Security Window
+        class'FakeMirrorInfo'.static.Create(self,vectm(-1008,425,-15),vectm(-880,430,80)); //Security Window
+        class'FakeMirrorInfo'.static.Create(self,vectm(-864,425,-15),vectm(-736,430,80)); //Security Window
+        class'FakeMirrorInfo'.static.Create(self,vectm(-720,400,-15),vectm(-710,256,80)); //Security Window
 
         Spawn(class'PlaceholderItem',,, vectm(12.36,1556.5,-51)); //1st floor front cube
         Spawn(class'PlaceholderItem',,, vectm(643.5,2139.7,-51.7)); //1st floor back cube
@@ -932,10 +938,9 @@ function PreFirstEntryMapFixes()
 
         }
 
-        if (VanillaMaps){
-            foreach AllActors(class'#var(prefix)BreakableGlass', bg, 'BreakableGlass'){break;}
-            class'FakeMirrorInfo'.static.Create(self,vectm(121,-672,1086),vectm(63,-628,1146), bg); //Breakable Corner Mirror
-        }
+        //Verified in both vanilla and Revision
+        foreach AllActors(class'#var(prefix)BreakableGlass', bg, 'BreakableGlass'){break;}
+        class'FakeMirrorInfo'.static.Create(self,vectm(121,-672,1086),vectm(63,-628,1146), bg); //Breakable Corner Mirror
 
         Spawn(class'PlaceholderItem',,, vectm(-39.86,-542.35,570.3)); //Computer desk
         Spawn(class'PlaceholderItem',,, vectm(339.25,-2111.46,506.3)); //Near lasers

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -449,6 +449,7 @@ function PreFirstEntryMapFixes()
         }
         foreach AllActors(class'#var(DeusExPrefix)Mover', m, 'elevator_door') {
             m.bIsDoor = true;// DXRDoors will pick this up later since we're in PreFirstEntry
+            m.FragmentClass = class'MetalFragment'; // only one of these two doors has any helpful sounds set
         }
         foreach AllActors(class'#var(prefix)FlagTrigger', ft, 'MJ12Alert') {
             ft.Tag = 'TongHasRom';

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -406,10 +406,10 @@ function PreFirstEntryMapFixes()
                 }
             }
 
-            class'FakeMirrorInfo'.static.Create(self,vectm(1335,-1663,1736),vectm(1345,-1535,1771)); //Jock's Bathroom
+            class'FakeMirrorInfo'.static.Create(self,vectm(1335,-1663,1736),vectm(1345,-1535,1775)); //Jock's Bathroom
             class'FakeMirrorInfo'.static.Create(self,vectm(1345,-1545,1736),vectm(1280,-1535,1790)); //Jock's Bathroom (right side)
-            class'FakeMirrorInfo'.static.Create(self,vectm(-1195,-1065,2280),vectm(-1075,-1045,2245)); //Maggie's Guest Bathroom
-            class'FakeMirrorInfo'.static.Create(self,vectm(-1060,-1415,2280),vectm(-1180,-1405,2240)); //Maggie's Master Bathroom
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1195,-1065,2285),vectm(-1075,-1045,2245)); //Maggie's Guest Bathroom
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1060,-1415,2285),vectm(-1180,-1405,2240)); //Maggie's Master Bathroom
 
         }
 

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -405,6 +405,12 @@ function PreFirstEntryMapFixes()
                     p.bIsSecretGoal = true;// don't clone him, he's too close
                 }
             }
+
+            class'FakeMirrorInfo'.static.Create(self,vectm(1335,-1663,1736),vectm(1345,-1535,1771)); //Jock's Bathroom
+            class'FakeMirrorInfo'.static.Create(self,vectm(1345,-1545,1736),vectm(1280,-1535,1790)); //Jock's Bathroom (right side)
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1195,-1065,2280),vectm(-1075,-1045,2245)); //Maggie's Guest Bathroom
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1060,-1415,2280),vectm(-1180,-1405,2240)); //Maggie's Master Bathroom
+
         }
 
         //behind Maggie's DispalyCase (sic), there is a Trigger to open it
@@ -706,6 +712,8 @@ function PreFirstEntryMapFixes()
             ft.flagValue=false;
             ft.Event='ResumeDate';
             ft.SetCollision(false,false,false);
+
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1840,-592,-255),vectm(-1860,-815,-320)); //Men's Bathroom
         }
 
         break;

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
@@ -458,6 +458,11 @@ function PreFirstEntryMapFixes()
 
             class'MoverToggleTrigger'.static.CreateMTT(self, 'DXRSmugglerElevatorUsed', 'elevatorbutton', 1, 0, 0.0, 9);
 
+            if (VanillaMaps){
+                foreach AllActors(class'#var(DeusExPrefix)Mover', d,'mirrordoor'){break;}
+                class'FakeMirrorInfo'.static.Create(self,vectm(-527,1660,348),vectm(-627,1655,220),d); //Mirror in front of Smuggler's Stash
+            }
+
             break;
     //#endregion
 

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
@@ -407,6 +407,7 @@ function PreFirstEntryMapFixes()
 
     //#region Bar
         case "08_NYC_BAR":
+            FixHarleyFilben();
             npClass.static.SpawnInfoDevice(self,class'#var(prefix)NewspaperOpen',vectm(-1171.976440,250.575806,53.729687),rotm(0,0,0,0),'08_Newspaper01'); //Joe Greene article, table near where Harley is in Vanilla
             if (class'MenuChoice_ToggleMemes'.static.IsEnabled(dxr.flags)){
                 Spawn(class'BarDancer',,,vectm(-2150,-500,48),rotm(0,0,0,0));

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
@@ -458,10 +458,9 @@ function PreFirstEntryMapFixes()
 
             class'MoverToggleTrigger'.static.CreateMTT(self, 'DXRSmugglerElevatorUsed', 'elevatorbutton', 1, 0, 0.0, 9);
 
-            if (VanillaMaps){
-                foreach AllActors(class'#var(DeusExPrefix)Mover', d,'mirrordoor'){break;}
-                class'FakeMirrorInfo'.static.Create(self,vectm(-527,1660,348),vectm(-627,1655,220),d); //Mirror in front of Smuggler's Stash
-            }
+            //Verified in both vanilla and Revision
+            foreach AllActors(class'#var(DeusExPrefix)Mover', d,'mirrordoor'){break;}
+            class'FakeMirrorInfo'.static.Create(self,vectm(-527,1660,348),vectm(-627,1655,220),d); //Mirror in front of Smuggler's Stash
 
             break;
     //#endregion

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
@@ -230,7 +230,7 @@ function PreFirstEntryMapFixes()
     local Smuggler smug;
     local #var(prefix)OrdersTrigger ot;
     local DXRReinforcementPoint reinforce;
-
+    local #var(prefix)BarrelFire bf;
 
 #ifdef injections
     local #var(prefix)Newspaper np;
@@ -331,6 +331,21 @@ function PreFirstEntryMapFixes()
                         dtel.SetDestination("08_NYC_Smug", 'PathNode83',, 16384);
                         class'DXREntranceRando'.static.AdjustTeleporterStatic(dxr, dtel);
                         break;
+                    }
+                }
+            }
+
+            if (VanillaMaps){
+                foreach AllActors(class'#var(prefix)BarrelFire', bf) {
+                    if(bf.name=='BarrelFire0') {
+                        bf.bIsSecretGoal = true; // the flaming barrel near Dowd is good for visibility
+                        break;
+                    }
+                }
+            } else {
+                foreach AllActors(class'#var(prefix)BarrelFire', bf) {
+                    if(bf.name=='BarrelFire40' || bf.name=='BarrelFire41') {
+                        bf.bIsSecretGoal = true; // the flaming barrel near Dowd is good for visibility
                     }
                 }
             }

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
@@ -250,6 +250,7 @@ function PreFirstEntryMapFixes_Bunker(bool isVanilla)
         class'PlaceholderEnemy'.static.Create(self,vectm(3744,-1030,-7481));
         class'PlaceholderEnemy'.static.Create(self,vectm(1341,3154,-464),,'Sitting');
         class'PlaceholderEnemy'.static.Create(self,vectm(1191,3035,-464),,'Sitting');
+        class'PlaceholderEnemy'.static.Create(self,vectm(480, -2730, -300), 9416); // on top of the vent entrance, because it's overused
 
         rg=Spawn(class'#var(prefix)RatGenerator',,, vectm(1658,2544,-522));//Behind Command 24
         rg.MaxCount=1;

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -225,6 +225,8 @@ function PreFirstEntryMapFixes()
             CandleabraLight(vect(1162.240112, 1481.900024, 879.068848), rot(0, 16384, 0));
 
             class'FakeMirrorInfo'.static.Create(self,vectm(1068,795,890),vectm(1028,810,835)); //Apartment Bathroom
+        } else {
+            class'FakeMirrorInfo'.static.Create(self,vectm(1352,-640,740),vectm(1451,-620,627)); //Apartment mirror near front door
         }
 
         //Add teleporter hint text to Jock
@@ -286,6 +288,8 @@ function PreFirstEntryMapFixes()
         if (VanillaMaps) {
             class'FakeMirrorInfo'.static.Create(self,vectm(-1575,-970,-55),vectm(-1585,-1155,-140)); //Bathroom mirror 1
             class'FakeMirrorInfo'.static.Create(self,vectm(-1015,-1530,-55),vectm(-1005,-1345,-140)); //Bathroom mirror 2
+        } else {
+            //These mirrors actually work in Revision, so no FakeMirrorInfo required
         }
 
         break;
@@ -434,10 +438,9 @@ function PreFirstEntryMapFixes()
 
         SetAllLampsState(true, false, true); // Everett's bedroom
 
-        if (VanillaMaps){
-            foreach AllActors(class'DeusExMover',m,'morganmirror'){break;}
-            class'FakeMirrorInfo'.static.Create(self,vectm(980,1480,508),vectm(1065,1473,390),m); //Mirror in front of Lucius's door
-        }
+        //Verified in both vanilla and Revision
+        foreach AllActors(class'DeusExMover',m,'morganmirror'){break;}
+        class'FakeMirrorInfo'.static.Create(self,vectm(980,1480,508),vectm(1065,1473,390),m); //Mirror in front of Lucius's door
 
         break;
     //#endregion

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -281,6 +281,11 @@ function PreFirstEntryMapFixes()
         Spawn(class'PlaceholderItem',,, vectm(-1464,-1649.6,-197)); //Bathroom stall 1
         Spawn(class'PlaceholderItem',,, vectm(-1096.7,-847,-197)); //Bathroom stall 2
 
+        if (VanillaMaps) {
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1575,-970,-55),vectm(-1585,-1155,-140)); //Bathroom mirror 1
+            class'FakeMirrorInfo'.static.Create(self,vectm(-1015,-1530,-55),vectm(-1005,-1345,-140)); //Bathroom mirror 2
+        }
+
         break;
     //#endregion
 

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -31,6 +31,7 @@ function PreFirstEntryMapFixes()
     local DestroyTrigger desTrig;
     local #var(injectsprefix)AllianceTrigger at;
     local #var(prefix)ControlPanel cp;
+    local #var(DeusExPrefix)Decoration dec;
     local Actor a;
 
     VanillaMaps = class'DXRMapVariants'.static.IsVanillaMaps(player());
@@ -42,7 +43,8 @@ function PreFirstEntryMapFixes()
         FixConversationAddNote(GetConversation('MeetAimee'), "Stupid, stupid, stupid password.");
         SetAllLampsState(true, false, true); // lamps in the building next to the metro station
 
-        AddSwitch(vect(-3615.780029, 3953.899902, 2121.5), rot(0, 16384, 0), 'roof_elevator_call');
+        dec = AddSwitch(vect(-3615.780029, 3953.899902, 2121.5), rot(0, 16384, 0), 'roof_elevator_call');
+        dec.ItemName = "Call Button";
         elevatortrig = Spawn(class'DXRMoverSequenceTrigger',, 'roof_elevator_call');
         elevatortrig.Event = 'roof_elevator';
 

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -223,6 +223,8 @@ function PreFirstEntryMapFixes()
             // make the apartment stairs less hidden, not safe to have stairs without a light!
             CandleabraLight(vect(1825.758057, 1481.900024, 576.077698), rot(0, 16384, 0));
             CandleabraLight(vect(1162.240112, 1481.900024, 879.068848), rot(0, 16384, 0));
+
+            class'FakeMirrorInfo'.static.Create(self,vectm(1068,795,890),vectm(1028,810,835)); //Apartment Bathroom
         }
 
         //Add teleporter hint text to Jock

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -432,6 +432,11 @@ function PreFirstEntryMapFixes()
 
         SetAllLampsState(true, false, true); // Everett's bedroom
 
+        if (VanillaMaps){
+            foreach AllActors(class'DeusExMover',m,'morganmirror'){break;}
+            class'FakeMirrorInfo'.static.Create(self,vectm(980,1480,508),vectm(1065,1473,390),m); //Mirror in front of Lucius's door
+        }
+
         break;
     //#endregion
     }

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
@@ -15,7 +15,7 @@ function int InitGoals(int mission, string map)
     pauldock = AddGoalLocation("01_NYC_UNATCOISLAND", "South Dock", NORMAL_GOAL | VANILLA_START, vect(-4760.569824, 10430.811523, -280.674988), rot(0, -7040, 0));
     hut = AddGoalLocation("01_NYC_UNATCOISLAND", "Hut", NORMAL_GOAL, vect(-2407.206787, 205.915558, -128.899979), rot(0, 30472, 0));
     electric = AddGoalLocation("01_NYC_UNATCOISLAND", "Electric Bunker", NORMAL_GOAL | START_LOCATION, vect(6552.227539, -3246.095703, -447.438049), rot(0, 0, 0));
-    jail = AddGoalLocation("01_NYC_UNATCOISLAND", "Jail", NORMAL_GOAL | START_LOCATION, vect(2127.692139, -1774.869141, -149.140366), rot(0, 0, 0));
+    jail = AddGoalLocation("01_NYC_UNATCOISLAND", "Jail", NORMAL_GOAL | START_LOCATION, vect(2127.692139, -1774.869141, -149.140366), rot(0, -16159, 0));
     topofbase = AddGoalLocation("01_NYC_UNATCOISLAND", "Top of the Base", NORMAL_GOAL, vect(2980.058105, -669.242554, 1056.577271), rot(0, 0, 0));
     top = AddGoalLocation("01_nyc_unatcoisland", "Top of the Statue", NORMAL_GOAL | VANILLA_GOAL | START_LOCATION, vect(2931.230957, 27.495235, 2527.800049), rot(0, 14832, 0));
     harleydock = AddGoalLocation("01_NYC_UNATCOISLAND", "North Dock", NORMAL_GOAL | START_LOCATION, vect(4018,-10308,-256), rot(0, 22520, 0));
@@ -77,7 +77,7 @@ function int InitGoalsRev(int mission, string map)
     pauldock = AddGoalLocation("01_NYC_UNATCOISLAND", "South Dock", NORMAL_GOAL | VANILLA_START, vect(-4728.569824, 9358.811523, -280.674988), rot(0, -7040, 0));
     hut = AddGoalLocation("01_NYC_UNATCOISLAND", "Hut", NORMAL_GOAL, vect(-2404,177,-83), rot(0, 30472, 0));
     electric = AddGoalLocation("01_NYC_UNATCOISLAND", "Electric Bunker", NORMAL_GOAL | START_LOCATION, vect(6552.227539, -3246.095703, -447.438049), rot(0, 0, 0));
-    jail=AddGoalLocation("01_NYC_UNATCOISLAND", "Jail", NORMAL_GOAL | START_LOCATION, vect(2127.692139, -1774.869141, -149.140366), rot(0, 0, 0));
+    jail=AddGoalLocation("01_NYC_UNATCOISLAND", "Jail", NORMAL_GOAL | START_LOCATION, vect(2127.692139, -1774.869141, -149.140366), rot(0, -16159, 0));
     topofbase = AddGoalLocation("01_NYC_UNATCOISLAND", "Top of the Base", NORMAL_GOAL, vect(2980.058105, -669.242554, 1056.577271), rot(0, 0, 0));
     top = AddGoalLocation("01_NYC_UNATCOISLAND", "Top of the Statue", NORMAL_GOAL | VANILLA_GOAL | START_LOCATION, vect(2931.230957, 27.495235, 2527.800049), rot(0, 14832, 0));
     harleydock = AddGoalLocation("01_NYC_UNATCOISLAND", "North Dock", NORMAL_GOAL | START_LOCATION, vect(4205,-9811,-279), rot(0, 0, 0));

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsM02.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsM02.uc
@@ -16,7 +16,7 @@ function int InitGoals(int mission, string map)
         AddGoalLocation("02_NYC_BATTERYPARK", "Dock", START_LOCATION | VANILLA_START, vect(-619.571289, -3679.116455, 255.099762), rot(0, 29856, 0));
         AddGoalLocation("02_NYC_BATTERYPARK", "Behind the Castle", START_LOCATION, vect(2364.934326, -2026.725952, 363.899994), rot(0, 159109, 0));
 
-        AddGoalLocation("02_NYC_BATTERYPARK", "In the command room", NORMAL_GOAL | START_LOCATION, vect(650.060547, -989.234863, -160.095200), rot(0, 0, 0));
+        AddGoalLocation("02_NYC_BATTERYPARK", "In the command room", NORMAL_GOAL | START_LOCATION, vect(650.060547, -989.234863, -160.095200), rot(0, 16718, 0));
 
         AddGoalLocation("02_NYC_BATTERYPARK", "Ambrosia Vanilla", NORMAL_GOAL | VANILLA_GOAL, vect(507.282898, -1066.344604, -403.132751), rot(0, 16536, 0));
         AddGoalLocation("02_NYC_BATTERYPARK", "Shanty Town", NORMAL_GOAL, vect(-2970,1840,348), rot(0, 0, 0));
@@ -99,9 +99,9 @@ function int InitGoalsRev(int mission, string map)
         AddGoalLocation("02_NYC_BATTERYPARK", "Dock", START_LOCATION | VANILLA_START, vect(-619.571289, -3679.116455, 255.099762), rot(0, 29856, 0));
         AddGoalLocation("02_NYC_BATTERYPARK", "Behind the Castle", START_LOCATION, vect(2364.934326, -2026.725952, 363.899994), rot(0, 159109, 0)); //TODO: Check location
 
-        AddGoalLocation("02_NYC_BATTERYPARK", "In the command room", NORMAL_GOAL | START_LOCATION, vect(650.060547, -989.234863, -160.095200), rot(0, 0, 0));
+        AddGoalLocation("02_NYC_BATTERYPARK", "In the command room", NORMAL_GOAL | START_LOCATION, vect(650.060547, -989.234863, -160.095200), rot(0, 16718, 0));
 
-        loc = AddGoalLocation("02_NYC_BATTERYPARK", "Ambrosia Vanilla", NORMAL_GOAL | VANILLA_GOAL | START_LOCATION, vect(507.282898, -1066.344604, -403.132751), rot(0, 16536, 0));
+        loc = AddGoalLocation("02_NYC_BATTERYPARK", "Ambrosia Vanilla", NORMAL_GOAL | VANILLA_GOAL, vect(507.282898, -1066.344604, -403.132751), rot(0, 16536, 0));
         AddActorLocation(loc, PLAYER_LOCATION, vect(81.434570, -1123.060547, -384.397644), rot(0, 8000, 0));
         AddGoalLocation("02_NYC_BATTERYPARK", "Shanty Town", NORMAL_GOAL, vect(-2970,1840,348), rot(0, 0, 0));
         AddGoalLocation("02_NYC_BATTERYPARK", "Behind the cargo", NORMAL_GOAL, vect(185,-30,-405), rot(0, 32768, 0));

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsM03.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsM03.uc
@@ -13,14 +13,14 @@ function int InitGoals(int mission, string map)
 
         AddGoalLocation("03_NYC_BATTERYPARK", "Jock", START_LOCATION | VANILLA_START, vect(-1226.699951, 2215.864258, 400.663818), rot(0, -25672, 0));
 
-        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Castle Clinton Entrance", NORMAL_GOAL | START_LOCATION, vect(1082.374023, 1458.807617, 334.248260), rot(0, 0, 0));
+        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Castle Clinton Entrance", NORMAL_GOAL | START_LOCATION, vect(1082.374023, 1458.807617, 334.248260), rot(0, 33619, 0));
         AddActorLocation(loc, 1, vect(1161.899657, 1559.100464, 331.741821), rot(0,0,0));
         AddActorLocation(loc, PLAYER_LOCATION, vect(1161.899657, 1559.100464, 331.741821), rot(0,34194,0));
 
-        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Eagle Statue", NORMAL_GOAL | START_LOCATION, vect(-2968.101563, -1407.404419, 334.242554), rot(0, 0, 0));
+        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Eagle Statue", NORMAL_GOAL | START_LOCATION, vect(-2968.101563, -1407.404419, 334.242554), rot(0, -16431, 0));
         AddActorLocation(loc, 1, vect(-2888.101563, -1307.404419, 332.242554), rot(0,0,0));
 
-        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Dock", NORMAL_GOAL | START_LOCATION, vect(-1079.890625, -3412.052002, 270.581390), rot(0, 0, 0));
+        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Dock", NORMAL_GOAL | START_LOCATION, vect(-1079.890625, -3412.052002, 270.581390), rot(0, -32966, 0));
         AddActorLocation(loc, 1, vect(-999.890625, -3312.052002, 268), rot(0,0,0));
 
         loc = AddGoalLocation("03_NYC_BATTERYPARK", "Hut", NORMAL_GOAL | VANILLA_GOAL, vect(-2763.231689,1370.594604,373.603882), rot(0,7272,0));
@@ -135,19 +135,19 @@ function int InitGoalsRev(int mission, string map)
 
         AddGoalLocation("03_NYC_BATTERYPARK", "Jock", START_LOCATION | VANILLA_START, vect(942,2675,387), rot(0, -25672, 0));
 
-        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Castle Clinton Entrance", NORMAL_GOAL | START_LOCATION, vect(1082.374023, 1458.807617, 334.248260), rot(0, 0, 0));
+        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Castle Clinton Entrance", NORMAL_GOAL | START_LOCATION, vect(1082.374023, 1458.807617, 334.248260), rot(0, 33619, 0));
         AddActorLocation(loc, 1, vect(1161.899657, 1559.100464, 331.741821), rot(0,0,0));
 
-        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Eagle Statue", NORMAL_GOAL | START_LOCATION, vect(-2968.101563, -1407.404419, 334.242554), rot(0, 0, 0));
+        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Eagle Statue", NORMAL_GOAL | START_LOCATION, vect(-2968.101563, -1407.404419, 334.242554), rot(0, -16431, 0));
         AddActorLocation(loc, 1, vect(-2888.101563, -1307.404419, 332.242554), rot(0,0,0));
 
-        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Dock", NORMAL_GOAL | START_LOCATION, vect(-1079.890625, -3412.052002, 270.581390), rot(0, 0, 0));
+        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Dock", NORMAL_GOAL | START_LOCATION, vect(-1079.890625, -3412.052002, 270.581390), rot(0, -32966, 0));
         AddActorLocation(loc, 1, vect(-999.890625, -3312.052002, 268), rot(0,0,0));
 
         loc = AddGoalLocation("03_NYC_BATTERYPARK", "Hut", NORMAL_GOAL | VANILLA_GOAL, vect(-2763.231689,1370.594604,373.603882), rot(0,7272,0));
         AddActorLocation(loc, 1, vect(-2683.231689, 1470.594604, 371), rot(0,0,0));
 
-        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Subway", NORMAL_GOAL | VANILLA_GOAL | START_LOCATION, vect(-4819.345215,3478.138916,-304.225006), rot(0,0,0));
+        loc = AddGoalLocation("03_NYC_BATTERYPARK", "Subway", NORMAL_GOAL | VANILLA_GOAL | START_LOCATION, vect(-4819.345215,3478.138916,-304.225006), rot(0,-20823,0));
         AddActorLocation(loc, 1, vect(-4739.345215, 3578.138916, -306), rot(0,0,0));
 
         if (dxr.flags.settings.starting_map > 32)

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsM09.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsM09.uc
@@ -276,7 +276,6 @@ function bool IsLayoutAllowed(int goalsToLocations[32])
                     break;
 
                 case "South Helipad":
-                case "Helipad Air Control":
                 case "East Helipad":
                 case "Helibay Barracks":
                 case "Helipad Air Control":

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsVandenberg.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsVandenberg.uc
@@ -18,15 +18,15 @@ function int InitGoals(int mission, string map)
         AddGoalLocation("12_VANDENBERG_CMD", "Third Floor Elevator", NORMAL_GOAL, vect(444.509338, 1503.229126, -1415.007568), rot(0, -16384, 0));
 
         loc = AddGoalLocation("12_VANDENBERG_CMD", "Near Pipes", NORMAL_GOAL | START_LOCATION, vect(-288.769806, 1103.257813, -1984.334717), rot(0, -16384, 0));
-        AddActorLocation(loc, PLAYER_LOCATION, vect(-214.927200, 888.034485, -2043.409302), rot(0, 0, 0));
+        AddActorLocation(loc, PLAYER_LOCATION, vect(-214.927200, 888.034485, -2043.409302), rot(0, 25877, 0));
 
         loc = AddGoalLocation("12_VANDENBERG_CMD", "Globe Room", NORMAL_GOAL | START_LOCATION, vect(-1276.664063, 1168.599854, -1685.868042), rot(0, 16384, 0));
         AddActorLocation(loc, PLAYER_LOCATION, vect(-1879.828003, 1820.156006, -1777.113892), rot(0, 0, 0));
 
         loc = AddGoalLocation("12_VANDENBERG_CMD", "Roof", NORMAL_GOAL | START_LOCATION | VANILLA_START, vect(927.361328, 2426.330811, -867.404114), rot(0, 32768, 0));
-        AddActorLocation(loc, PLAYER_LOCATION, vect(657.233215, 2501.673096, -908.798096), rot(0, -16384, 0));
+        AddActorLocation(loc, PLAYER_LOCATION, vect(657.233215, 2501.673096, -908.798096), rot(0, -7990, 0));
 
-        front_gate_start = AddGoalLocation("12_VANDENBERG_CMD", "Front Gate", START_LOCATION, vect(6436.471680, 7621.873535, -3061.458740), rot(0, 0, 0));
+        front_gate_start = AddGoalLocation("12_VANDENBERG_CMD", "Front Gate", START_LOCATION, vect(6436.471680, 7621.873535, -3061.458740), rot(0, 33063, 0));
         AddGoalLocation("12_VANDENBERG_CMD", "Outdoor Power Generator", NORMAL_GOAL | VANILLA_GOAL, vect(-2371.028564,-96.179214,-2070.390625), rot(0,-32768,0));
         AddGoalLocation("12_VANDENBERG_CMD", "Command Center Power Generator", NORMAL_GOAL | VANILLA_GOAL, vect(1628.947754,1319.745483,-2014.406982), rot(0,-65536,0));
 
@@ -151,15 +151,15 @@ function int InitGoalsRev(int mission, string map)
         AddGoalLocation("12_VANDENBERG_CMD", "Third Floor Elevator", NORMAL_GOAL, vect(444.509338, 1503.229126, -1415.007568), rot(0, -16384, 0));
 
         loc = AddGoalLocation("12_VANDENBERG_CMD", "Near Pipes", NORMAL_GOAL | START_LOCATION, vect(-288.769806, 1103.257813, -1984.334717), rot(0, -16384, 0));
-        AddActorLocation(loc, PLAYER_LOCATION, vect(-214.927200, 888.034485, -2043.409302), rot(0, 0, 0));
+        AddActorLocation(loc, PLAYER_LOCATION, vect(-214.927200, 888.034485, -2043.409302), rot(0, 25877, 0));
 
         loc = AddGoalLocation("12_VANDENBERG_CMD", "Globe Room", NORMAL_GOAL | START_LOCATION, vect(-1276.664063, 1168.599854, -1685.868042), rot(0, 16384, 0));
         AddActorLocation(loc, PLAYER_LOCATION, vect(-1879.828003, 1820.156006, -1777.113892), rot(0, 0, 0));
 
         loc = AddGoalLocation("12_VANDENBERG_CMD", "Roof", NORMAL_GOAL | START_LOCATION | VANILLA_START, vect(927.361328, 2426.330811, -867.404114), rot(0, 32768, 0));
-        AddActorLocation(loc, PLAYER_LOCATION, vect(657.233215, 2501.673096, -908.798096), rot(0, -16384, 0));
+        AddActorLocation(loc, PLAYER_LOCATION, vect(657.233215, 2501.673096, -908.798096), rot(0, -7990, 0));
 
-        front_gate_start = AddGoalLocation("12_VANDENBERG_CMD", "Front Gate", START_LOCATION, vect(6436.471680, 7621.873535, -3061.458740), rot(0, 0, 0));
+        front_gate_start = AddGoalLocation("12_VANDENBERG_CMD", "Front Gate", START_LOCATION, vect(6436.471680, 7621.873535, -3061.458740), rot(0, 33063, 0));
         AddGoalLocation("12_VANDENBERG_CMD", "Outdoor Power Generator", NORMAL_GOAL | VANILLA_GOAL, vect(-2371.028564,-96.179214,-2070.390625), rot(0,-32768,0));
         AddGoalLocation("12_VANDENBERG_CMD", "Command Center Power Generator", NORMAL_GOAL | VANILLA_GOAL, vect(1628.947754,1319.745483,-2014.406982), rot(0,-65536,0));
 

--- a/src/DXRModules/DeusEx/Classes/DXRAutosave.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRAutosave.uc
@@ -397,6 +397,8 @@ function string GetAutoSaveHelpText(coerce int choice)
         return "The game will automatically save the first time you enter a level.|n|nNo manual saves are allowed.|n|nThe autosave is overwritten when entering each map, except for the very first autosave of the mission.";
     case ExtraSafe:
         return "The game will automatically save after every level transition.|n|nYou are allowed to save manually whenever you would like.|n|nAutosaves are never cleared. A single playthrough may create over 1 GB worth of saves.";
+    case Ironman:
+        return "Absolutely no saves whatsoever.  One death and it's all over.  Good luck!";
     case LimitedSaves:
         return "The game will only autosave once at the start of the game.|n|nManual saves are allowed at any time, but require a Memory Containment Unit.|n|nMemory Containment Units can be found randomly placed around levels.";
     case FixedSaves:

--- a/src/DXRModules/DeusEx/Classes/DXRDoors.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRDoors.uc
@@ -118,6 +118,15 @@ function CheckConfig()
         i++;
         break;
 
+    case "06_HONGKONG_STORAGE":
+        // breaking these doors open allows you to skip the computer, which is very confusing for players
+        door_fixes[i].tag = 'UC_Chamber_Door';
+        door_fixes[i].bBreakable = false;
+        door_fixes[i].bPickable = false;
+        door_fixes[i].bHighlight = false;
+        i++;
+        break;
+
     case "09_NYC_SHIP":
         // don't break the ramp up to the ship!
         door_fixes[i].tag = 'ShipRamp';

--- a/src/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -3543,6 +3543,9 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             return "Kill enough of the named X51 scientists in Vandenberg.|n|n - Carla Brown on the roof|n - Stacy Webber in front of the hazard lab|n - Tim Baker in the closet near the hazard lab|n"$" - Stephanie Maxwell near the command room doors|n - Tony Mares in the comms building|n - Ben Roper in the command room|n"$" - Latasha Taylor in the command room|n - Stacey Marshall in the command room (with LDDP installed)";
         case "JoyOfCooking":
             return "Read a recipe from a book and experience the joy of cooking!|n|nThere is a recipe for Chinese Silver Loaves in the Wan Chai Market, and a recipe for Coq au Vin in the streets of Paris.";
+        case "DolphinJump": // keep height number in sync with DolphinJumpTrigger CreateDolphin
+            msg = TrimTrailingZeros(FloatToString(GetRealDistance(184), 1)) @ GetDistanceUnitLong();
+            return "Jump " $ msg $ " out of the water.|n|nHow high in the sky can you fly?";
         default:
             return "Unable to find help text for event '"$event$"'|nReport this to the developers!";
     }
@@ -3982,6 +3985,9 @@ defaultproperties
     bingo_options(354)=(event="EmergencyExit",desc="Locate %s emergency exits",desc_singular="Locate 1 emergency exit",max=8,missions=1918)
     bingo_options(355)=(event="Ex51",desc="Ex-51 (%s)",desc_singular="Ex-51",max=6,missions=4096)
     bingo_options(356)=(event="JoyOfCooking",desc="The Joy of Cooking",max=1,missions=1088)
+#ifdef injections || revision
+    bingo_options(357)=(event="DolphinJump",desc="The marks on your head look like stars in the sky",max=1,missions=56910)
+#endif
     //Current bingo_options array size is 400.  Keep this at the bottom of the list as a reminder!
 //#endregion
 

--- a/src/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -1162,6 +1162,7 @@ function SetWatchFlags() {
         }
         raceStart.raceName="Catacombs";
         raceStart.SetCollisionSize(60,80);
+        raceStart.targetTime=90; //Under 1 minute (around 55ish seconds) is possible if you really blast it
 
         checkPoint = Spawn(class'DXRRaceCheckPoint',,,vectm(2775,-3785,-450)); //Lines up for both
         checkPoint.SetCollisionSize(100,80);
@@ -1171,6 +1172,7 @@ function SetWatchFlags() {
         raceStart = Spawn(class'DXRRaceTimerStart',,,vectm(2775,-3785,-450));
         raceStart.raceName="Reverse Catacombs";
         raceStart.SetCollisionSize(100,80);
+        raceStart.targetTime=60; //Under 1 minute (around 55ish seconds) is possible forwards if you really blast it
 
         if (RevisionMaps){
             checkPoint = Spawn(class'DXRRaceCheckPoint',,,vectm(-3287,-2270,555));

--- a/src/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -2545,14 +2545,17 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
     switch(event){
         case "Free Space":
             return "Don't worry about it!  This one's free!";
+        case "TerroristCommander_Dead":
         case "TerroristCommander_PlayerDead":
             return "Kill Leo Gold, the terrorist commander on Liberty Island.  You must kill him yourself.";
         case "TiffanySavage_Dead":
             return "Let Tiffany Savage die (or kill her yourself).  She is being held hostage at the gas station.";
         case "PaulDenton_Dead":
             return "Let Paul Denton die (or kill him yourself) during the ambush on the hotel.";
+        case "JordanShea_Dead":
         case "JordanShea_PlayerDead":
             return "Kill Jordan Shea, the bartender at the Underworld Tavern in New York.  You must kill her yourself.";
+        case "SandraRenton_Dead":
         case "SandraRenton_PlayerDead":
             msg = "Kill Sandra Renton.  ";
             if (mission<=2){
@@ -2566,36 +2569,49 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             }
             msg = msg $ ".  You must kill her yourself.";
             return msg;
+        case "GilbertRenton_Dead":
         case "GilbertRenton_PlayerDead":
             return "Kill Gilbert Renton.  He can be found behind the front desk in the 'Ton hotel.  You must kill him yourself.";
         case "WarehouseEntered":
             return "Enter the underground warehouse in Paris.  This warehouse is located in the building across the street from the entrance to the Catacombs.";
         case "GuntherHermann_Dead":
             return "Kill Gunther.  He can be found guarding a computer somewhere in the cathedral in Paris.";
+        case "JoJoFine_Dead":
         case "JoJoFine_PlayerDead":
             return "Kill Jojo Fine.  He can be found in the 'Ton hotel before the ambush.  You must kill him yourself.";
+        case "TobyAtanwe_Dead":
         case "TobyAtanwe_PlayerDead":
             return "Kill Toby Atanwe, who is Morgan Everett's assistant.  He can be killed once you arrive at Everett's house.  You must kill him yourself.";
+        case "Antoine_Dead":
         case "Antoine_PlayerDead":
             return "Kill Antoine in the Paris club.  He can be found at a table in a back corner of the club selling bioelectric cells.  You must kill him yourself.";
+        case "Chad_Dead":
         case "Chad_PlayerDead":
             return "Kill Chad Dumier.  He can be found in the Silhouette hideout in the Paris catacombs.  You must kill him yourself.";
         case "paris_hostage_Dead":
             return "Let both of the hostages in the Paris catacombs die (whether you do it yourself or not).  They can be found locked in the centre of the catacombs bunker occupied by MJ12.";
+        case "Hela_Dead":
         case "Hela_PlayerDead":
             return "Kill Hela, the woman in black leading the MJ12 force in the Paris catacombs.  You must kill her yourself.";
+        case "Renault_Dead":
         case "Renault_PlayerDead":
             return "Kill Renault in the Paris hostel.  He is the man who asks you to steal zyme and will buy it from you.  You must kill him yourself.";
+        case "Labrat_Bum_Dead":
         case "Labrat_Bum_PlayerDead":
             return "Kill the bum locked up in the Hong Kong MJ12 lab.  You must kill him yourself.";
+        case "DXRNPCs1_Dead":
         case "DXRNPCs1_PlayerDead":
             return "Kill The Merchant.  He will randomly spawn in levels according to your chosen game settings.  You must kill him yourself.  Keep in mind that once you kill him, he will no longer appear for the rest of your run!";
+        case "lemerchant_Dead":
         case "lemerchant_PlayerDead":
             return "Kill Le Merchant.  He spawns near where you first land in Paris.  He's a different guy!  You must kill him yourself.";
+        case "Harold_Dead":
         case "Harold_PlayerDead":
             return "Kill Harold the mechanic.  He can be found working underneath the 747 in the LaGuardia hangar.  You must kill him yourself.";
+        case "aimee_Dead":
         case "aimee_PlayerDead":
             return "Kill Aimee, the woman worrying about her cats in Paris.  She can be found near where you first land in Paris.  You must kill her yourself.";
+        case "WaltonSimons_Dead":
         case "WaltonSimons_PlayerDead":
             msg="Kill Walton Simons.  ";
             if (mission<=14){
@@ -2605,6 +2621,7 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             }
             msg=msg$".  You must kill him yourself.";
             return msg;
+        case "JoeGreene_Dead":
         case "JoeGreene_PlayerDead":
             msg= "Kill Joe Greene, the reporter poking around in New York.  ";
             if (mission<=4){
@@ -2694,12 +2711,14 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             return "Rescue the hostages on the top floor of the 'Ton as well as Gilbert Renton.";
         case "SilhouetteHostagesAllRescued":
             return "Save both hostages in the Paris catacombs and escort them to safety in the Silhouette hideout.";
+        case "JosephManderley_Dead":
         case "JosephManderley_PlayerDead":
             return "Kill Manderley while escaping from UNATCO.  You must kill him yourself.";
         case "MadeItToBP":
             return "After the raid on the 'Ton hotel, escape to Gunther's roadblock in Battery Park.";
         case "MeetSmuggler":
             return "Talk to Smuggler in his Hell's Kitchen hideout.";
+        case "SickMan_Dead":
         case "SickMan_PlayerDead":
             return "Kill the junkie in Battery Park who asks for someone to kill him.  He is typically found near the East Coast Memorial (the eagle statue and large plaques).  You must kill him yourself.";
         case "M06PaidJunkie":
@@ -2882,22 +2901,27 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             return "Let Anna kill Lebedev by walking away without killing him yourself.";
         case "PlayerKilledLebedev":
             return "Murder Juan Lebedev on the 747 of your own volition.";
+        case "JuanLebedev_Unconscious":
         case "JuanLebedev_PlayerUnconscious":
             return "Knock Lebedev out instead of killing him.  You must knock him out yourself.";
         case "BrowserHistoryCleared":
             return "While escaping UNATCO, log into the computer in your office and clear your browser history.";
         case "AnnaKillswitch":
             return "After finding the pieces of Anna's killphrase, actually use it against her.";
+        case "AnnaNavarre_DeadM3":
         case "AnnaNavarre_PlayerDeadM3":
             return "Kill Anna Navarre on the 747.  You must kill her yourself.";
+        case "AnnaNavarre_DeadM4":
         case "AnnaNavarre_PlayerDeadM4":
             return "Kill Anna Navarre after sending the signal for the NSF but before being captured by UNATCO.  You must kill her yourself.";
+        case "AnnaNavarre_DeadM5":
         case "AnnaNavarre_PlayerDeadM5":
             return "Kill Anna Navarre in UNATCO HQ.  You must kill her yourself.";
         case "SimonsAssassination":
             return "Watch Walton Simons' full interrogation of the captured NSF soldiers.";
         case "AlliesKilled":
             return "Kill enough people who do not actively hate you.  (This should be most people who show as green on the crosshairs)";
+        case "MaySung_Dead":
         case "MaySung_PlayerDead":
             return "Kill May Sung, Maggie Chow's maid.  You must kill her yourself.";
         case "MostWarehouseTroopsDead":
@@ -2908,6 +2932,7 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             return "Destroy enough medical bots or aug bots.  You must destroy them yourself and disabling them with EMP does not count.";
         case "RepairBot_ClassDead":
             return "Destroy enough repair bots.  You must destroy them yourself and disabling them with EMP does not count.";
+        case "DrugDealer_Dead":
         case "DrugDealer_PlayerDead":
             return "Kill Rock, the drug dealer who lives in Brooklyn Bridge Station.  You must kill him yourself.";
         case "botordertrigger":
@@ -2996,6 +3021,7 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             return "Swim to the green beacon on top of the Ocean Lab crew module.  The green beacon can be seen out the window of the sub bay on the ocean floor.";
         case "PageTaunt_Played":
             return "After recovering the schematics for the Universal Constructor below the Ocean Lab, talk to Bob Page on the communicator before leaving.";
+        case "JerryTheVentGreasel_Dead":
         case "JerryTheVentGreasel_PlayerDead":
             return "Kill the greasel in the vents over the main hall of the MJ12 Lab in Hong Kong.  His name is Jerry and he is a good boy.  You must kill him yourself.";
         case "BiggestFan":
@@ -3028,6 +3054,7 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             return "Kill enough birds.  These can be either pigeons or seagulls.";
         case "GoneFishing":
             return "Kill enough fish.";
+        case "FordSchick_Dead":
         case "FordSchick_PlayerDead":
             return "Kill Ford Schick.  Note that you can do this after rescuing him.  You must kill him yourself.";
         case "ChateauInComputerRoom":
@@ -3148,6 +3175,7 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             return "Rent a companion for the night from the Mamasan in the Lucky Money club.";
         case "Sailor_ClassDeadM6":
             return "Kill enough of the sailors on the top floor of the Lucky Money club.  You must kill them yourself.";
+        case "Shannon_Dead":
         case "Shannon_PlayerDead":
             return "Kill Shannon in UNATCO HQ as retribution for her thieving ways.  You must kill her yourself.";
         case "DestroyCapitalism":
@@ -3183,6 +3211,7 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             }
             msg = msg$"|n|n(It's a Simpsons reference)";
             return msg;
+        case "Canal_Cop_Dead":
         case "Canal_Cop_PlayerDead":
             return "Kill one of the Chinese Military in the Hong Kong canals standing near the entrance to Tonnochi Road.  You must kill him yourself.";
         case "LightVandalism":
@@ -3440,6 +3469,7 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             return "Hear the Lucky Money bartender's ideas about good government.";
         case "M05MeetJaime_Played":
             return "Talk to Jaime while escaping UNATCO and tell him to stay or to join you in Hong Kong.";
+        case "jughead_Dead":
         case "jughead_PlayerDead":
             return "Kill El Rey, the leader of the Rooks in the Brooklyn Bridge Station.  You must kill him yourself.";
         case "JoshuaInterrupted_Played":
@@ -3454,6 +3484,7 @@ static simulated function string GetBingoGoalHelpText(string event,int mission, 
             return "Slaughter most of the Rooks in the Brooklyn Bridge Station.  You must kill them yourself.";
         case "GiveZyme":
             return "Give zyme to the two junkies in the Brooklyn Bridge Station.";
+        case "MarketKid_Unconscious":
         case "MarketKid_PlayerUnconscious":
             return "Knock out Louis Pan, the kid running a protection racket for the Luminous Path in the Wan Chai Market.  You must knock him out yourself.  Crime (sometimes) doesn't pay.";
         case "MaggieLived":

--- a/src/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -292,6 +292,8 @@ function PostFirstEntry()
     SetSeed( "DXRFixup PostFirstEntry missions" );
     if(#defined(mapfixes))
         PostFirstEntryMapFixes();
+
+    RemoveStopWhenEncroach();
 }
 
 function AnyEntry()

--- a/src/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -1163,6 +1163,10 @@ function RemoveStopWhenEncroach()
     local #var(prefix)Mover m;
 
     if(!class'MenuChoice_BalanceMaps'.static.MinorEnabled()) return;
+    switch(dxr.localURL) {
+    case "06_HONGKONG_TONGBASE": // allow the speedrun trick on the killswitch disabling
+        return;
+    }
 
     foreach AllActors(class'#var(prefix)Mover',m){
         //Stop when encroach is annoying and can allow some NPCs to block doorways

--- a/src/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -848,6 +848,16 @@ function FixAlexsEmail()
     }
 }
 
+function FixHarleyFilben()
+{
+    local #var(prefix)HarleyFilben harley;
+
+    //Harley defaults to not important, which means his name gets randomized
+    foreach AllActors(class'#var(prefix)HarleyFilben', harley) {
+        harley.bImportant = true;
+    }
+}
+
 function FixSamCarter()
 {
     local SamCarter s;

--- a/src/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -791,7 +791,96 @@ function string DifficultyDesc(int diff)
     }
 #endif
 
-    return StringifyFlags(Credits);
+    return DescribeDifficulty();
+}
+
+simulated function string DescribeDifficulty()
+{
+    local string str;
+    local int mode;
+    mode = Credits;
+
+    FlagInt('Rando_minskill', settings.minskill, mode, str);
+    FlagInt('Rando_maxskill', settings.maxskill, mode, str);
+    FlagInt('Rando_ammo', settings.ammo, mode, str);
+    FlagInt('Rando_multitools', settings.multitools, mode, str);
+    FlagInt('Rando_lockpicks', settings.lockpicks, mode, str);
+    FlagInt('Rando_biocells', settings.biocells, mode, str);
+    FlagInt('Rando_speedlevel', settings.speedlevel, mode, str);
+    FlagInt('Rando_keys', settings.keysrando, mode, str);
+    FlagInt('Rando_keys_containers', settings.keys_containers, mode, str);
+    FlagInt('Rando_doorspickable', settings.doorspickable, mode, str);
+    FlagInt('Rando_doorsdestructible', settings.doorsdestructible, mode, str);
+    FlagInt('Rando_deviceshackable', settings.deviceshackable, mode, str);
+    FlagInt('Rando_passwordsrandomized', settings.passwordsrandomized, mode, str);
+
+    FlagInt('Rando_medkits', settings.medkits, mode, str);
+    FlagInt('Rando_enemiesrandomized', settings.enemiesrandomized, mode, str);
+    FlagInt('Rando_enemystats', settings.enemystats, mode, str);
+    FlagInt('Rando_enemies_weapons', moresettings.enemies_weapons, mode, str);
+    FlagInt('Rando_hiddenenemiesrandomized', settings.hiddenenemiesrandomized, mode, str);
+    FlagInt('Rando_enemiesshuffled', settings.enemiesshuffled, mode, str);
+    FlagInt('Rando_infodevices', settings.infodevices, mode, str);
+    FlagInt('Rando_infodevices_containers', settings.infodevices_containers, mode, str);
+    FlagInt('Rando_dancingpercent', settings.dancingpercent, mode, str);
+    FlagInt('Rando_enemyrespawn', settings.enemyrespawn, mode, str);
+    FlagInt('Rando_reanimation', moresettings.reanimation, mode, str);
+    FlagInt('Rando_removeparismj12', remove_paris_mj12, mode, str);
+
+    FlagInt('Rando_skills_disable_downgrades', settings.skills_disable_downgrades, mode, str);
+    FlagInt('Rando_skills_reroll_missions', settings.skills_reroll_missions, mode, str);
+    FlagInt('Rando_skills_independent_levels', settings.skills_independent_levels, mode, str);
+    FlagInt('Rando_startinglocations', settings.startinglocations, mode, str);
+    FlagInt('Rando_goals', settings.goals, mode, str);
+    FlagInt('Rando_equipment', settings.equipment, mode, str);
+
+    FlagInt('Rando_medbots', settings.medbots, mode, str);
+    FlagInt('Rando_empty_medbots', moresettings.empty_medbots, mode, str);
+    FlagInt('Rando_repairbots', settings.repairbots, mode, str);
+    FlagInt('Rando_medbotuses', settings.medbotuses, mode, str);
+    FlagInt('Rando_repairbotuses', settings.repairbotuses, mode, str);
+    FlagInt('Rando_medbotcooldowns', settings.medbotcooldowns, mode, str);
+    FlagInt('Rando_repairbotcooldowns', settings.repairbotcooldowns, mode, str);
+    FlagInt('Rando_medbotamount', settings.medbotamount, mode, str);
+    FlagInt('Rando_repairbotamount', settings.repairbotamount, mode, str);
+
+    FlagInt('Rando_turrets_move', settings.turrets_move, mode, str);
+    FlagInt('Rando_turrets_add', settings.turrets_add, mode, str);
+
+    FlagInt('Rando_merchants', settings.merchants, mode, str);
+    FlagInt('Rando_banned_skills', settings.banned_skills, mode, str);
+    FlagInt('Rando_banned_skill_level', settings.banned_skill_levels, mode, str);
+    FlagInt('Rando_enemies_nonhumans', settings.enemies_nonhumans, mode, str);
+    FlagInt('Rando_bot_weapons', settings.bot_weapons, mode, str);
+    FlagInt('Rando_bot_stats', settings.bot_stats, mode, str);
+
+    FlagInt('Rando_swapitems', settings.swapitems, mode, str);
+    FlagInt('Rando_swapcontainers', settings.swapcontainers, mode, str);
+    FlagInt('Rando_augcans', settings.augcans, mode, str);
+    FlagInt('Rando_aug_value_rando', settings.aug_value_rando, mode, str);
+    FlagInt('Rando_skill_value_rando', settings.skill_value_rando, mode, str);
+    FlagInt('Rando_min_weapon_dmg', settings.min_weapon_dmg, mode, str);
+    FlagInt('Rando_max_weapon_dmg', settings.max_weapon_dmg, mode, str);
+    FlagInt('Rando_min_weapon_shottime', settings.min_weapon_shottime, mode, str);
+    FlagInt('Rando_max_weapon_shottime', settings.max_weapon_shottime, mode, str);
+
+    FlagInt('Rando_prison_pocket', settings.prison_pocket, mode, str);
+
+    FlagInt('Rando_bingo_win', settings.bingo_win, mode, str);
+    FlagInt('Rando_bingo_freespaces', settings.bingo_freespaces, mode, str);
+
+    FlagInt('Rando_menus_pause', settings.menus_pause, mode, str);
+    FlagInt('Rando_health', settings.health, mode, str);
+    FlagInt('Rando_energy', settings.energy, mode, str);
+
+    FlagInt('Rando_grenadeswap', settings.grenadeswap, mode, str);
+
+    FlagInt('Rando_newgameplus_max_item_carryover', newgameplus_max_item_carryover, mode, str);
+    FlagInt('Rando_num_skill_downgrades', newgameplus_num_skill_downgrades, mode, str);
+    FlagInt('Rando_num_removed_augs', newgameplus_num_removed_augs, mode, str);
+    FlagInt('Rando_num_removed_weapons', newgameplus_num_removed_weapons, mode, str);
+
+    return str;
 }
 
 function int GameModeIdForSlot(int slot)

--- a/src/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -587,6 +587,22 @@ function FlagsSettings SetDifficulty(int new_difficulty)
         settings.health = 100;
         settings.energy = 100;
         if(IsZeroRando()) {
+            #ifndef hx
+            switch(difficulty) {
+            case 1:
+                settings.CombatDifficulty = 1;
+                break;
+            case 2:
+                settings.CombatDifficulty = 1.5;
+                break;
+            case 3:
+                settings.CombatDifficulty = 2;
+                break;
+            case 4:
+                settings.CombatDifficulty = 4;
+                break;
+            }
+            #endif
             settings.passwordsrandomized = 0;
             settings.enemystats = 0;
             settings.bot_stats = 0;

--- a/src/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -26,11 +26,13 @@ const WaltonWareHalloween = 1032;// why didn't they put leap day at the end of O
 
 #ifdef hx
 var string difficulty_names[4];// Easy, Medium, Hard, DeusEx
+var string difficulty_descs[4];
 var FlagsSettings difficulty_settings[4];
 var MoreFlagsSettings more_difficulty_settings[4];
 #else
 var string vanilla_difficulty_names[5];// Super Easy QA, Easy, Medium, Hard, Realistic
 var string difficulty_names[5];// Super Easy QA, Normal, Hard, Extreme, Impossible
+var string difficulty_descs[5];
 var FlagsSettings difficulty_settings[5];
 var MoreFlagsSettings more_difficulty_settings[5];
 #endif
@@ -121,6 +123,7 @@ function CheckConfig()
 #ifndef hx
     difficulty_names[i] = "Super Easy QA";
     vanilla_difficulty_names[i] = "Super Easy QA";
+    //difficulty_descs[i] = "Super Easy QA Difficulty Description";
     difficulty_settings[i].CombatDifficulty = 0;
     difficulty_settings[i].doorsdestructible = 100;
     difficulty_settings[i].doorspickable = 100;
@@ -197,6 +200,7 @@ function CheckConfig()
 #else
     difficulty_names[i] = "Normal";
     vanilla_difficulty_names[i] = "Easy";
+    //difficulty_descs[i] = "Normal Difficulty Description";
     difficulty_settings[i].CombatDifficulty = 1.3;
 #endif
     difficulty_settings[i].doorsdestructible = 100;
@@ -273,6 +277,7 @@ function CheckConfig()
 #else
     difficulty_names[i] = "Hard";
     vanilla_difficulty_names[i] = "Medium";
+    //difficulty_descs[i] = "Hard Difficulty Description";
     difficulty_settings[i].CombatDifficulty = 2;
 #endif
     difficulty_settings[i].doorsdestructible = 40;
@@ -349,6 +354,7 @@ function CheckConfig()
 #else
     difficulty_names[i] = "Extreme";
     vanilla_difficulty_names[i] = "Hard";
+    //difficulty_descs[i] = "Extreme Difficulty Description";
     difficulty_settings[i].CombatDifficulty = 3;
 #endif
     difficulty_settings[i].doorsdestructible = 25;
@@ -425,6 +431,7 @@ function CheckConfig()
 #else
     difficulty_names[i] = "Impossible";
     vanilla_difficulty_names[i] = "Realistic";
+    //difficulty_descs[i] = "Impossible Difficulty Description";
     difficulty_settings[i].CombatDifficulty = 4;
 #endif
     difficulty_settings[i].doorsdestructible = 25;
@@ -762,6 +769,20 @@ function string DifficultyName(int diff)
     }
 #endif
     return difficulty_names[diff];
+}
+
+function string DifficultyDesc(int diff)
+{
+    if (diff>=ArrayCount(difficulty_descs)){
+        return "INVALID DIFFICULTY "$diff;
+    }
+#ifndef hx
+    if(IsZeroRando()) {
+        return ""; //Should we have difficulty descriptions for zero rando difficulties?
+    }
+#endif
+
+    return difficulty_descs[diff];
 }
 
 function int GameModeIdForSlot(int slot)

--- a/src/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -791,7 +791,7 @@ function string DifficultyDesc(int diff)
     }
 #endif
 
-    return DescribeDifficulty();
+    return "Settings for " $ DifficultyName(diff) $ " difficulty " $ GameModeName(gamemode) $ ":|n|n" $ DescribeDifficulty();
 }
 
 simulated function string DescribeDifficulty()
@@ -800,6 +800,9 @@ simulated function string DescribeDifficulty()
     local int mode;
     mode = Credits;
 
+    #ifndef hx
+        str = str $ "The player takes " $ int(settings.CombatDifficulty*100.0) $ "% damage.";
+    #endif
     FlagInt('Rando_minskill', settings.minskill, mode, str);
     FlagInt('Rando_maxskill', settings.maxskill, mode, str);
     FlagInt('Rando_ammo', settings.ammo, mode, str);

--- a/src/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -26,13 +26,11 @@ const WaltonWareHalloween = 1032;// why didn't they put leap day at the end of O
 
 #ifdef hx
 var string difficulty_names[4];// Easy, Medium, Hard, DeusEx
-var string difficulty_descs[4];
 var FlagsSettings difficulty_settings[4];
 var MoreFlagsSettings more_difficulty_settings[4];
 #else
 var string vanilla_difficulty_names[5];// Super Easy QA, Easy, Medium, Hard, Realistic
 var string difficulty_names[5];// Super Easy QA, Normal, Hard, Extreme, Impossible
-var string difficulty_descs[5];
 var FlagsSettings difficulty_settings[5];
 var MoreFlagsSettings more_difficulty_settings[5];
 #endif
@@ -123,7 +121,6 @@ function CheckConfig()
 #ifndef hx
     difficulty_names[i] = "Super Easy QA";
     vanilla_difficulty_names[i] = "Super Easy QA";
-    //difficulty_descs[i] = "Super Easy QA Difficulty Description";
     difficulty_settings[i].CombatDifficulty = 0;
     difficulty_settings[i].doorsdestructible = 100;
     difficulty_settings[i].doorspickable = 100;
@@ -200,7 +197,6 @@ function CheckConfig()
 #else
     difficulty_names[i] = "Normal";
     vanilla_difficulty_names[i] = "Easy";
-    //difficulty_descs[i] = "Normal Difficulty Description";
     difficulty_settings[i].CombatDifficulty = 1.3;
 #endif
     difficulty_settings[i].doorsdestructible = 100;
@@ -277,7 +273,6 @@ function CheckConfig()
 #else
     difficulty_names[i] = "Hard";
     vanilla_difficulty_names[i] = "Medium";
-    //difficulty_descs[i] = "Hard Difficulty Description";
     difficulty_settings[i].CombatDifficulty = 2;
 #endif
     difficulty_settings[i].doorsdestructible = 40;
@@ -354,7 +349,6 @@ function CheckConfig()
 #else
     difficulty_names[i] = "Extreme";
     vanilla_difficulty_names[i] = "Hard";
-    //difficulty_descs[i] = "Extreme Difficulty Description";
     difficulty_settings[i].CombatDifficulty = 3;
 #endif
     difficulty_settings[i].doorsdestructible = 25;
@@ -431,7 +425,6 @@ function CheckConfig()
 #else
     difficulty_names[i] = "Impossible";
     vanilla_difficulty_names[i] = "Realistic";
-    //difficulty_descs[i] = "Impossible Difficulty Description";
     difficulty_settings[i].CombatDifficulty = 4;
 #endif
     difficulty_settings[i].doorsdestructible = 25;
@@ -525,7 +518,7 @@ function MoreFlagsSettings GetMoreDifficulty(int diff)
 }
 
 //#region SetDifficulty
-function FlagsSettings SetDifficulty(int new_difficulty)
+function SetDifficulty(int new_difficulty)
 {
     difficulty = new_difficulty;
     settings = difficulty_settings[difficulty];
@@ -769,8 +762,6 @@ function FlagsSettings SetDifficulty(int new_difficulty)
         moresettings.newgameplus_curve_scalar = -1;
 
     class'DXRLoadouts'.static.AdjustFlags(self, loadout); // new game menu doesn't initialize its own DXRLoadouts
-
-    return settings;
 }
 //#endregion
 
@@ -789,16 +780,18 @@ function string DifficultyName(int diff)
 
 function string DifficultyDesc(int diff)
 {
-    if (diff>=ArrayCount(difficulty_descs)){
+    if (diff>=ArrayCount(difficulty_names)){
         return "INVALID DIFFICULTY "$diff;
     }
+    SetDifficulty(diff); // new game menu uses a temporary DXRFlags actor, and in-game flags menu can't access this help
+
 #ifndef hx
     if(IsZeroRando()) {
-        return ""; //Should we have difficulty descriptions for zero rando difficulties?
+        return "The player takes " $ int(settings.CombatDifficulty*100.0) $ "% damage.";
     }
 #endif
 
-    return difficulty_descs[diff];
+    return StringifyFlags(Credits);
 }
 
 function int GameModeIdForSlot(int slot)

--- a/src/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -719,6 +719,9 @@ function FlagsSettings SetDifficulty(int new_difficulty)
         settings.medbots = 0;
         settings.repairbots = 0;
         moresettings.empty_medbots = 0;
+        settings.banned_skills = 0; //Don't ban skills entirely
+        moresettings.aug_loc_rando = 100;
+        settings.skills_reroll_missions = 0; //Don't reroll skills (so the new game skill costs match in-game)
     }
     else if(gamemode == HalloweenMode) {
         //moresettings.camera_mode = 1;// 3rd person? or maybe just stick to 1st person lol

--- a/src/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -1129,13 +1129,16 @@ simulated function LogFlags(string prefix)
 simulated function string StringifyFlags(int mode)
 {
     local float CombatDifficulty;
-    local #var(PlayerPawn) p;
 #ifdef hx
     CombatDifficulty = HXGameInfo(Level.Game).CombatDifficulty;
 #else
     CombatDifficulty = settings.CombatDifficulty;
 #endif
-    return BindFlags(mode, "difficulty: " $ TrimTrailingZeros(CombatDifficulty));
+    if(mode==Credits) {
+        return BindFlags(mode, "Combat Difficulty: " $ TrimTrailingZeros(CombatDifficulty*100) $ "%");
+    } else {
+        return BindFlags(mode, "difficulty: " $ TrimTrailingZeros(CombatDifficulty));
+    }
 }
 
 simulated function int FlagsHash()

--- a/src/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -914,9 +914,39 @@ simulated function string flagValToHumanVal(name flagname, int val){
             break;
 
         case 'Rando_doorspickable':
+            switch(val){
+                //Matching setting names in DXRMenuSetupRando
+                case 100:
+                    return "All Undefeatable Doors Pickable (100%)";
+                case 70:
+                    return "Many Undefeatable Doors Pickable (70%)";
+                case 40:
+                    return "Some Undefeatable Doors Pickable (40%)";
+                case 25:
+                    return "Few Undefeatable Doors Pickable (25%)";
+                case 0:
+                    return "Keep Undefeatable Doors Unpickable (0%)";
+                default:
+                    return val $ "%";
+            }
+            break;
         case 'Rando_doorsdestructible':
-            return val $ "%";
-
+            switch(val){
+                //Matching setting names in DXRMenuSetupRando
+                case 100:
+                    return "All Undefeatable Doors Breakable (100%)";
+                case 70:
+                    return "Many Undefeatable Doors Breakable (70%)";
+                case 40:
+                    return "Some Undefeatable Doors Breakable (40%)";
+                case 25:
+                    return "Few Undefeatable Doors Breakable (25%)";
+                case 0:
+                    return "Keep Undefeatable Doors Unbreakable (0%)";
+                default:
+                    return val $ "%";
+            }
+            break;
         case 'Rando_spoilers':
             if(val==0){
                 return "Disallowed";

--- a/src/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -105,7 +105,7 @@ replication
 
 // override these in subclass
 function InitDefaults();
-function FlagsSettings SetDifficulty(int new_difficulty);
+function SetDifficulty(int new_difficulty);
 simulated function ExecMaxRando();
 function string DifficultyName(int diff);
 function string GameModeName(int gamemode);

--- a/src/DXRModules/DeusEx/Classes/DXRFlagsNGPMaxRando.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlagsNGPMaxRando.uc
@@ -166,7 +166,7 @@ function NewGamePlus()
     local DXRSkills skills;
     local DXRAugmentations augs;
     local DXRLoadouts loadouts;
-    local int i, bingo_win, bingo_freespaces, old_bingo_scale, old_bingo_duration, newgameplus_curve_scalar, menus_pause, aug_loc_rando, splits_overlay;
+    local int i, bingo_win, bingo_freespaces, old_bingo_scale, old_bingo_duration, newgameplus_curve_scalar, menus_pause, aug_loc_rando, splits_overlay, old_clothes_looting;
     local float exp;
     local int randomStart;
     local int oldseed;
@@ -203,6 +203,7 @@ function NewGamePlus()
         menus_pause = settings.menus_pause;
         aug_loc_rando=moresettings.aug_loc_rando;
         splits_overlay = moresettings.splits_overlay;
+        old_clothes_looting = clothes_looting;
         SetDifficulty(difficulty);
         ExecMaxRando();
         settings.bingo_win = bingo_win;
@@ -213,6 +214,7 @@ function NewGamePlus()
         settings.menus_pause = menus_pause;
         moresettings.aug_loc_rando=aug_loc_rando;
         moresettings.splits_overlay = splits_overlay;
+        clothes_looting = old_clothes_looting;
 
         // increase difficulty on each flag like exp = newgameplus_loops; x *= 1.2 ^ exp;
         exp = newgameplus_loops;

--- a/src/DXRModules/DeusEx/Classes/DXRHints.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRHints.uc
@@ -168,7 +168,11 @@ simulated function InitHints()
         if(class'MenuChoice_BalanceSkills'.static.IsEnabled()) AddHint("Weapon animation speeds now improve with skills,", "especially grenades with Demolition skill.");
         if(class'MenuChoice_BalanceItems'.static.IsEnabled()) AddHint("Grenades can now be attached to the floor", "or even on a door!");
         if(class'MenuChoice_BalanceSkills'.static.IsEnabled()) AddHint("Attaching a grenade to a wall increases its", "blast radius and damage, especially with high skill.");
-        AddHint("You can safely save during infolinks!", "Give it a shot, Tong won't mind!");
+        if(class'MenuChoice_SaveDuringInfolinks'.static.IsEnabled(dxr.flags)){
+            AddHint("You can safely save during infolinks!", "Give it a shot, Tong won't mind!");
+        } else {
+            AddHint("Wish you could save during infolinks?", "Look for the 'Saving During Infolinks' option in the settings!");
+        }
         if(class'MenuChoice_BalanceEtc'.static.IsEnabled()) AddHint("Red lasers will always set off an alarm.", "Blue lasers won't, but will trigger something else!");
         if(class'MenuChoice_BalanceEtc'.static.IsEnabled()) AddHint("Everything except an NPC will set off a laser!", "Better be careful around them!");
         AddHint("Enemies with gold visors are resistant to gas", "so you might need to deal with them differently!");

--- a/src/DXRModules/DeusEx/Classes/DXRHordeMode.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRHordeMode.uc
@@ -2,28 +2,28 @@ class DXRHordeMode extends DXRActorsBase transient;
 
 var int wave;
 var int time_to_next_wave;
-var config int time_between_waves;
+var int time_between_waves;
 var bool in_wave;
 var int time_in_wave;
 var int last_num_pawns_reported;
-var config int time_before_damage;
-var config int damage_timer;
-var config int time_before_teleport_enemies;
-var config float popin_dist;
-var config int skill_points_award;
-var config int early_end_wave_timer;
-var config int early_end_wave_enemies;
-var config int items_per_wave;
-var config float difficulty_per_wave;
-var config float difficulty_first_wave;
-var config int wine_bottles_per_enemy;
-var config name default_orders;
-var config name default_order_tag;
-var config string map_name;
-var config name remove_objects[16];
-var config name unlock_doors[8];
-var config name lock_doors[16];
-var config vector starting_location;
+var int time_before_damage;
+var int damage_timer;
+var int time_before_teleport_enemies;
+var float popin_dist;
+var int skill_points_award;
+var int early_end_wave_timer;
+var int early_end_wave_enemies;
+var int items_per_wave;
+var float difficulty_per_wave;
+var float difficulty_first_wave;
+var int wine_bottles_per_enemy;
+var name default_orders;
+var name default_order_tag;
+var string map_name;
+var name remove_objects[16];
+var name unlock_doors[8];
+var name lock_doors[16];
+var vector starting_location;
 
 var DXRMachines machines;
 
@@ -46,113 +46,108 @@ var config ItemChances items[32];
 function CheckConfig()
 {
     local int i;
-    if( ConfigOlderThan(3,1,0,2) ) {
-        time_between_waves = 65;
-        time_before_damage = 180;
-        damage_timer = 10;
-        time_before_teleport_enemies = 3;
-        early_end_wave_timer = 240;
-        early_end_wave_enemies = 5;
-        popin_dist = 1800.0;
-        skill_points_award = 2500;
-        items_per_wave = 25;
-        difficulty_per_wave = 1.75;
-        difficulty_first_wave = 3;
-        wine_bottles_per_enemy = 2;
-        for(i=0; i<ArrayCount(items); i++) {
-            items[i].type="";
-            items[i].chance=0;
-        }
-        i=0;
-        items[i].type = "BioelectricCell";
-        items[i].chance = 6;
-        i++;
-        items[i].type = "CrateExplosiveSmall";
-        items[i].chance = 8;
-        i++;
-        items[i].type = "Barrel1";
-        items[i].chance = 8;
-        i++;
-        items[i].type = "WeaponGasGrenade";
-        items[i].chance = 7;
-        i++;
-        items[i].type = "WeaponLAM";
-        items[i].chance = 7;
-        i++;
-        items[i].type = "WeaponEMPGrenade";
-        items[i].chance = 7;
-        i++;
-        items[i].type = "WeaponNanoVirusGrenade";
-        items[i].chance = 7;
-        i++;
-        items[i].type = "FireExtinguisher";
-        items[i].chance = 6;
-        i++;
-        items[i].type = "Ammo10mm";
-        items[i].chance = 7;
-        i++;
-        items[i].type = "Ammo762mm";
-        items[i].chance = 7;
-        i++;
-        items[i].type = "AmmoShell";
-        items[i].chance = 7;
-        i++;
-        items[i].type = "Ammo3006";
-        items[i].chance = 2;
-        i++;
-        items[i].type = "AmmoRocket";
-        items[i].chance = 1;
-        i++;
-        items[i].type = "AmmoDartPoison";
-        items[i].chance = 1;
-        // and 19% more...
-        i++;
-        items[i].type = "AugmentationCannister";
-        items[i].chance = 5;
-        i++;
-        items[i].type = "RepairBot";
-        items[i].chance = 3;
-        i++;
-        items[i].type = "MedicalBot";
-        items[i].chance = 5;
-        i++;
-        items[i].type = "MedKit";
-        items[i].chance = 3;
-        i++;
-        items[i].type = "AugmentationUpgradeCannister";
-        items[i].chance = 3;
 
-        map_name = "11_paris_cathedral";
-        starting_location = vect(-3811.785156, 2170.053223, -774.903442);
-        default_orders = 'Attacking';
-        default_order_tag = '';
-
-        i=0;
-        remove_objects[i++] = 'MapExit';
-        remove_objects[i++] = 'ScriptedPawn';
-        remove_objects[i++] = 'DataLinkTrigger';
-        remove_objects[i++] = 'Teleporter';
-        remove_objects[i++] = 'SecurityCamera';
-        remove_objects[i++] = 'AutoTurret';
-        remove_objects[i++] = 'AlarmUnit';
-        remove_objects[i++] = 'LaserTrigger';
-
-        i=0;
-        lock_doors[i++] = 'BreakableGlass0';
-        lock_doors[i++] = 'BreakableGlass1';
-        lock_doors[i++] = 'BreakableGlass2';
-        lock_doors[i++] = 'BreakableGlass3';
-        lock_doors[i++] = 'BreakableGlass4';
-        lock_doors[i++] = 'BreakableGlass5';
-        lock_doors[i++] = 'BreakableGlass6';
-        lock_doors[i++] = 'BreakableGlass7';
-        lock_doors[i++] = 'DeusExMover8';
-        lock_doors[i++] = 'DeusExMover9';
-        lock_doors[i++] = 'DeusExMover17';
-
-        i=0;
-        unlock_doors[i++] = 'DeusExMover19';
+    for(i=0; i<ArrayCount(items); i++) {
+        items[i].type="";
+        items[i].chance=0;
     }
+    i=0;
+    items[i].type = "BioelectricCell";
+    items[i].chance = 6;
+    i++;
+    items[i].type = "CrateExplosiveSmall";
+    items[i].chance = 8;
+    i++;
+    items[i].type = "Barrel1";
+    items[i].chance = 8;
+    i++;
+    items[i].type = "WeaponGasGrenade";
+    items[i].chance = 7;
+    i++;
+    items[i].type = "WeaponLAM";
+    items[i].chance = 7;
+    i++;
+    items[i].type = "WeaponEMPGrenade";
+    items[i].chance = 7;
+    i++;
+    items[i].type = "WeaponNanoVirusGrenade";
+    items[i].chance = 7;
+    i++;
+    items[i].type = "FireExtinguisher";
+    items[i].chance = 6;
+    i++;
+    items[i].type = "Ammo10mm";
+    items[i].chance = 7;
+    i++;
+    items[i].type = "Ammo762mm";
+    items[i].chance = 7;
+    i++;
+    items[i].type = "Ammo20mm";
+    items[i].chance = 0.25;
+    i++;
+    items[i].type = "AmmoShell";
+    items[i].chance = 7;
+    i++;
+    items[i].type = "AmmoSabot";
+    items[i].chance = 0.5;
+    i++;
+    items[i].type = "Ammo3006";
+    items[i].chance = 2;
+    i++;
+    items[i].type = "AmmoRocket";
+    items[i].chance = 1;
+    i++;
+    items[i].type = "AmmoRocketWP";
+    items[i].chance = 0.25;
+    i++;
+    items[i].type = "AmmoDartPoison";
+    items[i].chance = 1;
+    i++;
+    items[i].type = "AugmentationCannister";
+    items[i].chance = 5;
+    i++;
+    items[i].type = "RepairBot";
+    items[i].chance = 3;
+    i++;
+    items[i].type = "MedicalBot";
+    items[i].chance = 5;
+    i++;
+    items[i].type = "MedKit";
+    items[i].chance = 3;
+    i++;
+    items[i].type = "AugmentationUpgradeCannister";
+    items[i].chance = 2;
+
+    map_name = "11_paris_cathedral";
+    starting_location = vect(-3811.785156, 2170.053223, -774.903442);
+    default_order_tag = '';
+
+    i=0;
+    remove_objects[i++] = 'MapExit';
+    remove_objects[i++] = 'ScriptedPawn';
+    remove_objects[i++] = 'DataLinkTrigger';
+    remove_objects[i++] = 'Teleporter';
+    remove_objects[i++] = 'SecurityCamera';
+    remove_objects[i++] = 'AutoTurret';
+    remove_objects[i++] = 'AlarmUnit';
+    remove_objects[i++] = 'LaserTrigger';
+
+    i=0;
+    lock_doors[i++] = 'BreakableGlass0';
+    lock_doors[i++] = 'BreakableGlass1';
+    lock_doors[i++] = 'BreakableGlass2';
+    lock_doors[i++] = 'BreakableGlass3';
+    lock_doors[i++] = 'BreakableGlass4';
+    lock_doors[i++] = 'BreakableGlass5';
+    lock_doors[i++] = 'BreakableGlass6';
+    lock_doors[i++] = 'BreakableGlass7';
+    lock_doors[i++] = 'DeusExMover8';
+    lock_doors[i++] = 'DeusExMover9';
+    lock_doors[i++] = 'DeusExMover17';
+
+    i=0;
+    unlock_doors[i++] = 'DeusExMover19';
+
     map_name = Caps(map_name);
     Super.CheckConfig();
 
@@ -373,7 +368,6 @@ function AnyEntry()
 
     machines = DXRMachines(dxr.FindModule(class'DXRMachines'));
 
-    class'DXRAugmentations'.static.AddAug( player(), class'AugSpeed', dxr.flags.settings.speedlevel );
     dxre.GiveRandomWeapon(player());
     dxre.GiveRandomWeapon(player());
     dxre.GiveRandomMeleeWeapon(player());
@@ -996,4 +990,21 @@ function RunTests()
         total += items[i].chance;
     }
     testfloat( total, 100, "config items chances, check total adds up to 100%");
+}
+
+defaultproperties
+{
+    time_between_waves=65
+    time_before_damage=180
+    damage_timer=10
+    time_before_teleport_enemies=3
+    early_end_wave_timer=240
+    early_end_wave_enemies=5
+    popin_dist=1800.0
+    skill_points_award=2500;
+    items_per_wave=25
+    difficulty_per_wave=1.75
+    difficulty_first_wave=3
+    wine_bottles_per_enemy=2
+    default_orders=Attacking
 }

--- a/src/DXRModules/DeusEx/Classes/DXRMemes.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRMemes.uc
@@ -362,6 +362,42 @@ function RandomHotelDoorSounds()
 
 }
 
+function MakeNonHostileMrH(vector loc, rotator rotate)
+{
+    local MrH mrh;
+    local rotator rotted;
+    local vector locr;
+
+    locr = vectm(loc.X,loc.Y,loc.Z);
+    rotted = rotm(rotate.Pitch,rotate.Yaw,rotate.Roll,GetRotationOffset(class'MrH'));
+
+    mrh = Spawn(class'MrH',,,locr,rotted);
+    mrh.InitialAlliances[0].AllianceLevel=1; //This runs before the pawn is initialized, so this works to make him non-hostile
+    mrh.Orders='Standing';
+    mrh.SetOrders('Standing');
+}
+
+function CreateTrainingMrH()
+{
+    local vector loc;
+    local rotator rotate;
+
+    switch(dxr.localURL){
+        case "00_TrainingCombat":
+            loc = vect(1485,-310,-35);
+            rotate = rot(0,11440,0);
+            break;
+        case "00_TrainingFinal":
+            loc = vect(1680,-172,45);
+            rotate = rot(0,32768,0);
+            break;
+    }
+
+    if (loc!=vect(0,0,0)){
+        MakeNonHostileMrH(loc,rotate);
+    }
+}
+
 function PreFirstEntry()
 {
     Super.PreFirstEntry();
@@ -372,6 +408,10 @@ function PreFirstEntry()
         case "INTRO":
             //Make sure the intro has an actual location to show up in toots
             dxr.dxInfo.MissionLocation="the intro cinematic";
+            break;
+        case "00_TrainingCombat":
+        case "00_TrainingFinal":
+            CreateTrainingMrH();
             break;
         case "15_AREA51_PAGE":
             RandomBobPage();

--- a/src/DXRModules/DeusEx/Classes/DXRMemes.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRMemes.uc
@@ -1002,6 +1002,8 @@ function RandomizeCutscene()
         }
     }
 
+    MakeTubeContentsFloat();
+
     /*foreach AllActors(class'CameraPoint', c)
     {
         c.bHidden = false;
@@ -1020,6 +1022,44 @@ function RandomizeCutscene()
 
     RandomizeCutsceneOrder();
     ForceIntroFight();
+}
+
+function MakeTubeContentsFloat()
+{
+    local bool RevisionMaps;
+    local vector TubeLoc;
+    local rotator TubeRot;
+    local float widthScale,heightScale;
+    local Actor a;
+
+    switch(dxr.localURL)
+    {
+        case "INTRO":
+            break;
+        default:
+            return;
+    }
+
+    RevisionMaps = class'DXRMapVariants'.static.IsRevisionMaps(player());
+
+    if (RevisionMaps){
+        TubeLoc = vectm(-9889,-8523,-5136);
+        TubeRot = rot(0,8992,0);
+    } else {
+        TubeLoc = vectm(-11088,-8577,-5048);
+        TubeRot = rot(0,16304,0);
+    }
+
+    foreach RadiusActors(class'Actor',a,50,TubeLoc){
+        if (a.bHidden) continue;
+        a.SetPhysics(PHYS_None);
+        widthScale = class'#var(prefix)DentonClone'.default.CollisionRadius / a.Default.CollisionRadius;
+        heightScale = class'#var(prefix)DentonClone'.default.CollisionHeight / a.Default.CollisionHeight;
+        a.DrawScale = FMin(widthScale,heightScale); //Don't use SetActorScale, because that works from the existing scale
+        a.SetLocation(TubeLoc);
+        a.SetRotation(TubeRot); //Rotation should get updated to account for RotationOffset
+    }
+
 }
 
 function ForceIntroFight()

--- a/src/DXRModules/DeusEx/Classes/DXRMemes.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRMemes.uc
@@ -1030,6 +1030,7 @@ function MakeTubeContentsFloat()
     local vector TubeLoc;
     local rotator TubeRot;
     local float widthScale,heightScale;
+    local int RotOffset;
     local Actor a;
 
     switch(dxr.localURL)
@@ -1057,7 +1058,11 @@ function MakeTubeContentsFloat()
         heightScale = class'#var(prefix)DentonClone'.default.CollisionHeight / a.Default.CollisionHeight;
         a.DrawScale = FMin(widthScale,heightScale); //Don't use SetActorScale, because that works from the existing scale
         a.SetLocation(TubeLoc);
-        a.SetRotation(TubeRot); //Rotation should get updated to account for RotationOffset
+
+        //Rotation should get updated to account for RotationOffset
+        RotOffset = GetRotationOffset(a.Class);
+        TubeRot = rotm(TubeRot.Pitch,TubeRot.Yaw-RotOffset,TubeRot.Roll,RotOffset);
+        a.SetRotation(TubeRot);
     }
 
 }

--- a/src/DXRModules/DeusEx/Classes/DXRNPCs.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRNPCs.uc
@@ -281,6 +281,7 @@ function ScriptedPawn CreateMerchant(string name, Name bindname, class<Merchant>
     //Got somethin' that might interest ya'.
     //Got some rare things on sale, stranger!
     //Welcome!
+    e = AddTransferRepairTrigger(c,e);
     e = AddSpeech(c, e, "Whaddaya buyin'?", false, "BuyCommon");
     e = AddPurchaseChoices(c, e, items);
     e = AddSpeech(c, e, "Come back anytime.", false, "leave");
@@ -512,13 +513,39 @@ function ConEventTrigger AddMerchantTelem(Conversation c, ConEvent prev, ItemPur
 
 }
 
+function ConEventTrigger AddTransferRepairTrigger(Conversation c, ConEvent prev)
+{
+    local ConEventTrigger e;
+    local RepairConObjTransferTrigger rt;
+    local string tagName, j;
+    local class<Json> js;
+    local int k;
+
+    tagName="ConEventTransferObjectRepair"$c.conName; //Append the bindname to the end
+
+    e = new(c) class'ConEventTrigger';
+    e.eventType=ET_Trigger;
+    e.triggerTag = StringToName(tagName);
+    AddConEvent(c, prev, e);
+
+    //Make sure the Repair Triggers actually exist
+    foreach AllActors(class'RepairConObjTransferTrigger',rt,e.triggerTag){break;}
+    if (rt==None){
+        rt=Spawn(class'RepairConObjTransferTrigger',,e.triggerTag);
+        rt.conName = c.conName;
+        rt.AddPackage("#var(package)"); //Add our package to the list of possibilities
+    }
+
+    return e;
+}
+
 function ConEventTransferObject AddTransfer(Conversation c, ConEvent prev, class<Inventory> item)
 {
     local ConEventTransferObject e;
 
     e = new(c) class'ConEventTransferObject';
     e.eventType = ET_TransferObject;
-    e.objectName = string(item.name);
+    e.objectName = string(item);  //Fully qualify the class name so it includes the package name (for safety)
     e.giveObject = item;
     e.transferCount = 1;
     e.fromName = c.conOwnerName;

--- a/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -364,6 +364,7 @@ function bool IsStartMap()
     return _IsStartMap(dxr);
 }
 
+//#region _GetStartMap
 static function string _GetStartMap(int start_map_val, optional out string friendlyName, optional out int bShowInMenu)
 {
     friendlyName = ""; // clear the out param to protect against reuse by the caller
@@ -624,6 +625,7 @@ function DeusExNote AddNoteFromConv(#var(PlayerPawn) player, bool bEmptyNotes, n
     return None;
 }
 
+//#region PreFirstEntryStartMapFixes
 function PreFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, int start_flag)
 {
     local bool bEmptyNotes, bFemale;
@@ -899,6 +901,7 @@ function SkillAwardCrate SpawnWaltonWareCrate(#var(PlayerPawn) player)
     return crate;
 }
 
+//#region PostFirstEntryStartMapFixes
 function PostFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, int start_flag)
 {
     local DeusExGoal goal;
@@ -1038,6 +1041,7 @@ function PostFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase,
     }
 }
 
+//#region BingoGoalImpossible
 static function bool BingoGoalImpossible(string bingo_event, int start_map, int end_mission)
 {// TODO: probably mid-mission starts for M03 and M04 need to exclude some unatco goals, some hong kong starts might need exclusions too
     switch(start_map/10)
@@ -1148,6 +1152,8 @@ static function bool BingoGoalImpossible(string bingo_event, int start_map, int 
             return start_map >= 115;
         case "TrainTracks":
             return start_map > 115;
+        case "JockBlewUp":
+            return end_mission < 15;
         }
         break;
 
@@ -1242,7 +1248,7 @@ static function bool BingoGoalImpossible(string bingo_event, int start_map, int 
     return False;
 }
 
-
+// #region BingoGoalPossible
 static function bool BingoGoalPossible(string bingo_event, int start_map, int end_mission)
 {
     // TODO: any of the exceptions in GetStartingMissionMask, and will also need to add them to GetMaybeMissionMask
@@ -1295,6 +1301,7 @@ static function int ChooseRandomStartMap(DXRBase m, int avoidStart)
     return startMap;
 }
 
+//#region _ChooseRandomStartMap
 static function int _ChooseRandomStartMap(DXRBase m)
 {
     local int i;

--- a/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -1366,7 +1366,7 @@ static function int _ChooseRandomStartMap(DXRBase m)
         i = m.rng(3);
         switch(i) {
         case 0: return 119;
-        case 1: return 121;
+        case 1: return 122;
         case 2: return 129;
         }
         return 119;

--- a/src/DXRModules/DeusEx/Classes/DXRWeapons.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRWeapons.uc
@@ -100,6 +100,7 @@ simulated function bool RandoProjectile(DeusExWeapon w, out class<Projectile> p,
     case class'#var(prefix)Dart':
         if(#defined(vmd)) p.default.Damage = ratio * 20.0;
         else p.default.Damage = ratio * 15.0;
+        p.default.Damage = Max(p.default.Damage, 2);
         break;
 
     case class'#var(prefix)DartFlare':
@@ -108,22 +109,22 @@ simulated function bool RandoProjectile(DeusExWeapon w, out class<Projectile> p,
         break;
         #endif
     case class'#var(prefix)DartPoison':
-        p.default.Damage = ratio * 5.0;
+        p.default.Damage = Max(ratio * 5.0, 2);
         break;
 
     // plasma, don't worry about PS40 because that gets handled in its own class
     case class'#var(prefix)PlasmaBolt':
     case class'PlasmaBoltFixTicks':
         f = 18.0;
-        p.default.Damage = ratio * f;
+        p.default.Damage = Max(ratio * f, 2);
 #ifndef hx
-        class'#var(prefix)PlasmaBolt'.default.mpDamage = ratio * f;
-        class'PlasmaBoltFixTicks'.default.mpDamage = ratio * f;
+        class'#var(prefix)PlasmaBolt'.default.mpDamage = Max(ratio * f, 2);
+        class'PlasmaBoltFixTicks'.default.mpDamage = Max(ratio * f, 2);
 #endif
         p = class'PlasmaBoltFixTicks';
         d = p;
-        p.default.Damage = ratio * f;
-        w.HitDamage = ratio * f;// write back the weapon damage
+        p.default.Damage = Max(ratio * f, 2);
+        w.HitDamage = Max(ratio * f, 2);// write back the weapon damage
         break;
 
     case class'#var(prefix)Rocket':

--- a/src/DXRNonVanilla/DeusEx/Classes/RevRandoPlayer.uc
+++ b/src/DXRNonVanilla/DeusEx/Classes/RevRandoPlayer.uc
@@ -824,6 +824,24 @@ event WalkTexture( Texture Texture, vector StepLocation, vector StepNormal )
         bOnLadder = False;
 }
 
+event HeadZoneChange(ZoneInfo newHeadZone)
+{
+    if (HeadRegion.Zone.bWaterZone && !newHeadZone.bWaterZone)
+    {
+        class'DolphinJumpTrigger'.static.CreateDolphin(self);
+    }
+    Super.HeadZoneChange(newHeadZone);
+}
+
+function Landed(vector HitNormal)
+{
+    local DolphinJumpTrigger dolphin;
+    foreach AllActors(class'DolphinJumpTrigger', dolphin) {
+        dolphin.Destroy();
+    }
+    Super.Landed(HitNormal);
+}
+
 function bool CanInstantLeftClick(DeusExPickup item)
 {
     if (inHand!=None) return false;

--- a/src/DXRNonVanilla/DeusEx/Classes/RevRandoPlayer.uc
+++ b/src/DXRNonVanilla/DeusEx/Classes/RevRandoPlayer.uc
@@ -1290,3 +1290,13 @@ exec function ToggleScope()
         }
     }
 }
+
+exec function PlayerLoc()
+{
+    ClientMessage("Player location: (" $ Location.x $ ", " $ Location.y $ ", " $ Location.z $ ")");
+}
+
+exec function PlayerRot()
+{
+    ClientMessage("Player rotation: (" $ Rotation.pitch $ ", " $ Rotation.yaw $ ", " $ Rotation.roll $ ")");
+}

--- a/src/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/src/DXRVanilla/DeusEx/Classes/Player.uc
@@ -570,6 +570,7 @@ function Landed(vector HitNormal)
     local Augmentation aug;
     local int augLevel;
     local float augReduce, dmg, softener;
+    local DolphinJumpTrigger dolphin;
 
     softener = 1;
     /*if(class'MenuChoice_BalanceAugs'.static.IsEnabled() && AugmentationSystem != None)
@@ -622,6 +623,10 @@ function Landed(vector HitNormal)
     //else if ( (Level.Game != None) && (Level.Game.Difficulty > 1) && (Velocity.Z > 0.5 * JumpZ) )
         //MakeNoise(0.1 * Level.Game.Difficulty);
     bJustLanded = true;
+
+    foreach AllActors(class'DolphinJumpTrigger', dolphin) {
+        dolphin.Destroy();
+    }
 }
 
 function bool CanInstantLeftClick(DeusExPickup item)
@@ -941,6 +946,14 @@ exec function bool DropItem(optional Inventory inv, optional bool bDrop)
 	return bDropped;
 }
 
+event HeadZoneChange(ZoneInfo newHeadZone)
+{
+    if (HeadRegion.Zone.bWaterZone && !newHeadZone.bWaterZone)
+    {
+        class'DolphinJumpTrigger'.static.CreateDolphin(self);
+    }
+    Super.HeadZoneChange(newHeadZone);
+}
 
 event WalkTexture( Texture Texture, vector StepLocation, vector StepNormal )
 {

--- a/src/DXRVanilla/DeusEx/Classes/Weapon.uc
+++ b/src/DXRVanilla/DeusEx/Classes/Weapon.uc
@@ -565,9 +565,11 @@ simulated function bool UpdateInfo(Object winObject)
     winInfo.AddInfoItem(msgInfoClip, str, HasClipMod());
 
     // rate of fire
+    // RANDO: Always show rate of fire
     if ((Default.ReloadCount == 0) || bHandToHand)
     {
-        str = msgInfoNA;
+        //str = msgInfoNA;
+        str = FormatFloatString(1.0/ShotTime, 0.1) $ "/SEC";
     }
     else
     {

--- a/src/DXRando/DeusEx/Classes/DXRBinoculars.uc
+++ b/src/DXRando/DeusEx/Classes/DXRBinoculars.uc
@@ -103,6 +103,13 @@ simulated function Timer()
             }
             else
             {
+                if (#var(DeusExPrefix)Mover(target)!=None){
+                    if (class'FakeMirrorInfo'.static.IsPointInMirrorZone(peeper,HitLocation)){
+                        hitMirror = true;
+                        //peeper.ClientMessage("Hit fake mirror attached to mover");
+                        break;
+                    }
+                }
                 peepee = target;
                 break;
             }

--- a/src/DXRando/DeusEx/Classes/DXRandoCrowdControlEffects.uc
+++ b/src/DXRando/DeusEx/Classes/DXRandoCrowdControlEffects.uc
@@ -1404,7 +1404,7 @@ function floorIsLava() {
 
     if (
         ( player().Base.IsA('LevelInfo') || player().Base.IsA('Mover') )
-#ifdef vanilla
+#ifdef vanilla || revision
         && player().bOnLadder==False
 #endif
     ) {

--- a/src/DXRando/DeusEx/Classes/FakeMirrorInfo.uc
+++ b/src/DXRando/DeusEx/Classes/FakeMirrorInfo.uc
@@ -9,6 +9,8 @@ var bool wasAttached; //So we can differentiate between never being attached and
 
 function SetZone(vector new_min_pos, vector new_max_pos)
 {
+    local vector middle;
+
     if (new_min_pos.X > new_max_pos.X){
         min_pos.X = new_max_pos.X;
         max_pos.X = new_min_pos.X;
@@ -32,6 +34,11 @@ function SetZone(vector new_min_pos, vector new_max_pos)
         min_pos.Z = new_min_pos.Z;
         max_pos.Z = new_max_pos.Z;
     }
+
+    middle.X = (min_pos.X + max_pos.X)/2;
+    middle.Y = (min_pos.Y + max_pos.Y)/2;
+    middle.Z = (min_pos.Z + max_pos.Z)/2;
+    SetLocation(middle);
 }
 
 function SetAttached(Actor attached)

--- a/src/DXRando/DeusEx/Classes/FakeMirrorInfo.uc
+++ b/src/DXRando/DeusEx/Classes/FakeMirrorInfo.uc
@@ -1,0 +1,65 @@
+class FakeMirrorInfo extends Info;
+
+var vector min_pos;
+var vector max_pos;
+
+function SetZone(vector new_min_pos, vector new_max_pos)
+{
+    if (new_min_pos.X > new_max_pos.X){
+        min_pos.X = new_max_pos.X;
+        max_pos.X = new_min_pos.X;
+    } else {
+        min_pos.X = new_min_pos.X;
+        max_pos.X = new_max_pos.X;
+    }
+
+    if (new_min_pos.Y > new_max_pos.Y){
+        min_pos.Y = new_max_pos.Y;
+        max_pos.Y = new_min_pos.Y;
+    } else {
+        min_pos.Y = new_min_pos.Y;
+        max_pos.Y = new_max_pos.Y;
+    }
+
+    if (new_min_pos.Z > new_max_pos.Z){
+        min_pos.Z = new_max_pos.Z;
+        max_pos.Z = new_min_pos.Z;
+    } else {
+        min_pos.Z = new_min_pos.Z;
+        max_pos.Z = new_max_pos.Z;
+    }
+}
+
+function bool IsPointInMyMirrorZone(vector point)
+{
+    if (point.X > max_pos.X) return false;
+    if (point.Y > max_pos.Y) return false;
+    if (point.Z > max_pos.Z) return false;
+
+    if (point.X < min_pos.X) return false;
+    if (point.Y < min_pos.Y) return false;
+    if (point.Z < min_pos.Z) return false;
+
+    return true;
+}
+
+static function bool IsPointInMirrorZone(Actor a, vector point)
+{
+    local FakeMirrorInfo fmi;
+
+    foreach a.AllActors(class'FakeMirrorInfo',fmi){
+        if (fmi.IsPointInMyMirrorZone(point)) return True;
+    }
+
+    return False;
+}
+
+static function FakeMirrorInfo Create(Actor a, vector new_min_pos, vector new_max_pos)
+{
+    local FakeMirrorInfo fmi;
+
+    fmi = a.Spawn(class'FakeMirrorInfo');
+    fmi.SetZone(new_min_pos,new_max_pos);
+
+    return fmi;
+}

--- a/src/DXRando/DeusEx/Classes/FakeMirrorInfo.uc
+++ b/src/DXRando/DeusEx/Classes/FakeMirrorInfo.uc
@@ -5,6 +5,7 @@ var vector max_pos;
 
 var Actor attach;
 var vector attachStartLoc;
+var bool wasAttached; //So we can differentiate between never being attached and the attached thing getting destroyed
 
 function SetZone(vector new_min_pos, vector new_max_pos)
 {
@@ -38,6 +39,7 @@ function SetAttached(Actor attached)
     if (attached==None) return;
     attach = attached;
     attachStartLoc = attach.Location;
+    wasAttached = true;
 }
 
 //This only works for things that slide (no rotation)
@@ -48,9 +50,31 @@ function vector GetAttachedOffset()
     return attach.Location - attachStartLoc;
 }
 
+function bool IsValidMirror()
+{
+    local #var(DeusExPrefix)Mover dxm;
+
+    if (!wasAttached) return True; //If it isn't attached to something, it's always valid
+
+    if (attach==None) return False; //If the attached thing doesn't exist anymore, it isn't valid
+
+    dxm = #var(DeusExPrefix)Mover(attach);
+    if (dxm!=None){
+        if (dxm.bDestroyed) return False; //If the attached mover was destroyed, it's no longer valid
+    }
+
+    return True;
+}
+
 function bool IsPointInMyMirrorZone(vector point)
 {
     local vector maxLoc,minLoc,attachOffset;
+
+    if (!IsValidMirror()) {
+        //No longer valid, guess I'll die
+        Destroy();
+        return false;
+    }
 
     attachOffset = GetAttachedOffset();
 

--- a/src/DXRando/DeusEx/Classes/FakeMirrorInfo.uc
+++ b/src/DXRando/DeusEx/Classes/FakeMirrorInfo.uc
@@ -3,6 +3,9 @@ class FakeMirrorInfo extends Info;
 var vector min_pos;
 var vector max_pos;
 
+var Actor attach;
+var vector attachStartLoc;
+
 function SetZone(vector new_min_pos, vector new_max_pos)
 {
     if (new_min_pos.X > new_max_pos.X){
@@ -30,15 +33,37 @@ function SetZone(vector new_min_pos, vector new_max_pos)
     }
 }
 
+function SetAttached(Actor attached)
+{
+    if (attached==None) return;
+    attach = attached;
+    attachStartLoc = attach.Location;
+}
+
+//This only works for things that slide (no rotation)
+function vector GetAttachedOffset()
+{
+    if (attach==None) return vect(0,0,0);
+
+    return attach.Location - attachStartLoc;
+}
+
 function bool IsPointInMyMirrorZone(vector point)
 {
-    if (point.X > max_pos.X) return false;
-    if (point.Y > max_pos.Y) return false;
-    if (point.Z > max_pos.Z) return false;
+    local vector maxLoc,minLoc,attachOffset;
 
-    if (point.X < min_pos.X) return false;
-    if (point.Y < min_pos.Y) return false;
-    if (point.Z < min_pos.Z) return false;
+    attachOffset = GetAttachedOffset();
+
+    maxLoc = max_pos + attachOffset;
+    minLoc = min_pos + attachOffset;
+
+    if (point.X > maxLoc.X) return false;
+    if (point.Y > maxLoc.Y) return false;
+    if (point.Z > maxLoc.Z) return false;
+
+    if (point.X < minLoc.X) return false;
+    if (point.Y < minLoc.Y) return false;
+    if (point.Z < minLoc.Z) return false;
 
     return true;
 }
@@ -54,12 +79,13 @@ static function bool IsPointInMirrorZone(Actor a, vector point)
     return False;
 }
 
-static function FakeMirrorInfo Create(Actor a, vector new_min_pos, vector new_max_pos)
+static function FakeMirrorInfo Create(Actor a, vector new_min_pos, vector new_max_pos, optional Actor attached)
 {
     local FakeMirrorInfo fmi;
 
     fmi = a.Spawn(class'FakeMirrorInfo');
     fmi.SetZone(new_min_pos,new_max_pos);
+    fmi.SetAttached(attached);
 
     return fmi;
 }

--- a/src/DXRando/DeusEx/Classes/SkillAwardCrate.uc
+++ b/src/DXRando/DeusEx/Classes/SkillAwardCrate.uc
@@ -38,6 +38,6 @@ defaultproperties
     Mesh=LodMesh'DeusExDeco.CrateBreakableMed'
     CollisionRadius=34.000000
     CollisionHeight=24.000000
-    Mass=50.000000
+    Mass=35.000000
     Buoyancy=60.000000
 }

--- a/src/DXRando/DeusEx/Classes/WaterCooler.uc
+++ b/src/DXRando/DeusEx/Classes/WaterCooler.uc
@@ -10,19 +10,11 @@ function Frob(Actor Frobber, Inventory frobWith)
     local bool chugged;
     local float cooldown;
 
-#ifdef hx
-    oldUsing = BubbleTime > 0.0;
-#else
-    oldUsing = bUsing;
-#endif
+    oldUsing = #switch(hx: BubbleTime > 0.0, bUsing);
     oldNumUses = numUses;
 
     Super.Frob(Frobber, frobWith);
-#ifdef hx
-    newUsing = BubbleTime > 0.0;
-#else
-    newUsing = bUsing;
-#endif
+    newUsing = #switch(hx: BubbleTime > 0.0, bUsing);
 
     if (newUsing && !oldUsing) {
         if(class'MenuChoice_BalanceEtc'.static.IsEnabled() || #defined(vmd)) {

--- a/src/DXRando/DeusEx/Classes/WaterFountain.uc
+++ b/src/DXRando/DeusEx/Classes/WaterFountain.uc
@@ -10,19 +10,11 @@ function Frob(Actor Frobber, Inventory frobWith)
     local bool chugged;
     local float cooldown;
 
-#ifdef hx
-    oldUsing = BubbleTime > 0.0;
-#else
-    oldUsing = bUsing;
-#endif
+    oldUsing = #switch(hx: BubbleTime > 0.0, bUsing);
     oldNumUses = numUses;
 
     Super.Frob(Frobber, frobWith);
-#ifdef hx
-    newUsing = BubbleTime > 0.0;
-#else
-    newUsing = bUsing;
-#endif
+    newUsing = #switch(hx: BubbleTime > 0.0, bUsing);
 
     if (newUsing && !oldUsing) {
         if(class'MenuChoice_BalanceEtc'.static.IsEnabled() || #defined(vmd)) {
@@ -42,11 +34,7 @@ function Frob(Actor Frobber, Inventory frobWith)
         }
         if (chugged)
         {
-#ifdef injections
-            class'WaterCooler'.static.PlayDrown(Frobber);
-#else
-            class'DXRWaterCooler'.static.PlayDrown(Frobber);
-#endif
+            class'#var(injectsprefix)WaterCooler'.static.PlayDrown(Frobber);
             class'DXREvents'.static.MarkBingo("ChugWater");
         }
     }

--- a/src/GUI/DeusEx/Classes/DXRHUDCompassDisplay.uc
+++ b/src/GUI/DeusEx/Classes/DXRHUDCompassDisplay.uc
@@ -1,11 +1,19 @@
 class DXRHUDCompassDisplay injects HUDCompassDisplay;
 
+var transient bool inited;
+var vector coords_mult;
+
 event Tick(float deltaSeconds)
 {
-    local vector coords_mult;
     local Rotator playerRot;
+    local DXRFlags f;
 
-    coords_mult = class'DXRMapVariants'.static.GetCoordsMult(player.GetURLMap());
+    if (player==None) return;
+
+    if (!inited){
+        coords_mult = class'DXRMapVariants'.static.GetCoordsMult(player.GetURLMap());
+        inited = true;
+    }
 
     //Mirror the players rotation if on mirrored maps (so it goes back to unmirrored rotation)
     playerRot = class'DXRBase'.static.rotm_static(player.Rotation.Pitch,

--- a/src/GUI/DeusEx/Classes/DXRHUDCompassDisplay.uc
+++ b/src/GUI/DeusEx/Classes/DXRHUDCompassDisplay.uc
@@ -1,0 +1,40 @@
+class DXRHUDCompassDisplay injects HUDCompassDisplay;
+
+event Tick(float deltaSeconds)
+{
+    local vector coords_mult;
+    local Rotator playerRot;
+
+    coords_mult = class'DXRMapVariants'.static.GetCoordsMult(player.GetURLMap());
+
+    //Mirror the players rotation if on mirrored maps (so it goes back to unmirrored rotation)
+    playerRot = class'DXRBase'.static.rotm_static(player.Rotation.Pitch,
+                                                  player.Rotation.Yaw,
+                                                  player.Rotation.Roll,
+                                                  class'DXRActorsBase'.static.GetRotationOffset(player.class),
+                                                  coords_mult);
+
+    // Only continue if we moved
+    //Duplicated from HUDCompassDisplay, but using playerRot instead of player.Rotation
+    if (lastPlayerYaw != playerRot.Yaw)
+    {
+        lastPlayerYaw = playerRot.Yaw;
+
+        // Based on the player's rotation and the map's True North, calculate
+        // where to draw the tick marks and letters
+        drawPos = clipWidthHalf - (((lastPlayerYaw - mapNorth) & 65535) / UnitsPerPixel);
+
+        // We have two tickmark windows to compensate what happens with
+        // the wrap condition.
+
+        if ((drawPos > 0) && (drawPos < clipWidth))
+            wrapPos = drawPos - tickWidth;
+        else if (drawPos - tickWidth < (clipWidthHalf))
+            wrapPos = drawPos + tickWidth;
+        else
+            wrapPos = 100;
+
+        winCompass1.SetPos(drawPos, 0);
+        winCompass2.SetPos(wrapPos, 0);
+    }
+}

--- a/src/GUI/DeusEx/Classes/DXRHUDCompassDisplay.uc
+++ b/src/GUI/DeusEx/Classes/DXRHUDCompassDisplay.uc
@@ -6,7 +6,6 @@ var vector coords_mult;
 event Tick(float deltaSeconds)
 {
     local Rotator playerRot;
-    local DXRFlags f;
 
     if (player==None) return;
 

--- a/src/GUI/DeusEx/Classes/DXRHUDCompassDisplay.uc
+++ b/src/GUI/DeusEx/Classes/DXRHUDCompassDisplay.uc
@@ -2,6 +2,7 @@ class DXRHUDCompassDisplay injects HUDCompassDisplay;
 
 var transient bool inited;
 var vector coords_mult;
+var int rotOffset;
 
 event Tick(float deltaSeconds)
 {
@@ -11,6 +12,7 @@ event Tick(float deltaSeconds)
 
     if (!inited){
         coords_mult = class'DXRMapVariants'.static.GetCoordsMult(player.GetURLMap());
+        rotOffset = class'DXRActorsBase'.static.GetRotationOffset(player.class);
         inited = true;
     }
 
@@ -18,7 +20,7 @@ event Tick(float deltaSeconds)
     playerRot = class'DXRBase'.static.rotm_static(player.Rotation.Pitch,
                                                   player.Rotation.Yaw,
                                                   player.Rotation.Roll,
-                                                  class'DXRActorsBase'.static.GetRotationOffset(player.class),
+                                                  rotOffset,
                                                   coords_mult);
 
     // Only continue if we moved

--- a/src/GUI/DeusEx/Classes/FrobDisplayWindow.uc
+++ b/src/GUI/DeusEx/Classes/FrobDisplayWindow.uc
@@ -596,10 +596,10 @@ function string WeaponStrInfo(#var(DeusExPrefix)Weapon w, out int numLines)
         strInfo=strInfo$" (Default: "$compDmg$")";
     }
 
-    strInfo=strInfo $ CR() $"Fire Rate: "$ class'DXRInfo'.static.TruncateFloat(fireRate,1)$"/s";
+    strInfo=strInfo $ CR() $"Fire Rate: "$ w.FormatFloatString(fireRate,0.1)$"/s";
 
     if (compFireRate!=0 && compFireRate!=fireRate){
-        strInfo=strInfo$" (Default: "$class'DXRInfo'.static.TruncateFloat(compFireRate,1)$")";
+        strInfo=strInfo$" (Default: "$w.FormatFloatString(compFireRate,0.1)$")";
     }
 
     return strInfo;

--- a/src/GUI/DeusEx/Classes/PersonaScreenBingo.uc
+++ b/src/GUI/DeusEx/Classes/PersonaScreenBingo.uc
@@ -120,16 +120,66 @@ function ShowBingoGoalHelp( Window bingoTile )
     }
 }
 
+function string GetNextStartingMap(DXRando dxr)
+{
+    local int nextStartNum;
+    local string nextStartName;
+    local DXRStartMap m;
+
+    if(dxr.flags.settings.starting_map == 0) return "";
+
+    m = DXRStartMap(class'DXRStartMap'.static.Find());
+    if(m == None) return "";
+    dxr.seed++;
+    nextStartNum = m.ChooseRandomStartMap(m, dxr.flags.settings.starting_map);
+    dxr.seed--;
+    nextStartName = m.GetStartingMapName(nextStartNum);
+    return nextStartName;
+}
+
 function bool ButtonActivated( Window buttonPressed )
 {
-    local int val;
+    local int bingoWin, bingosCompleted,  bingoDuration, currentLoop;
+    local string infoText, nextStartName, difficulty;
+    local DXRando dxr;
 
     if(buttonPressed == btnReset) {
         root.MessageBox(ResetWindowHeader,ResetWindowText,0,False,Self);
         return true;
     }
     else if(buttonPressed == btnBingoInfo) {
-        class'BingoHintMsgBox'.static.Create(root, InfoWindowHeader, InfoWindowText, 1, False, self);
+        dxr = class'DXRando'.default.dxr;
+
+        bingoWin = dxr.flags.settings.bingo_win;
+        bingosCompleted = class'PlayerDataItem'.static.GiveItem(dxr.player).NumberOfBingos();
+        bingoDuration = dxr.flags.bingo_duration;
+        currentLoop = dxr.flags.newgameplus_loops;
+        difficulty = class'DXRInfo'.static.FloatToString(dxr.player.CombatDifficulty, 3);
+
+        nextStartName = GetNextStartingMap(dxr);
+
+        infoText = InfoWindowText $ "|n";
+        if (dxr.flags.IsBingoCampaignMode() && bingoWin > 0) {
+            infoText = infoText $ "|nBingo Lines Required to Progress: " $ bingoWin;
+        } else if (bingoWin > 0) {
+            infoText = infoText $ "|nBingo Lines to Win: " $ bingoWin;
+        }
+        infoText = infoText $ "|nBingo Lines Completed: " $ bingosCompleted;
+        infoText = infoText $ "|nBingo Duration: ";
+        if (bingoDuration == 0) {
+            infoText = infoText $ "End of the Game";
+        } else {
+            infoText = infoText $ bingoDuration $ " Mission";
+            if (bingoDuration != 1) {
+                infoText = infoText $ "s";
+            }
+        }
+        infoText = infoText $ "|n|nNew Game Plus Loops Completed: " $ currentLoop;
+        if(nextStartName != "") infoText = infoText $ "|nNext Loop Starting Map: " $ nextStartName;
+        infoText = infoText $ "|n|nCombat Difficulty: " $ difficulty;
+
+        class'BingoHintMsgBox'.static.Create(root, InfoWindowHeader, infoText, 1, False, self);
+
         return true;
     }
     else if(BingoTile(buttonPressed)!=None){
@@ -142,27 +192,27 @@ function bool ButtonActivated( Window buttonPressed )
 
 defaultproperties
 {
-     ClientWidth=426
-     ClientHeight=407
-     clientOffsetX=105
-     clientOffsetY=17
-     clientTextures(0)=Texture'DeusExUI.UserInterface.LogsBackground_1'
-     clientTextures(1)=Texture'DeusExUI.UserInterface.LogsBackground_2'
-     clientTextures(2)=Texture'DeusExUI.UserInterface.LogsBackground_3'
-     clientTextures(3)=Texture'DeusExUI.UserInterface.LogsBackground_4'
-     clientBorderTextures(0)=Texture'DeusExUI.UserInterface.ConversationsBorder_1'
-     clientBorderTextures(1)=Texture'DeusExUI.UserInterface.ConversationsBorder_2'
-     clientBorderTextures(2)=Texture'DeusExUI.UserInterface.ConversationsBorder_3'
-     clientBorderTextures(3)=Texture'DeusExUI.UserInterface.ConversationsBorder_4'
-     clientBorderTextures(4)=Texture'DeusExUI.UserInterface.ConversationsBorder_5'
-     clientBorderTextures(5)=Texture'DeusExUI.UserInterface.ConversationsBorder_6'
-     clientTextureRows=2
-     clientTextureCols=2
-     clientBorderTextureRows=2
-     clientBorderTextureCols=3
-     ResetWindowHeader="Are you sure?"
-     ResetWindowText="Are you sure you want to reset your board?  All bingo progress will be lost!"
-     InfoWindowHeader="Bingo Info"
-     InfoWindowText="Complete specific tasks to mark off bingo squares!|n|nSquares marked gray can be completed this mission.  Black squares cannot be completed in this mission.  Green squares have been completed.  Red squares can no longer be completed.|n|nClick on the squares to get more info about the specific task in each one!"
-     bingoWikiUrl="https://github.com/Die4Ever/deus-ex-randomizer/wiki/Bingo-Goals"
+    ClientWidth=426
+    ClientHeight=407
+    clientOffsetX=105
+    clientOffsetY=17
+    clientTextures(0)=Texture'DeusExUI.UserInterface.LogsBackground_1'
+    clientTextures(1)=Texture'DeusExUI.UserInterface.LogsBackground_2'
+    clientTextures(2)=Texture'DeusExUI.UserInterface.LogsBackground_3'
+    clientTextures(3)=Texture'DeusExUI.UserInterface.LogsBackground_4'
+    clientBorderTextures(0)=Texture'DeusExUI.UserInterface.ConversationsBorder_1'
+    clientBorderTextures(1)=Texture'DeusExUI.UserInterface.ConversationsBorder_2'
+    clientBorderTextures(2)=Texture'DeusExUI.UserInterface.ConversationsBorder_3'
+    clientBorderTextures(3)=Texture'DeusExUI.UserInterface.ConversationsBorder_4'
+    clientBorderTextures(4)=Texture'DeusExUI.UserInterface.ConversationsBorder_5'
+    clientBorderTextures(5)=Texture'DeusExUI.UserInterface.ConversationsBorder_6'
+    clientTextureRows=2
+    clientTextureCols=2
+    clientBorderTextureRows=2
+    clientBorderTextureCols=3
+    ResetWindowHeader="Are you sure?"
+    ResetWindowText="Are you sure you want to reset your board?  All bingo progress will be lost!"
+    InfoWindowHeader="Bingo Info"
+    InfoWindowText="Complete specific tasks to mark off bingo squares!|n|nSquares marked gray can be completed this mission.  Black squares cannot be completed in this mission.  Green squares have been completed.  Red squares can no longer be completed.|n|nClick on the squares to get more info about the specific task for each one!"
+    bingoWikiUrl="https://github.com/Die4Ever/deus-ex-randomizer/wiki/Bingo-Goals"
 }

--- a/src/GUI/DeusEx/Classes/ScopeView.uc
+++ b/src/GUI/DeusEx/Classes/ScopeView.uc
@@ -124,14 +124,14 @@ simulated function PeepTimer(int timerID, int invocations, int clientData)
                 //But also make sure it isn't a fake mirror zone
                 if (class'FakeMirrorInfo'.static.IsPointInMirrorZone(Player,HitLocation)){
                     hitMirror = true;
-                    //peeper.ClientMessage("Hit fake mirror on transparent thing");
+                    //peeper.ClientMessage("Hit fake mirror on transparent thing "$HitLocation);
                     break;
                 }
 
             } else if (target==Player.Level){
                 if (class'FakeMirrorInfo'.static.IsPointInMirrorZone(Player,HitLocation)){
                     hitMirror = true;
-                    //peeper.ClientMessage("Hit fake mirror");
+                    //peeper.ClientMessage("Hit fake mirror "$HitLocation);
                     break;
                 }
             }

--- a/src/GUI/DeusEx/Classes/ScopeView.uc
+++ b/src/GUI/DeusEx/Classes/ScopeView.uc
@@ -137,6 +137,13 @@ simulated function PeepTimer(int timerID, int invocations, int clientData)
             }
             else
             {
+                if (#var(DeusExPrefix)Mover(target)!=None){
+                    if (class'FakeMirrorInfo'.static.IsPointInMirrorZone(Player,HitLocation)){
+                        hitMirror = true;
+                        //peeper.ClientMessage("Hit fake mirror attached to mover");
+                        break;
+                    }
+                }
                 peepee = target;
                 break;
             }

--- a/src/GUI/DeusEx/Classes/ScopeView.uc
+++ b/src/GUI/DeusEx/Classes/ScopeView.uc
@@ -140,7 +140,7 @@ simulated function PeepTimer(int timerID, int invocations, int clientData)
                 if (#var(DeusExPrefix)Mover(target)!=None){
                     if (class'FakeMirrorInfo'.static.IsPointInMirrorZone(Player,HitLocation)){
                         hitMirror = true;
-                        //peeper.ClientMessage("Hit fake mirror attached to mover");
+                        //peeper.ClientMessage("Hit fake mirror attached to mover "$HitLocation);
                         break;
                     }
                 }

--- a/src/Pawns/DeusEx/Classes/DXRMJ12TroopBase.uc
+++ b/src/Pawns/DeusEx/Classes/DXRMJ12TroopBase.uc
@@ -16,10 +16,7 @@ function Explode(optional vector HitLocation) // argument for compatibility with
     local float explosionDamage;
     local float explosionRadius;
 
-#ifdef revision
-    Super.Explode();
-    return;
-#elseif vmd
+#ifdef revision || vmd
     Super.Explode();
     return;
 #endif

--- a/src/Pawns/DeusEx/Classes/DXRUNATCOTroopBase.uc
+++ b/src/Pawns/DeusEx/Classes/DXRUNATCOTroopBase.uc
@@ -16,10 +16,7 @@ function Explode(optional vector HitLocation) // argument for compatibility with
     local float explosionDamage;
     local float explosionRadius;
 
-#ifdef revision
-    Super.Explode();
-    return;
-#elseif vmd
+#ifdef revision || vmd
     Super.Explode();
     return;
 #endif

--- a/src/Triggers/DeusEx/Classes/DXRRaceTimerStart.uc
+++ b/src/Triggers/DeusEx/Classes/DXRRaceTimerStart.uc
@@ -92,12 +92,42 @@ function RaceFinished()
 
     p = #var(PlayerPawn)(GetPlayerPawn());
     if (p!=None){
-        //p.ClientMessage("Finished "$raceName$" in "$class'DXRInfo'.static.FloatToString(totalTime,3)$" seconds!");
+        //p.ClientMessage("Finished "$raceName$" in "$ConstructTimeStr(totalTime)$"!");
         if (beatTarget && class'MenuChoice_ToggleMemes'.static.IsEnabled(class'DXRando'.default.dxr.flags)){
-            p.ClientMessage("Beat "$raceName$" in "$class'DXRInfo'.static.FloatToString(totalTime,3)$" seconds, under the target time of "$class'DXRInfo'.static.FloatToString(targetTime,3)$" seconds!");
+            p.ClientMessage("Beat "$raceName$" in "$ConstructTimeStr(totalTime)$", under the target time of "$ConstructTimeStr(targetTime)$"!");
         }
     }
+}
 
+function string ConstructTimeStr(float timeSecs)
+{
+    local int hours, minutes;
+    local string timeStr;
+
+    hours = int(timeSecs/3600);
+    timeSecs = timeSecs - (hours*3600);
+
+    minutes = int(timeSecs/60);
+    timeSecs = timeSecs - (minutes*60);
+
+    timeStr = "";
+    if (hours>0){
+        timeStr = timeStr $ hours $ " hour";
+        if (hours!=1){
+            timeStr = timeStr $ "s";
+        }
+        timeStr = timeStr $", ";
+    }
+    if (minutes>0){
+        timeStr = timeStr $ minutes$" minute";
+        if (minutes!=1){
+            timeStr = timeStr $ "s";
+        }
+        timeStr = timeStr $ ", ";
+    }
+    timeStr = timeStr $ class'DXRInfo'.static.FloatToString(timeSecs,3) $ " seconds";
+
+    return timeStr;
 }
 
 defaultproperties

--- a/src/Triggers/DeusEx/Classes/DolphinJumpTrigger.uc
+++ b/src/Triggers/DeusEx/Classes/DolphinJumpTrigger.uc
@@ -1,0 +1,34 @@
+#compileif injections || revision
+class DolphinJumpTrigger extends BingoTrigger;
+
+static function DolphinJumpTrigger CreateDolphin(PlayerPawn p)
+{
+    local DolphinJumpTrigger t;
+
+    // keep height number in sync with DXREvents GetBingoGoalHelpText
+    t = p.Spawn(class'DolphinJumpTrigger',,, p.Location+vect(0,0,184));
+    t.SetTimer(0.55, false);
+}
+
+function bool IsRelevant(actor Other)
+{
+    local #var(PlayerPawn) p;
+    p = #var(PlayerPawn)(Other);
+    if(p != None) {
+        return p.Physics == PHYS_Falling && !p.bOnLadder;
+    }
+    return false;
+}
+
+function Timer()
+{
+    Destroy();
+}
+
+defaultproperties
+{
+    CollisionRadius=32
+    CollisionHeight=32
+    bDestroyOthers=true
+    bingoEvent="DolphinJump"
+}

--- a/src/Triggers/DeusEx/Classes/RepairConObjTransferTrigger.uc
+++ b/src/Triggers/DeusEx/Classes/RepairConObjTransferTrigger.uc
@@ -1,0 +1,78 @@
+class RepairConObjTransferTrigger extends Trigger;
+
+var name conName;
+var string packages[5];
+
+function Trigger(Actor Other, Pawn Instigator)
+{
+    local ConEventTransferObject e;
+
+    foreach AllObjects(class'ConEventTransferObject',e)
+    {
+        if (e.conversation.conName != conName) continue;
+        if (e.objectName!="" && e.giveObject==None){
+            RepairConEventTransferObjectClassReference(e);
+        }
+    }
+}
+
+function RepairConEventTransferObjectClassReference(ConEventTransferObject e)
+{
+    local class<Inventory> actualClass;
+    local string className;
+    local bool fullyQualified;
+    local int i;
+
+    className = e.objectName;
+    if(instr(e.objectName, ".") != -1) {
+        fullyQualified = true;
+    }
+
+    actualClass = class<inventory>(DynamicLoadObject(className, class'Class')); //Try loading the named class directly
+
+    if (!fullyQualified){
+        //if the class was fully qualified (with a package name), we have to assume that was the intended class
+        //whether we find it or not.  If it wasn't, let's try some other packages
+        for (i=0;i<ArrayCount(packages);i++)
+        {
+            if (packages[i]=="") continue;
+            className = packages[i]$"."$e.objectName;
+            actualClass = class<inventory>(DynamicLoadObject(className, class'Class'));
+            if (actualClass!=None){
+                break;
+            }
+        }
+    }
+
+    if (actualClass==None){
+        //Couldn't find a viable class, no repair possible on this event
+        return;
+    }
+
+    e.giveObject = actualClass;
+}
+
+
+function AddPackage(string packageName)
+{
+    local int i;
+    for (i=0;i<ArrayCount(packages);i++)
+    {
+        if (packages[i]!="") continue;
+        if (packages[i]==packageName) return; //Don't add the same thing twice
+        packages[i]=packageName;
+        return;
+    }
+}
+
+
+defaultproperties
+{
+    bCollideActors=false
+    bCollideWorld=false
+    bBlockActors=false
+    bBlockPlayers=false
+    bProjTarget=false
+    bTriggerOnceOnly=false
+    packages(0)="DeusEx"
+}


### PR DESCRIPTION
# Major Changes Since v3.5.0.2 Alpha:

- Compass direction gets mirrored when appropriate so verbal directions match the on-screen compass
- The Merchant can properly transfer items from packages that aren't the DeusEx package (which broke Rubber Baton sales in non-vanilla)
- Fixed a bunch of mirrors for bingo purposes
- Minimum damage of 2 for tranq darts and other projectiles
- Show next loop starting map when bingo_win is greater than zero in the Bingo Info window

# Minor Changes Since v3.5.0.2 Alpha:

- Horde mode:
    - Horde Mode no longer bans skills outright, uses aug slot rando, and doesn't reroll skill costs
    - Allow Ironman (All Saves Disabled) save mode to be shown in the list if it is the current default
    - Remove forced Speed Enhancement from Horde Mode, now it depends on your loadout where Speed Enhancement is still selectable
    - Added 20mm, Sabot, and WP to item options.
- Unaugmented Prison Pocket
- Paul's apartment door in M04 can be manually closed again (It works this way in M02)
- Always RemoveStopWhenEncroach() movers because it's bad
- First draft help text for Crowd Control and Mirrored Maps
- M15 Bunker PlaceholderEnemy on top of vent to make that route slightly harder and more in-line with the blast door route
- Update rotations on all randomized start locations so they're facing an identifiable direction (instead of a wall or something)
- Show fire rate of melee weapons on Inventory screen.
- Change SkillAwardCrate mass to 35
- Replace Vandenberg comsat random start with tunnels (basically the same thing)
- M06: storage UC_Chamber_Door not breakable (breaking this can cause a lot of confusion, and you need to use the computer anyways to get the UC schematics in order to progress)
- Make sure Harley Filben's name isn't randomized
- M08: don't move the flaming barrel near Dowd, it's good for visibility
- Catacombs race now has a forwards target time of 90 seconds, and Reverse Catacombs has a target time of 60 seconds. Race timers can display the time in the most appropriate set of units (e.g., 1 minute, 30 seconds)
- Name the Denfert-Rochereau elevator call button "call button"
- Hint about saving during infolinks actually varies based on the configured setting
- Both doors for elevator to Level 2 lab break into MetalFragment
- Prevent M05 Karkians from being cloned, so they don't clone outside the enclosure
- Intro Randomization makes sure the object in the clone tube floats in the middle and gets scaled to fill up the space
- Disable Let Jock Die bingo goal when end_mission < 15
- Zero Rando fixed CombatDifficulty below Realistic
- difficulty descriptions
- Update descriptions for Doors Pickable and Doors Destructible in the credits so they show the selected setting name
- Clothes Looting setting persists through NG+
- Floor Is Lava: fix ladder check for Revision
- "The marks on your head look like stars in the sky"

# Previous Alpha Changes: https://github.com/Die4Ever/deus-ex-randomizer/pull/1192