### PR TITLE
v3.6.1.2 Alpha

### DIFF
--- a/src/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -1034,13 +1034,21 @@ function DeusExGoal GiveGoalFromCon(#var(PlayerPawn) player, name goaltag, name 
 
 function bool RemoveGoalFromCon(name goalName, name convname, optional int which)
 {
+    local Conversation con;
+    local ConEventAddGoal ceag;
     local ConEvent prevCe;
 
-    GetGoalConEvent(goalName, convname, which, prevCe);
-    if (prevCe != None && prevCe.nextEvent != None) {
+    con = GetConversation(convname);
+    ceag = GetGoalConEvent(goalName, convname, which, prevCe);
+
+    if (con.eventList == ceag) {
+        con.eventList = ceag.nextEvent;
+        return true;
+    } else if (prevCe != None && prevCe.nextEvent != None) {
         prevCe.nextEvent = prevCe.nextEvent.nextEvent;
         return true;
     }
+    
     return false;
 }
 

--- a/src/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -6,7 +6,7 @@ simulated static function CurrentVersion(optional out int major, optional out in
     major=3;
     minor=6;
     patch=1;
-    build=1;//build can't be higher than 99
+    build=2;//build can't be higher than 99
 }
 
 simulated static function bool VersionIsStable()

--- a/src/DXRFixes/DeusEx/Classes/MenuScreenLoadGame.uc
+++ b/src/DXRFixes/DeusEx/Classes/MenuScreenLoadGame.uc
@@ -14,11 +14,16 @@ function CreateGamesList()
 
 function AddSaveRow(DeusExSaveInfo saveInfo, int saveIndex)
 {
+    local string desc;
     if (saveInfo != None)
     {
         //if(Right(saveInfo.Description, 15) == " CRASH AUTOSAVE") return; // hiding them freaks me out
 
-        lstGames.AddRow( saveInfo.Description              $ ";" $
+        //Strip semicolons out of the description, in case someone made a bad save (semicolons are now blocked though)
+        //Upgrade them from semi to full colons!
+        desc = class'DXRInfo'.static.ReplaceText(saveInfo.Description,";",":");
+
+        lstGames.AddRow( desc                              $ ";" $
                          BuildTimeStringFromInfo(saveInfo) $ ";" $
                          BuildTimeStringSeconds(saveInfo)  $ ";" $
                          BuildTimeStringFromInfo(saveInfo) $ ";" $

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
@@ -1042,6 +1042,7 @@ function AnyEntryMapFixes()
     local Conversation con;
     local ConEvent ce;
     local ConEventTrigger cet;
+    local ConEventSpeech ces, ces2;
     local #var(DeusExPrefix)Mover dxm;
 
     if(dxr.flagbase.GetBool('schematic_downloaded') && !dxr.flagbase.GetBool('DL_downloaded_Played')) {
@@ -1107,8 +1108,28 @@ function AnyEntryMapFixes()
         SetTimer(1, true);
         break;
     case "12_VANDENBERG_CMD":
+        if (dxr.flags.GetStartingMap() > 120) {
+            // a lot of this conversation doesn't make sense on later starts. but you can't get a map for the bingo goal without it
+            con = GetConversation('MeetCarlaBrown');
+            
+            ces = GetSpeechEvent(con.eventList, "Easier than a straight fight with military bots");
+            ces2 = GetSpeechEvent(con.eventList, "I suppose you're right");
+            ces.nextEvent = ces2.nextEvent;
+            ces2.nextEvent = ces;
+
+            ces = GetSpeechEvent(con.eventList, "We have a common enemy");
+            ces.nextEvent = ces2;
+
+            ces = GetSpeechEvent(con.eventList, "You with the NSF?");
+            con.eventList = ces;
+            
+            RemoveGoalFromCon('DestroyBots', 'MeetCarlaBrown');
+            RemoveGoalFromCon('ActivatePower', 'MeetCarlaBrown');
+        }
+
         // timer to count the MJ12 Bots
         SetTimer(1, True);
+    
         break;
 
     case "14_OCEANLAB_LAB":

--- a/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -922,12 +922,12 @@ function PreFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, 
         case 125: // fallthrough
             GiveKey(player, 'control_room', "Control Room Key");
         case 122: // fallthrough
-            AddNoteFromConv(player, bEmptyNotes, 'MeetTonyMares', 0); // Gary savage is thought to be in the control room
+            if (start_flag <= 125) {
+                AddNoteFromConv(player, bEmptyNotes, 'MeetTonyMares', 0); // Gary savage is thought to be in the control room
+            }
         case 121: // fallthrough
-            AddNoteFromConv(player, bEmptyNotes, 'MeetCarlaBrown', 0); // Backup power for the bot security system
             MarkConvPlayed("DL_no_carla", bFemale);
             break;
-
         case 153:
             MarkConvPlayed("DL_Helios_Door1", bFemale);         // Not yet.  No... I will not allow you to enter Sector 4 until you have received my instructions.
             MarkConvPlayed("DL_Helios_Intro", bFemale);         // I will now explain why you have been allowed to reach Sector 3.

--- a/src/DXRVanilla/DeusEx/Classes/MenuUILoadSaveEditWindow.uc
+++ b/src/DXRVanilla/DeusEx/Classes/MenuUILoadSaveEditWindow.uc
@@ -1,0 +1,10 @@
+class DXRMenuUILoadSaveEditWindow injects MenuUILoadSaveEditWindow;
+
+//*ACTUALLY* prevent semicolons
+function bool FilterChar(out string chStr)
+{
+    return ((chStr != ";") && (!bReadOnly));
+
+    //Original logic was just wrong
+    //return ((chStr != ";") || (!bReadOnly));
+}

--- a/src/notes/patchV3.6.1.md
+++ b/src/notes/patchV3.6.1.md
@@ -3,6 +3,7 @@
 
 - Fixed Area 51 Sectors 2 and 3 goals rando locations not working.
 - Ballistic Protection aug now uses slightly less energy (when Augs Balance Changes are enabled), and has a shorter auto linger time (when Semi-Automatic Augs are enabled).
+- On WaltonWare M12/M14 starts past Vandenberg Command, you can backtrack to Carla to get the map.
 
 ## Revision
 

--- a/src/notes/patchV3.6.1.md
+++ b/src/notes/patchV3.6.1.md
@@ -27,5 +27,6 @@
 - Added book colours and open/closed information to bingo goals help texts.
 - Fixed quick aug menu exploit with infinite upgrades while paused.
 - Swapped NPCs get their DesiredRotation set when swapped, along with their regular Rotation.  This fixes some enemies who would sometimes be facing the wrong direction, like the terrorists in the M02 Hotel, or the guards near the elevator in the M03 Airfield Helibase.
+- Semicolons are no longer allowed in save names in vanilla (The original logic to do this was incorrect)
 
 </details>

--- a/src/notes/patchV3.6.1.md
+++ b/src/notes/patchV3.6.1.md
@@ -28,5 +28,6 @@
 - Fixed quick aug menu exploit with infinite upgrades while paused.
 - Swapped NPCs get their DesiredRotation set when swapped, along with their regular Rotation.  This fixes some enemies who would sometimes be facing the wrong direction, like the terrorists in the M02 Hotel, or the guards near the elevator in the M03 Airfield Helibase.
 - Semicolons are no longer allowed in save names in vanilla (The original logic to do this was incorrect)
+  - If you had a save file with a semicolon in the name, it should now be possible to load the save properly.
 
 </details>


### PR DESCRIPTION
# Changes Since v3.6.1.1 Alpha:

- On WaltonWare M12/M14 starts past Vandenberg Command, you can backtrack to Carla to get the map.
- Semicolons are no longer allowed in save names in vanilla (The original logic to do this was incorrect)
  - If you had a save file with a semicolon in the name, it should now be possible to load the save properly.

# All Changes Since v3.6:

## Major Changes

- Fixed Area 51 Sectors 2 and 3 goals rando locations not working.
- Ballistic Protection aug now uses slightly less energy (when Augs Balance Changes are enabled), and has a shorter auto linger time (when Semi-Automatic Augs are enabled).
- On WaltonWare M12/M14 starts past Vandenberg Command, you can backtrack to Carla to get the map.

## Revision

- Added support for autorun in Revision.  At the moment, it is not configurable through the in-game keybinds and must be manually configured.
  - In the RevisionUser.ini file, go to the \[Extension.InputExt\] section and find the key you want to bind to enable autorun.  Change it so that it maps to ToggleAutorun, eg. to make C enable autorun: `C=ToggleAutorun`
- Doors into the M03 hangar (on both sides) are no longer potentially destroyable
- Keypad on the helipad-side door to the M03 hangar can no longer be hacked

## Minor Changes

- Zombie merchants are no longer ignored by the AI
- Hazmat suits can no longer be marked as Trash while being used in Zero Rando (or when balance changes are disabled)
- Added book colours and open/closed information to bingo goals help texts.
- Fixed quick aug menu exploit with infinite upgrades while paused.
- Swapped NPCs get their DesiredRotation set when swapped, along with their regular Rotation.  This fixes some enemies who would sometimes be facing the wrong direction, like the terrorists in the M02 Hotel, or the guards near the elevator in the M03 Airfield Helibase.
- Semicolons are no longer allowed in save names in vanilla (The original logic to do this was incorrect)
  - If you had a save file with a semicolon in the name, it should now be possible to load the save properly.
