### PR TITLE
Use j instead of i in the EnumOption() check for a full array

### DIFF
--- a/src/DXRCore/DeusEx/Classes/DXRMenuBase.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuBase.uc
@@ -216,7 +216,7 @@ function NewGroup(string text)
 
 function bool EnumOption(string label, int value, optional out int output, optional string helpText)
 {
-    local int i;
+    local int i, j;
     local string s;
     local EnumBtn e;
 
@@ -245,8 +245,8 @@ function bool EnumOption(string label, int value, optional out int output, optio
             wnds[id] = enums[id].btn;
         }
         log(self$"    EnumOption: "$label$" == "$value$" compared to default of "$output);
-        i = ArrayCount(enums[id].values)-1;
-        if(enums[id].values[i] != "" && enums[id].values[i] != label) {
+        j = ArrayCount(enums[id].values)-1;
+        if(enums[id].values[j] != "" && enums[id].values[j] != label) {
             label = "ERROR: FULL";
             enums[id].btn.SetButtonText(label);
         }


### PR DESCRIPTION
Repurposing the `i` variable this way destroys its value that later code below relies on.

Fixes a bug with having click on the Splits Overlay button twice to get it to change.