### PR TITLE
Reset play time on new game again

### DIFF
--- a/src/DXRModules/DeusEx/Classes/DXRStats.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRStats.uc
@@ -83,6 +83,17 @@ simulated function PlayerAnyEntry(#var(PlayerPawn) p)
     }
 }
 
+simulated function ResetMissionTimes()
+{
+    local int mission;
+
+    for (mission = 1; mission <= 15; mission++) {
+        missions_times[mission] = 0;
+        missions_menu_times[mission] = 0;
+    }
+}
+
+
 function IncMissionTimer(int mission)
 {
     local string flagname, dataname;

--- a/src/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
+++ b/src/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
@@ -203,6 +203,10 @@ function InitStats(DXRStats newstats)
         }
     }
 
+    if (stats.dxr.flags.newgameplus_loops == 0 && class'DXRStartMap'.static._IsStartMap(stats.dxr)) {
+        stats.ResetMissionTimes();
+    }
+
     total = TotalTime();
 
     msg = "Total IGT: " $ stats.fmtTimeToString(total);


### PR DESCRIPTION
Currently, the time when starting a new game only starts at zero after restarting the game itself.