### PR TITLE
v3.5.0.7 Beta

### DIFF
--- a/src/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -56,7 +56,6 @@ function SwapAll(string classname, float percent_chance)
 
     for(i=num-1; i>=0; i--) { // Fisher-Yates shuffle the array before swapping the actor locations (swapping actor locations can fail, shuffling the array cannot fail, Fisher-Yates works better for unfailable shuffles)
         slot = rng(i+1);
-        Swap(temp[i], temp[slot]);
         a = temp[i];
         temp[i] = temp[slot];
         temp[slot] = a;

--- a/src/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
+++ b/src/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
@@ -777,14 +777,13 @@ function MoveAwayFrom(Actor other)
 
     if(destLoc != vect(0,0,0) && VSize(Velocity)>0) return; // already moving somewhere
     if(#var(PlayerPawn)(other) == None) return; // we only care if it's a player?
+    if(Pawn(other).Weapon == None) return; // only if carrying a weapon
     if(GetAllianceType(Pawn(other).Alliance) == ALLIANCE_Hostile) return;
     extra = other.CollisionRadius + CollisionRadius;
     rot = Rotator(Location - other.Location);
-    if(Pawn(other).Weapon != None) extra += 48;
-    bSuccess = AIDirectionReachable(other.Location, rot.Yaw, rot.Pitch, 48, 100+extra, destLoc);
+    bSuccess = AIDirectionReachable(other.Location, rot.Yaw, rot.Pitch, 48+extra, 100+extra, destLoc);
     if(bSuccess) {
-        if(Pawn(other).Weapon != None) GotoState(GetStateName(), 'RunAway');
-        else GotoState(GetStateName(), 'WalkAway');
+        GotoState(GetStateName(), 'RunAway');
     } else {
         destLoc = vect(0,0,0);
     }
@@ -858,15 +857,6 @@ state Standing
         bStasis = True;
 
         StopBlendAnims();
-    }
-
-WalkAway: // DXRando
-    if(destLoc != vect(0,0,0)) {
-        if (ShouldPlayWalk(destLoc))
-            PlayWalking();
-        MoveTo(destLoc, GetWalkingSpeed());
-        CheckDestLoc(destLoc);
-        destLoc = vect(0,0,0);
     }
 
 RunAway: // DXRando
@@ -1040,15 +1030,6 @@ state Dancing
         bStasis = True;
 
         StopBlendAnims();
-    }
-
-WalkAway: // DXRando
-    if(destLoc != vect(0,0,0)) {
-        if (ShouldPlayWalk(destLoc))
-            PlayWalking();
-        MoveTo(destLoc, GetWalkingSpeed());
-        CheckDestLoc(destLoc);
-        destLoc = vect(0,0,0);
     }
 
 RunAway: // DXRando

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM00.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM00.uc
@@ -153,3 +153,49 @@ function PostFirstEntryMapFixes()
     }
 }
 //#endregion
+
+//#region Any Entry
+function AnyEntryMapFixes()
+{
+    if(dxr.flags.IsZeroRando()) return;
+
+    switch(dxr.localURL) {
+    case "00_Training":
+        SpawnTrainingMerchant(vectm(4435,480,-145),rotm(0,32768,0,16384),class'Soyfood',10,class'SodaCan',5, class'Candybar',7,class'Flare',20);
+        break;
+    case "00_TrainingCombat":
+        SpawnTrainingMerchant(vectm(1715,1085,-110),rotm(0,-9000,0,16384),class'WeaponGepGun',500,class'WeaponLAM',100);
+        break;
+    case "00_TrainingFinal":
+        SpawnTrainingMerchant(vectm(6575,-4770,80),rotm(0,16384,0,16384),class'Medkit',50,class'BioElectricCell',50);
+        break;
+    }
+}
+//#endregion
+
+
+//#region Training Merchant
+function SpawnTrainingMerchant(vector loc, rotator rot,
+                               optional class<Inventory> forcedItem1, optional int forcedItemPrice1,
+                               optional class<Inventory> forcedItem2, optional int forcedItemPrice2,
+                               optional class<Inventory> forcedItem3, optional int forcedItemPrice3,
+                               optional class<Inventory> forcedItem4, optional int forcedItemPrice4)
+{
+    local DXRNPCs npcs;
+    local ScriptedPawn sp;
+
+    // we need to do this in AnyEntry because we need to recreate the conversation objects since they're transient
+    npcs = DXRNPCs(dxr.FindModule(class'DXRNPCs'));
+    if(npcs != None) {
+        sp = npcs.CreateForcedMerchant("Training Merchant", 'trainingmerchant', class'TrainingMerchant', loc, rot,
+                                       false, //Don't add extra items
+                                       true, //randomize item prices
+                                       500,  //Price limit of 500 (No items with base price over 500)
+                                       npcs.CreateForcedItems(
+                                       forcedItem1,forcedItemPrice1,
+                                       forcedItem2,forcedItemPrice2,
+                                       forcedItem3,forcedItemPrice3,
+                                       forcedItem4,forcedItemPrice4));
+    }
+}
+//#endregion

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -463,9 +463,11 @@ function SpawnLeMerchant(vector loc, rotator rot)
         // we need to do this in AnyEntry because we need to recreate the conversation objects since they're transient
         npcs = DXRNPCs(dxr.FindModule(class'DXRNPCs'));
         if(npcs != None) {
-            //Price limit of 600 (No items with base price over 600)
-            //Forced Hazmat at base price of 150
-            sp = npcs.CreateForcedMerchant("Le Merchant", 'lemerchant', class'LeMerchant', loc, rot, 600, class'#var(prefix)HazMatSuit', 150);
+            sp = npcs.CreateForcedMerchant("Le Merchant", 'lemerchant', class'LeMerchant', loc, rot,
+                                           true, //Add random items on top of his forced items
+                                           true, //Randomize item prices
+                                           600, //Price limit of 600 (No items with base price over 600)
+                                           npcs.CreateForcedItems(class'#var(prefix)HazMatSuit', 150)); //Forced Hazmat at base price of 150
         }
         // give him weapons to defend himself
         dxre = DXREnemies(dxr.FindModule(class'DXREnemies'));

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsM15.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsM15.uc
@@ -34,10 +34,14 @@ function int InitGoals(int mission, string map)
         AddActorLocation(loc, 1, vect(-3455,-3261,-1560), rot(0,0,0));
 
         AddGoal("15_AREA51_BUNKER", "Area 51 Blast Door Computer", GOAL_TYPE1, 'ComputerSecurity0', PHYS_None);
-        AddGoalLocation("15_AREA51_BUNKER", "the tower", GOAL_TYPE1 | VANILLA_GOAL, vect(-1248.804321,137.393707,442.793121), rot(0, 0, 0));
-        AddGoalLocation("15_AREA51_BUNKER", "Command 24", GOAL_TYPE1, vect(1125.200562,2887.646484,-432.319794), rot(0, 0, 0));
-        AddGoalLocation("15_AREA51_BUNKER", "the hangar", GOAL_TYPE1, vect(1062.942261,-2496.865723,-443.252533), rot(0, 16384, 0));
-        AddGoalLocation("15_AREA51_BUNKER", "the supply shed", GOAL_TYPE1, vect(-1527.608521,3280.824219,-158.588562), rot(0, -16384, 0));
+        loc = AddGoalLocation("15_AREA51_BUNKER", "the tower", GOAL_TYPE1 | VANILLA_GOAL, vect(-1248.804321,137.393707,442.793121), rot(0, 0, 0));
+        AddMapMarker(class'Image15_Area51Bunker',29,220,"C","Blast Door Computer", loc,"The Blast Door Computer can sometimes be found at the top of the Tower.");
+        loc = AddGoalLocation("15_AREA51_BUNKER", "Command 24", GOAL_TYPE1, vect(1125.200562,2887.646484,-432.319794), rot(0, 0, 0));
+        AddMapMarker(class'Image15_Area51Bunker',151,277,"C","Blast Door Computer", loc,"The Blast Door Computer can sometimes be found in the Command 24 building.");
+        loc = AddGoalLocation("15_AREA51_BUNKER", "the hangar", GOAL_TYPE1, vect(1062.942261,-2496.865723,-443.252533), rot(0, 16384, 0));
+        AddMapMarker(class'Image15_Area51Bunker',95,134,"C","Blast Door Computer", loc,"The Blast Door Computer can sometimes be found on the outside of the building inside the Hangar.");
+        loc = AddGoalLocation("15_AREA51_BUNKER", "the supply shed", GOAL_TYPE1, vect(-1527.608521,3280.824219,-158.588562), rot(0, -16384, 0));
+        AddMapMarker(class'Image15_Area51Bunker',63,316,"C","Blast Door Computer", loc,"The Blast Door Computer can sometimes be found in the Supply Shed (Which is not visible on this map image).");
 
         if (dxr.flags.settings.starting_map > 150)
         {
@@ -94,8 +98,13 @@ function int InitGoals(int mission, string map)
         } else {
             //Only use the rooms as extra locations
             loc = AddGoalLocation("15_AREA51_PAGE", "Upper UC Control Room", GOAL_TYPE1, vect(7991,-7395,-5096), rot(0, 32768, 0));
+            AddMapMarker(class'Image15_Area51_Sector4',237,11,"E","Ending", loc,"One of the end game goals can be located on the wall of the Control Room for the upper UC (UC-03).");
+
             loc = AddGoalLocation("15_AREA51_PAGE", "Middle UC Control Room", NORMAL_GOAL, vect(5382,-8556,-5540), rot(0, 0, 0));
+            AddMapMarker(class'Image15_Area51_Sector4',53,348,"E","Ending", loc,"One of the end game goals can be located on the wall of the Control Room for the middle UC (UC-01).");
+
             loc = AddGoalLocation("15_AREA51_PAGE", "Bottom UC Control Room", NORMAL_GOAL, vect(7868,-7631,-5931), rot(0, 16384, 0));
+            AddMapMarker(class'Image15_Area51_Sector4',224,187,"E","Ending", loc,"One of the end game goals can be located on the wall of the Control Room for the bottom UC (UC-02).");
         }
 
         return 154;

--- a/src/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -1221,7 +1221,6 @@ simulated function TutorialDisableRandomization(bool enableSomeRando)
         settings.medbots = 100;
         settings.repairbots = 100;
         settings.augcans = 100;
-        settings.merchants = 100;
     }
     else {
         settings.swapitems = 0;
@@ -1234,6 +1233,7 @@ simulated function TutorialDisableRandomization(bool enableSomeRando)
         settings.augcans = 0;
     }
 
+    settings.merchants = 0;  //We'll manually add merchants so they don't interfere
     settings.keysrando = 0;
     settings.speedlevel = 0;
     settings.startinglocations = 0;

--- a/src/DXRModules/DeusEx/Classes/DXRReduceItems.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRReduceItems.uc
@@ -40,10 +40,6 @@ function CheckConfig()
 
     if(class'MenuChoice_BalanceItems'.static.IsEnabled()) {
         i=0;
-        _item_reductions[i].type = class'#var(prefix)Ammo10mm';
-        _item_reductions[i].percent = 85;
-        i++;
-
         _item_reductions[i].type = class'#var(prefix)AmmoPlasma';
         _item_reductions[i].percent = 130;
         i++;
@@ -66,7 +62,7 @@ function CheckConfig()
 
         i=0;
         _max_ammo[i].type = class'#var(prefix)Ammo10mm';
-        _max_ammo[i].percent = 60;
+        _max_ammo[i].percent = 67; // 150 down to 100
         i++;
 
         _max_ammo[i].type = class'#var(prefix)AmmoPlasma';

--- a/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -113,7 +113,8 @@ function PreFirstEntry()
         if (dxr.flags.settings.starting_map >= 121) {
             RemoveJock('UN_BlackHeli');
             foreach AllActors(class'#var(DeusExPrefix)Mover', dxMover, 'comhqdoor') {
-                dxMover.InterpolateTo(1, 0.0);
+                dxMover.bTriggerOnceOnly = true;
+                dxMover.Trigger(self, None);
                 break;
             }
             dxr.flagbase.SetBool('DL_TonyScared_Played', true,, 15); // You won't find cover in the comm building.
@@ -205,7 +206,8 @@ function RemoveJock(name jockTag)
 
     foreach AllActors(class'#var(prefix)BlackHelicopter', jock, jockTag) {
         log("Removing a BlackHelicopter from " $ dxr.localURL $ " with tag '" $ jock.tag $ "'");
-        jock.LeaveWorld();
+        jock.Event='';
+        jock.Destroy();
         break;
     }
 }

--- a/src/DXRando/DeusEx/Classes/DXRFashionManager.uc
+++ b/src/DXRando/DeusEx/Classes/DXRFashionManager.uc
@@ -46,7 +46,7 @@ struct ClothesTextures{
     var Texture tex2;
 };
 
-struct Clothes {
+struct ClothesStruct {
     var travel EClothesType type;
     var travel EGender gender;
     var travel String tex1;
@@ -70,7 +70,7 @@ struct CurrentOutfit {
 
 var travel bool isFemale;
 var travel ESkinTone PlayerSkinTone;
-var travel Clothes clothing[250];
+var travel ClothesStruct clothing[250];
 var travel int numClothes;
 
 const cPLAYER = 0;
@@ -173,6 +173,10 @@ function Mesh GetCurPaulModel()
 function InitClothes(bool giveAll)
 {
     //local class<#var(DeusExPrefix)Carcass> carcClass;
+
+    if(numClothes > 0 && clothing[0].type == CT_None) {
+        numClothes = 0;
+    }
 
 #ifndef hx
 //    IngestCarcass(class'JCDentonMaleCarcass');
@@ -392,9 +396,9 @@ simulated function bool AppropriateForSkinTone(ESkinTone ClothingSkin)
 
 //Fallback, just in case the player somehow doesn't have suitable clothes.
 //In theory we shouldn't really ever need these, but better safe than sorry
-simulated function Clothes DefaultClothingByType(EClothesType type, bool female)
+simulated function ClothesStruct DefaultClothingByType(EClothesType type, bool female)
 {
-    local Clothes defClothes;
+    local ClothesStruct defClothes;
 
     defClothes.type=type;
     defClothes.gender=G_Both;
@@ -467,9 +471,9 @@ simulated function Clothes DefaultClothingByType(EClothesType type, bool female)
     return defClothes;
 }
 
-simulated function Clothes PickRandomClothingByType(EClothesType type, bool female)
+simulated function ClothesStruct PickRandomClothingByType(EClothesType type, bool female)
 {
-    local Clothes choices[ArrayCount(clothing)];
+    local ClothesStruct choices[ArrayCount(clothing)];
     local int numChoices,i;
 
     for (i=0;i<numClothes;i++){
@@ -484,7 +488,7 @@ simulated function Clothes PickRandomClothingByType(EClothesType type, bool fema
     return choices[Rand(numChoices)];
 }
 
-simulated function ClothesTextures FetchClothesTextures(Clothes c)
+simulated function ClothesTextures FetchClothesTextures(ClothesStruct c)
 {
     local ClothesTextures ct;
 
@@ -501,7 +505,7 @@ simulated function ClothesTextures FetchClothesTextures(Clothes c)
 simulated function GenerateOverrides(bool female, EOutfitType outfit, out Texture newMultis[8])
 {
     local int i;
-    local Clothes c1,c2,c3,c4;
+    local ClothesStruct c1,c2,c3,c4;
     local ClothesTextures ct1,ct2,ct3,ct4;
 
     for (i=0;i<ArrayCount(newMultis);i++){

--- a/src/Pawns/DeusEx/Classes/TrainingMerchant.uc
+++ b/src/Pawns/DeusEx/Classes/TrainingMerchant.uc
@@ -1,0 +1,51 @@
+//Welcome to the Coalition, Merchant
+class TrainingMerchant extends Merchant;
+
+//Merchant'ed UNATCO Troop
+/*
+    Texture=Texture'DeusExItems.Skins.PinkMaskTex'
+    Mesh=LodMesh'DeusExCharacters.GM_Jumpsuit'
+    MultiSkins(0)=Texture'DeusExCharacters.Skins.SkinTex1'
+    MultiSkins(1)=Texture'DeusExCharacters.Skins.Businessman3Tex2'
+    MultiSkins(2)=Texture'DeusExCharacters.Skins.Businessman3Tex1'
+    MultiSkins(3)=Texture'DeusExCharacters.Skins.SkinTex1'
+    MultiSkins(4)=Texture'DeusExItems.Skins.PinkMaskTex'
+    MultiSkins(5)=Texture'DeusExItems.Skins.GrayMaskTex'
+    MultiSkins(6)=Texture'DeusExCharacters.Skins.UNATCOTroopTex3'
+    MultiSkins(7)=Texture'DeusExItems.Skins.PinkMaskTex'
+*/
+
+//UNATCO'ed Merchant (Looks a bit weird because of the lack of helmet and the mask bit)
+/*
+    Mesh=LodMesh'DeusExCharacters.GM_Suit'
+    MultiSkins(0)=Texture'DeusExCharacters.Skins.MiscTex1'
+    MultiSkins(1)=Texture'DeusExCharacters.Skins.UNATCOTroopTex1'
+    MultiSkins(2)=Texture'DeusExCharacters.Skins.MiscTex1'
+    MultiSkins(3)=Texture'DeusExCharacters.Skins.Businessman3Tex1'
+    MultiSkins(4)=Texture'DeusExCharacters.Skins.Businessman3Tex1'
+    MultiSkins(5)=Texture'DeusExItems.Skins.GrayMaskTex'
+    MultiSkins(6)=Texture'DeusExItems.Skins.BlackMaskTex'
+    MultiSkins(7)=Texture'DeusExItems.Skins.PinkMaskTex'
+*/
+
+defaultproperties
+{
+    FamiliarName="Training Merchant"
+    UnfamiliarName="Training Merchant"
+    Texture=Texture'DeusExItems.Skins.PinkMaskTex'
+    Mesh=LodMesh'DeusExCharacters.GM_Jumpsuit'
+    MultiSkins(0)=Texture'DeusExCharacters.Skins.SkinTex1'
+    MultiSkins(1)=Texture'DeusExCharacters.Skins.Businessman3Tex2'
+    MultiSkins(2)=Texture'DeusExCharacters.Skins.Businessman3Tex1'
+    MultiSkins(3)=Texture'DeusExCharacters.Skins.SkinTex1'
+    MultiSkins(4)=Texture'DeusExItems.Skins.PinkMaskTex'
+    MultiSkins(5)=Texture'DeusExItems.Skins.GrayMaskTex'
+    MultiSkins(6)=Texture'DeusExCharacters.Skins.UNATCOTroopTex3'
+    MultiSkins(7)=Texture'DeusExItems.Skins.PinkMaskTex'
+    CarcassType=Class'TrainingMerchantCarcass'
+    bHateCarcass=true
+    bHateDistress=true
+    bHateIndirectInjury=true
+    bHateInjury=true
+    bHateShot=true
+}

--- a/src/Pawns/DeusEx/Classes/TrainingMerchantCarcass.uc
+++ b/src/Pawns/DeusEx/Classes/TrainingMerchantCarcass.uc
@@ -1,0 +1,51 @@
+//=============================================================================
+// TrainingMerchantCarcass
+//=============================================================================
+class TrainingMerchantCarcass extends MerchantCarcass;
+
+//Merchant'ed UNATCO Troop
+/*
+    Texture=Texture'DeusExItems.Skins.PinkMaskTex'
+    Mesh2=LodMesh'DeusExCharacters.GM_Jumpsuit_CarcassB'
+    Mesh3=LodMesh'DeusExCharacters.GM_Jumpsuit_CarcassC'
+    Mesh=LodMesh'DeusExCharacters.GM_Jumpsuit_Carcass'
+    MultiSkins(0)=Texture'DeusExCharacters.Skins.SkinTex1'
+    MultiSkins(1)=Texture'DeusExCharacters.Skins.Businessman3Tex2'
+    MultiSkins(2)=Texture'DeusExCharacters.Skins.Businessman3Tex1'
+    MultiSkins(3)=Texture'DeusExCharacters.Skins.SkinTex1'
+    MultiSkins(4)=Texture'DeusExItems.Skins.PinkMaskTex'
+    MultiSkins(5)=Texture'DeusExItems.Skins.GrayMaskTex'
+    MultiSkins(6)=Texture'DeusExCharacters.Skins.UNATCOTroopTex3'
+    MultiSkins(7)=Texture'DeusExItems.Skins.PinkMaskTex'
+*/
+
+//UNATCO'ed Merchant (Looks a bit weird because of the lack of helmet and the mask bit)
+/*
+    Mesh2=LodMesh'DeusExCharacters.GM_Suit_CarcassB'
+    Mesh3=LodMesh'DeusExCharacters.GM_Suit_CarcassC'
+    Mesh=LodMesh'DeusExCharacters.GM_Suit_Carcass'
+    MultiSkins(0)=Texture'DeusExCharacters.Skins.MiscTex1'
+    MultiSkins(1)=Texture'DeusExCharacters.Skins.UNATCOTroopTex1'
+    MultiSkins(2)=Texture'DeusExCharacters.Skins.MiscTex1'
+    MultiSkins(3)=Texture'DeusExCharacters.Skins.Businessman3Tex1'
+    MultiSkins(4)=Texture'DeusExCharacters.Skins.Businessman3Tex1'
+    MultiSkins(5)=Texture'DeusExItems.Skins.GrayMaskTex'
+    MultiSkins(6)=Texture'DeusExItems.Skins.BlackMaskTex'
+    MultiSkins(7)=Texture'DeusExItems.Skins.PinkMaskTex'
+*/
+
+defaultproperties
+{
+    Texture=Texture'DeusExItems.Skins.PinkMaskTex'
+    Mesh2=LodMesh'DeusExCharacters.GM_Jumpsuit_CarcassB'
+    Mesh3=LodMesh'DeusExCharacters.GM_Jumpsuit_CarcassC'
+    Mesh=LodMesh'DeusExCharacters.GM_Jumpsuit_Carcass'
+    MultiSkins(0)=Texture'DeusExCharacters.Skins.SkinTex1'
+    MultiSkins(1)=Texture'DeusExCharacters.Skins.Businessman3Tex2'
+    MultiSkins(2)=Texture'DeusExCharacters.Skins.Businessman3Tex1'
+    MultiSkins(3)=Texture'DeusExCharacters.Skins.SkinTex1'
+    MultiSkins(4)=Texture'DeusExItems.Skins.PinkMaskTex'
+    MultiSkins(5)=Texture'DeusExItems.Skins.GrayMaskTex'
+    MultiSkins(6)=Texture'DeusExCharacters.Skins.UNATCOTroopTex3'
+    MultiSkins(7)=Texture'DeusExItems.Skins.PinkMaskTex'
+}


### PR DESCRIPTION
# Changes since v3.5.0.6 Beta:

- Add markers on the Area 51 Bunker and Area 51 Sector 4 maps for the Blast Door Computer and the UC Room locations
- Create new Training Merchant for use in... Training.
- Fixed item shuffling appearing in Zero Rando and Training
- Pawns only move away from you if you're holding a weapon when you bump into them
- slightly more pistol ammo
- Fixed backwards compatibilty with old saves
- WaltonWare starts later than Vandenberg Command now properly destroy the entry jock
- WaltonWare start later than Vandenberg Command, Comms door cannot be closed

# Previously: v3.5.0.6 Beta: https://github.com/Die4Ever/deus-ex-randomizer/pull/1216

# Previously v3.5.0.5 Beta: https://github.com/Die4Ever/deus-ex-randomizer/pull/1214

# Previously v3.5.0.4 Alpha: https://github.com/Die4Ever/deus-ex-randomizer/pull/1211

# Previously v3.5.0.3 Alpha https://github.com/Die4Ever/deus-ex-randomizer/pull/1204

# Previously v3.5.0.2 Alpha https://github.com/Die4Ever/deus-ex-randomizer/pull/1192

# Previously v3.5.0.1 Alpha https://github.com/Die4Ever/deus-ex-randomizer/pull/1185

# Previously v3.5.0.0 Alpha https://github.com/Die4Ever/deus-ex-randomizer/pull/1172