### PR TITLE
Don't mark ChangeClothes as failed when Clothes Looting is enabled

### DIFF
--- a/src/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -1949,7 +1949,10 @@ function MarkBingoFailedSpecial()
         if (! HasItem(player(), class'VialAmbrosia')) {
             MarkBingoAsFailed("GaveDowdAmbrosia");
         }
-        MarkBingoAsFailed("ChangeClothes");
+        // with clothes looting, the last clothes rack is in 15_AREA51_ENTRANCE
+        if (dxr.flags.clothes_looting == 0 || class'DXRMapVariants'.static.IsVanillaMaps(dxr.player) == false) {
+            MarkBingoAsFailed("ChangeClothes");
+        }
         break;
     case "11_PARIS_EVERETT":
         if(dxr.flags.IsReducedRando()) {


### PR DESCRIPTION
This is always still possible if clothes looting is enabled.