### PR TITLE
v3.6.2.6 Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We also offer **Vanilla Fixer**: This one is for the purists. Use our installer 
     - **Zero Rando Plus**: Same as Zero Rando, but also enables our balance changes.
     - See the Rando ➜ Gameplay menu for more customization of balance changes and QoL features.
   - **WaltonWare**: A quick option to get into the game without the time commitment of the full game. You start in a random mission and **win by completing one bingo line**. All bingo goals will be completable within just a few maps. As New Game+ keeps making it harder, see how fast you can complete them or how many you can complete! Also check out the full game variant of this: Mr. Page's Mean Bingo Machine.
-  - Various [**Halloween modes**](https://www.youtube.com/watch?v=FbzNkWJXZ1o) that add survival horror mechanics, such as zombies, limited saves, and an invincible stalker!
+  - Various [**Halloween modes**](https://www.youtube.com/watch?v=FbzNkWJXZ1o) that add survival horror mechanics, such as zombies, limited saves, and invincible stalkers!
   - See the [(Wiki page)](https://github.com/Die4Ever/deus-ex-randomizer/wiki/Game-Modes) for a full list of our game modes.
 
 ## Trailers

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
@@ -25,7 +25,7 @@ function int InitGoals(int mission, string map)
         pauldock = AddGoalLocation("01_NYC_UNATCOISLAND", "South Dock", VANILLA_START, vect(-4760.569824, 10430.811523, -280.674988), rot(0, -7040, 0));
         jail = AddGoalLocation("01_NYC_UNATCOISLAND", "Jail", START_LOCATION, vect(2127.692139, -1774.869141, -149.140366), rot(0, -16159, 0));
     }
-    topofbase = AddGoalLocation("01_NYC_UNATCOISLAND", "Top of the Base", NORMAL_GOAL, vect(2980.058105, -840, 1090), rot(0, -16384, 0));  //Overlooking the North Dock
+    topofbase = AddGoalLocation("01_NYC_UNATCOISLAND", "Top of the Base", NORMAL_GOAL, vect(2980.058105, -670, 1090), rot(0, -16384, 0));  //Overlooking the North Dock
     top = AddGoalLocation("01_nyc_unatcoisland", "Top of the Statue", NORMAL_GOAL | VANILLA_GOAL | START_LOCATION, vect(2931.230957, 27.495235, 2527.800049), rot(0, 14832, 0));
     harleydock = AddGoalLocation("01_NYC_UNATCOISLAND", "North Dock", NORMAL_GOAL | START_LOCATION, vect(4018,-10308,-256), rot(0, 22520, 0));
         AddActorLocation(harleydock, PLAYER_LOCATION, vect(1297.173096, -10257.972656, -287.428131), rot(0, 0, 0));
@@ -103,7 +103,7 @@ function int InitGoalsRev(int mission, string map)
     }
     hut = AddGoalLocation("01_NYC_UNATCOISLAND", "Hut", NORMAL_GOAL, vect(-2404,177,-83), rot(0, 30472, 0));
     electric = AddGoalLocation("01_NYC_UNATCOISLAND", "Electric Bunker", NORMAL_GOAL | START_LOCATION, vect(6552.227539, -3246.095703, -447.438049), rot(0, 0, 0));
-    topofbase = AddGoalLocation("01_NYC_UNATCOISLAND", "Top of the Base", NORMAL_GOAL, vect(2980.058105, -840, 1090), rot(0, -16384, 0));  //Overlooking the North Dock
+    topofbase = AddGoalLocation("01_NYC_UNATCOISLAND", "Top of the Base", NORMAL_GOAL, vect(2980.058105, -670, 1090), rot(0, -16384, 0));  //Overlooking the North Dock
     top = AddGoalLocation("01_NYC_UNATCOISLAND", "Top of the Statue", NORMAL_GOAL | VANILLA_GOAL | START_LOCATION, vect(2931.230957, 27.495235, 2527.800049), rot(0, 14832, 0));
     harleydock = AddGoalLocation("01_NYC_UNATCOISLAND", "North Dock", NORMAL_GOAL | START_LOCATION, vect(4205,-9811,-279), rot(0, 0, 0));
         AddActorLocation(harleydock, PLAYER_LOCATION, vect(1297.173096, -10257.972656, -287.428131), rot(0, 0, 0));

--- a/src/DXRModules/DeusEx/Classes/DXRAutosave.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRAutosave.uc
@@ -480,7 +480,8 @@ function bool IsLimitedSaves()
 
 function MapAdjustments()
 {
-    local Actor a;
+    local ATM a;
+    local MemConUnit mcu;
     local vector loc;
     local int i;
 
@@ -488,12 +489,23 @@ function MapAdjustments()
         SetSeed("spawn MCU");
         for(i=0; i<20; i++) {
             loc = GetRandomPositionFine();
-            a = Spawn(class'MemConUnit',,, loc);
-            if(a != None) {
-                l("MapAdjustments() spawned MCU " $ a $ " at " $ loc);
+            mcu = Spawn(class'MemConUnit',,, loc);
+            if(mcu != None) {
+                l("MapAdjustments() spawned MCU " $ mcu $ " at " $ loc);
                 break;
             }
         }
+    }
+
+    switch(dxr.localURL) {
+    case "12_VANDENBERG_GAS":
+        if(IsFixedSaves()) {
+            a = ATM(AddActor(class'#var(prefix)ATM', vect(1231.338379, 554.900024, -903.686279), rot(0,-16384,0)));
+            a.UserList[0].accountNumber = "20000622";
+            a.UserList[0].PIN = "1031";
+            a.UserList[0].balance = 100;
+        }
+        break;
     }
 }
 

--- a/src/DXRModules/DeusEx/Classes/DXRMemes.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRMemes.uc
@@ -37,7 +37,7 @@ function PlayDressUp(Actor a,class<Actor> influencer, float rotYaw)
         a.bFixedRotationDir = influencer.default.bFixedRotationDir;
     }
 
-    a.DrawScale = a.CollisionHeight / influencer.default.CollisionHeight;
+    a.DrawScale = a.CollisionHeight / (influencer.default.CollisionHeight / influencer.default.DrawScale);
     r.Yaw = rotYaw;
     a.SetRotation(r);
 }
@@ -104,7 +104,7 @@ function RandomBobPage()
 
         if ( rng(3)!=0 && !IsAprilFools() ) return; //33% chance of getting a random bob
 
-        switch(rng(28)){
+        switch(rng(29)){
         case 0: PlayDressUp(bob,class'Cactus1',8000); return;
         case 1: PlayDressUp(bob,class'Mailbox',8000); return;
         case 2: PlayDressUp(bob,class'CarWrecked',8000); return;
@@ -133,6 +133,7 @@ function RandomBobPage()
         case 25: PlayDressUp(bob,class'VendingMachine',-8000); return;
         case 26: PlayDressUp(bob,class'Hooker1',-8000); return;
         case 27: PlayDressUp(bob,class'ChildMale2',-8000); return;
+        case 28: PlayDressUp(bob,class'Bobby',-8000); return;
         }
 
     }

--- a/src/DXRando/DeusEx/Classes/BobbyPossessionEffect.uc
+++ b/src/DXRando/DeusEx/Classes/BobbyPossessionEffect.uc
@@ -48,6 +48,8 @@ static function Create(Bobby bob, BobbyFake faker, DXRHalloween halloween)
     bob.bTransient = false;
     effect.faker = faker;
     effect.halloween = halloween;
+
+    faker.PlayPossessionAnim();
 }
 
 static function PossessFake(BobbyFake faker, DXRHalloween h)

--- a/src/DXRando/DeusEx/Classes/WeaponWeepingAnnaPunch.uc
+++ b/src/DXRando/DeusEx/Classes/WeaponWeepingAnnaPunch.uc
@@ -49,5 +49,5 @@ defaultproperties
     maxRange=80
     AccurateRange=80
     ShotTime=0.3
-    HitDamage=12
+    HitDamage=10
 }

--- a/src/Pawns/DeusEx/Classes/Bobby.uc
+++ b/src/Pawns/DeusEx/Classes/Bobby.uc
@@ -270,7 +270,7 @@ Begin:
     bDisappear = false;
     Acceleration=vect(0,0,0);
     Velocity=vect(0,0,0);
-    PlayWaiting();
+    LoopAnim('Shocked',2.5); //He's BUZZING with excitement!
     if(orderActor!=None) LookAtActor(orderActor,true,true,true);
 }
 //#endregion

--- a/src/Pawns/DeusEx/Classes/Bobby.uc
+++ b/src/Pawns/DeusEx/Classes/Bobby.uc
@@ -270,7 +270,7 @@ Begin:
     bDisappear = false;
     Acceleration=vect(0,0,0);
     Velocity=vect(0,0,0);
-    LoopAnim('Shocked',2.5); //He's BUZZING with excitement!
+    PlayPossessionAnim();
     if(orderActor!=None) LookAtActor(orderActor,true,true,true);
 }
 //#endregion
@@ -381,6 +381,12 @@ function MakePawnIgnored(bool bNewIgnore)
 ////////////////////////////////
 // #region Animation Hacks
 ////////////////////////////////
+function PlayPossessionAnim()
+{
+    if (!Region.Zone.bWaterZone){
+        LoopAnim('Shocked',2.5); //He's BUZZING with excitement!
+    }
+}
 
 //Don't play breathing animations
 function TweenToWaiting(float tweentime)

--- a/src/Pawns/DeusEx/Classes/BobbyFake.uc
+++ b/src/Pawns/DeusEx/Classes/BobbyFake.uc
@@ -58,6 +58,13 @@ function PlayTakeHitSound(int Damage, name damageType, int Mult)
     return;
 }
 
+function PlayPossessionAnim()
+{
+    if (!Region.Zone.bWaterZone){
+        LoopAnim('Shocked',2.5); //He's BUZZING with excitement!
+    }
+}
+
 //GMK_DressShirt doesn't actually have a sitting animation ¯\_(ツ)_/¯
 function PlaySitting()
 {

--- a/src/notes/patchV3.6.2.md
+++ b/src/notes/patchV3.6.2.md
@@ -22,6 +22,7 @@
 - Slightly reduced the number of Jack-o-Lanterns when they are enabled
 - Crash saves are now hidden from the load game menu, because they were confusing to see
 - Crash saves and autosaves no longer overwrite each other
+- In Fixed Save modes, the Vandenberg gas station now gets an ATM
 - The WaltonWare countdown at the end of a loop now makes a crash save
 - Removed config options from password detection and prevention logic
 - Blocked password from being detected in Jacob's Shadow: Chapter 20, as well as the MJ12 Compromised Individuals list

--- a/src/notes/patchV3.6.2.md
+++ b/src/notes/patchV3.6.2.md
@@ -10,7 +10,7 @@
 <summary>Click to expand Minor Changes</summary>
 
 - Adjusted the rotation of several goal randomization locations
-  - The Terrorist Commander on Liberty Island now looks out over the North Dock when he's on the base of the statue, making him visible from afar
+  - The Terrorist Commander on Liberty Island now looks out over the North Dock when he's on the base of the statue
   - The location near the water valves in Brooklyn Bridge Station now looks towards the steam vents instead of looking at the wall
   - The location on the East side of the Rooks' territory in Brooklyn Bridge Station now looks into the hall area, instead of towards the fence
   - The location in Manderley's bathroom in mission 5 now looks towards the door instead of the wall

--- a/src/notes/patchV3.6.2.md
+++ b/src/notes/patchV3.6.2.md
@@ -34,5 +34,6 @@
 - Lenny, the junkie with a LAM in Brooklyn Bridge Station, will now talk to you again if you didn't have room the first time you tried to trade with him
 - Slightly reduced spawn rate of rubber batons in limited loadouts
 - Paul has slightly more health and better accuracy in M04
+- Dr. Mehdi Kit (the bum in the abandoned bunker in the Paris Catacombs who sells medkits and darts) will no longer sell you infinite darts
 
 </details>


### PR DESCRIPTION
# Changes Since v3.6.2.5 Beta:

- Dr Mehdi Kit will no longer sell infinite darts
- Slightly nerfed Weeping Anna punch damage
- Improved stalker line of sight checks
- Tweaked Leo top of base location, closer to old spot
- Gas station ATM for Fixed Saves modes

# All Changes Since v3.6.1:

## Major Changes

- New Halloween stalker types: Bobby and Weeping Anna. There is now an advanced setting to choose which stalker types to enable, or how many stalkers.
- Added new game mode: Mr. Page's Horrifying Bingo Machine.
- Fixed and/or Limited Save modes now get emergency autosaves for crashes and when exiting the game, same as WaltonWare Hardcore.

## Minor Changes

<details>
<summary>Click to expand Minor Changes</summary>

- Adjusted the rotation of several goal randomization locations
  - The Terrorist Commander on Liberty Island now looks out over the North Dock when he's on the base of the statue
  - The location near the water valves in Brooklyn Bridge Station now looks towards the steam vents instead of looking at the wall
  - The location on the East side of the Rooks' territory in Brooklyn Bridge Station now looks into the hall area, instead of towards the fence
  - The location in Manderley's bathroom in mission 5 now looks towards the door instead of the wall
  - The location in the UNATCO HQ West office in mission 5 now looks vaguely towards the center of the room, instead of being perfectly parallel with the wall
- Adjusted the location of the character in the North-West corner of Brooklyn Bridge station slightly so that they won't end up inside a box when containers get shuffled sometimes
- Mr. H now causes less chaos in UNATCO, Tong's base, and the Vandenberg computer room (where you meet Gary)
- Tweaked seeding of Mr. H spawn locations
- Slightly reduced number of zombies in graveyard in Halloween modes
- Slightly reduced the number of Jack-o-Lanterns when they are enabled
- Crash saves are now hidden from the load game menu, because they were confusing to see
- Crash saves and autosaves no longer overwrite each other
- In Fixed Save modes, the Vandenberg gas station now gets an ATM
- The WaltonWare countdown at the end of a loop now makes a crash save
- Removed config options from password detection and prevention logic
- Blocked password from being detected in Jacob's Shadow: Chapter 20, as well as the MJ12 Compromised Individuals list
- Trashcans no longer drop contents when carrying across map transitions
- Some more mutual exclusions for bingo goals
- Fixed max health bug in Vanilla? Madder.
- Lyla (An LDDP character in the mission 4 bar) now uses the correct female damage and death sounds, instead of dying like a man
- Added a large crate to Oceanlab UC to buff the upper vents route
- Fixed quick aug upgrade menu when you have 10 augs that can be upgraded
- Lenny, the junkie with a LAM in Brooklyn Bridge Station, will now talk to you again if you didn't have room the first time you tried to trade with him
- Slightly reduced spawn rate of rubber batons in limited loadouts
- Paul has slightly more health and better accuracy in M04
- Dr. Mehdi Kit (the bum in the abandoned bunker in the Paris Catacombs who sells medkits and darts) will no longer sell you infinite darts

</details>
