### PR TITLE
v3.7.1.8 Alpha

### DIFF
--- a/src/DXRBalance/DeusEx/Classes/BalancePlayer.uc
+++ b/src/DXRBalance/DeusEx/Classes/BalancePlayer.uc
@@ -76,10 +76,8 @@ function PlayTakeHitSound(int Damage, name damageType, int Mult)
 function RandomizeAugStates()
 {
     local Augmentation aug;
-    local DXRBase dxrb;
 
     for(aug = AugmentationSystem.FirstAug; aug!=None; aug = aug.next){
-
         //Skip synthetic heart since deactivating it turns off all your augs
         //(Maybe this could only skip it for deactivation?)
         if (aug.bHasIt && !aug.bAlwaysActive && (AugHeartLung(aug)==None)) {
@@ -232,7 +230,7 @@ function float ArmorReduceDamage(float damage)
 function bool DXReduceDamage(int Damage, name damageType, vector hitLocation, out int adjustedDamage, bool bCheckOnly)
 {
     local float newDamage, oldDamage;
-    local float augLevel, skillLevel;
+    local float augLevel;
     local float pct;
     local bool bReduced;
     local float damageMult;
@@ -431,10 +429,8 @@ function int HealPlayer(int baseHealPoints, optional Bool bUseMedicineSkill)
 
 function int _HealPlayer(int baseHealPoints, optional Bool bUseMedicineSkill, optional bool bFixLegs)
 {
-    local float mult;
     local int adjustedHealAmount, aha2, tempaha;
     local int origHealAmount;
-    local float dividedHealAmount;
 
     if (bUseMedicineSkill)
         adjustedHealAmount = CalculateSkillHealAmount(baseHealPoints);
@@ -549,8 +545,6 @@ function HealPart(out int points, out int amt)
 exec function ActivateAugmentation(int num)
 {
     local Augmentation anAug;
-    local int count, wantedSlot, slotIndex;
-    local bool bFound;
 
     if (RestrictInput())
         return;
@@ -586,7 +580,6 @@ function Augmentation FindAugByName(string augName)
 function ActivateAugByName(string augName)
 {
     local Augmentation anAug;
-    local bool bFound;
 
     if (RestrictInput())
         return;
@@ -752,13 +745,13 @@ state PlayerWalking
     function ProcessMove(float DeltaTime, vector newAccel, eDodgeDir DodgeMove, rotator DeltaRot)
     {
         local int newSpeed, defSpeed;
-        local name mat;
         local vector HitLocation, HitNormal, checkpoint, downcheck;
         local Actor HitActor, HitActorDown;
         local bool bCantStandUp;
         local Vector loc, traceSize;
         local float alpha, maxLeanDist;
-        local float legTotal, weapSkill, augValue, carriedMass;
+        local float weapSkill, augValue, carriedMass;
+        // local float legTotal;
 
         //Allow mid-air crouching without toggle crouch (Toggle crouch will handle this itself)
         //Toggle crouch only allows *crouching* in mid-air, not *uncrouching*, do the same here

--- a/src/DXRBalance/DeusEx/Classes/BalanceWeaponShuriken.uc
+++ b/src/DXRBalance/DeusEx/Classes/BalanceWeaponShuriken.uc
@@ -6,7 +6,6 @@ simulated function Projectile ProjectileFire(class<projectile> ProjClass, float 
 {
     local DeusExProjectile p;
     local float skill, mult;
-    local int i;
 
     skill = GetWeaponSkill();
     mult = (-2.0 * skill) + 1.0;

--- a/src/DXRBalance/DeusEx/Classes/ChargedPickup.uc
+++ b/src/DXRBalance/DeusEx/Classes/ChargedPickup.uc
@@ -99,7 +99,6 @@ function HandleTickSound(DeusExPlayer Player)
     if (endDrain==0) return; //Don't tick if we aren't draining
 
     if(ticksRemaining-- <= 0){
-
         PlayTickSound(Player);
 
         if (Charge > (defaultCharge/2)){

--- a/src/DXRBalance/DeusEx/Classes/RobotBalance.uc
+++ b/src/DXRBalance/DeusEx/Classes/RobotBalance.uc
@@ -82,7 +82,7 @@ function Destroyed()
 function PetRobot(#var(PlayerPawn) petter)
 {
     local DXRCameraModes camera;
-    local float animTime,tweenTime;
+    local float animTime;
     local bool highPet;
 
     if (petter==None) return;
@@ -126,7 +126,6 @@ function Frob(Actor Frobber, Inventory frobWith)
 {
     local #var(PlayerPawn) p;
     local bool canPet;
-    local DXRando dxr;
 
     Super.Frob(Frobber,frobWith);
 

--- a/src/DXRCore/DeusEx/Classes/DXRActorsBase.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRActorsBase.uc
@@ -41,7 +41,7 @@ function CheckConfig()
 function SwapAll(string classname, float percent_chance)
 {
     local Actor temp[4096];
-    local Actor a, b;
+    local Actor a;
     local int num, i, slot;
     local class<Actor> c;
 
@@ -143,8 +143,6 @@ static function bool IsRelevantPawn(class<Actor> a)
 
 static function bool IsInitialEnemy(ScriptedPawn p)
 {
-    local int i;
-
     return p.GetAllianceType( class'#var(PlayerPawn)'.default.Alliance ) == ALLIANCE_Hostile;
 }
 
@@ -1517,7 +1515,7 @@ function vector GetRandomPosition(optional vector target, optional float mindist
 {
     local NavigationPoint temp[4096];
     local NavigationPoint p;
-    local int i, num, slot;
+    local int num, slot;
     local float dist;
 
     if( maxdist <= mindist )
@@ -1894,7 +1892,6 @@ function bool _NearestWall(out LocationNormal out, FMinMax distrange)
 
 function bool NearestWall(out LocationNormal out, FMinMax distrange, optional float away_from_wall)
 {
-
     if( _NearestWall(out, distrange) == false ) {
         return false;
     }
@@ -2038,7 +2035,6 @@ function bool PositionIsSafeLenient(Vector oldloc, Actor test, Vector newloc)
 function RemoveMoverPrePivot(Mover m)
 {
     local vector pivot;
-    local rotator r;
     local bool AbCollideActors, AbBlockActors, AbBlockPlayers;
 
     AbCollideActors = m.bCollideActors;
@@ -2113,7 +2109,6 @@ function DebugMarkKeyActor(Actor a, coerce string id)
 
 function DebugMarkKeyPosition(vector pos, coerce string id)
 {
-    local ActorDisplayWindow actorDisplay;
     local Actor a;
     if( ! #bool(locdebug)) {
         err("Don't call DebugMarkKeyPosition without locdebug mode! Add locdebug to the compiler_settings.default.json file");

--- a/src/DXRCore/DeusEx/Classes/DXRBase.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRBase.uc
@@ -245,7 +245,7 @@ simulated function bool RandoLevelValues(Actor a, float min, float max, float we
     local #var(prefix)Augmentation aug;
     local #var(prefix)Skill sk;
     local string s, word, s_defaults, t;
-    local int i, len, mid, oldseed, removals;
+    local int i, len, oldseed, removals;
     local float val, defaultval;
     local float d_min, d_max, avg_diff;
     local float points[16];
@@ -426,8 +426,6 @@ static simulated function string DescriptionLevelShort(Actor act, int i, out flo
 
 static simulated function string DescriptionLevelExtended(Actor act, int i, out string word, out float val, float defaultval, out string shortDisplay)
 {
-    local float f;
-
     log("WARNING: DXRBase DescriptionLevel failed for " $ act);
     word = "Values";
     shortDisplay=string(val);
@@ -561,7 +559,6 @@ final function Class<Actor> ModifyActorClass( out Class<Actor> ActorClass )
 //id lets you provide an ID so you can identify where the response should go
 simulated function CreateMessageBox( String msgTitle, String msgText, int msgBoxMode,
                            DXRBase module, int id, optional bool noPause) {
-
     local DXRMessageBoxWindow msgBox;
 
     l(module$" CreateMessageBox "$msgTitle$" - "$msgText);

--- a/src/DXRCore/DeusEx/Classes/DXRInfo.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRInfo.uc
@@ -629,6 +629,28 @@ simulated static function int MurmurHash3(coerce string str, optional int seed)
     return h1;
 }
 
+static function Actor ActorLookedAt(Pawn looker, optional float maxRange)
+{
+    local Rotator viewRot;
+    local Vector eyeOrigin, traceEnd, pointlessVec;
+
+    if (looker == None)
+        return None;
+
+    if (maxRange <= 0.0)
+        maxRange = 8192.0;
+
+    if (#var(PlayerPawn)(looker) != None)
+        viewRot = #var(PlayerPawn)(looker).ViewRotation;
+    else
+        viewRot = looker.Rotation;
+
+    eyeOrigin = looker.Location + class'DXRBase'.static.MakeVector(0.0, 0.0, looker.BaseEyeHeight);
+    traceEnd = eyeOrigin + Vector(viewRot) * maxRange;
+
+    return looker.Trace(pointlessVec, pointlessVec, traceEnd, eyeOrigin, true);
+}
+
 /*
 ========= TEST FUNCTIONS
 */

--- a/src/DXRCore/DeusEx/Classes/DXRInfo.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRInfo.uc
@@ -176,7 +176,7 @@ static function string ConstructTimeStr(float timeSecs)
 
 static function int _SystemTime(LevelInfo Level)
 {
-    local int time, m;
+    local int time;
     time = Level.Second + (Level.Minute*60) + (Level.Hour*3600) + (Level.Day*86400);
 
     switch(Level.Month) {

--- a/src/DXRCore/DeusEx/Classes/DXRMenuBase.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuBase.uc
@@ -898,6 +898,36 @@ function string SetEnumValue(int e, string text)
     return s;
 }
 
+function string GetTextWindowText(int twId)
+{
+    local TextWindow tw;
+
+    tw = TextWindow(wnds[twId]);
+    if (tw == None) return "";
+    return tw.GetText();
+}
+
+function SetTextWindowText(int twId, string str)
+{
+    local TextWindow tw;
+
+    tw = TextWindow(wnds[twId]);
+    if (tw == None) return;
+    tw.SetText(str);
+}
+
+function int GetIdFromLabel(string label)
+{
+    local int i;
+
+    for (i = 0; i < ArrayCount(labels); i++) {
+        if (labels[i] == label) {
+            return i;
+        }
+    }
+    return -1;
+}
+
 event StyleChanged()
 {
     local ColorTheme theme;

--- a/src/DXRCore/DeusEx/Classes/DXRMenuBase.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuBase.uc
@@ -63,7 +63,6 @@ const HELP_BTN_PAD = 5;
 event Init(DXRando d)
 {
     local vector coords;
-    local int i;
     dxr = d;
     flags = dxr.flags;
     BR = Chr(10);
@@ -433,7 +432,6 @@ function BindControls(optional string action)
 
 function InitHelp()
 {
-    local MenuUILabelWindow winLabel;
     local vector coords;
 
     if(!bUsesHelpWindow) return;
@@ -721,7 +719,6 @@ function DXRMenuUIHelpButtonWindow CreateEnumHelpBtn(MenuUIActionButtonWindow ma
 
 function EnumBtn CreateEnum(int row, string label, string helptext, optional EnumBtn e)
 {
-    local int i;
     if(e.values[0] == "") {
         e.values[0] = "Off";
         e.values[1] = "On";
@@ -783,7 +780,6 @@ function bool CheckClickEnum( Window buttonPressed, optional bool rightClick )
 
 function bool CheckClickHelpBtn( Window buttonPressed )
 {
-    local int i;
     local DXRMenuUIHelpButtonWindow helpButton;
 
     helpButton = DXRMenuUIHelpButtonWindow(buttonPressed);

--- a/src/DXRCore/DeusEx/Classes/DXRMenuReSetupRando.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuReSetupRando.uc
@@ -37,13 +37,6 @@ function BindControls(optional string action)
 
     f = GetFlags();
     CreateLabelRow("You may need to save/load or reach a new map for changes to take effect."$BR$"Be careful when changing these settings in the middle of a mission.");
-    NewGroup("Basic");
-
-    class'DXRMenuSelectDifficulty'.static.CreateLoadoutEnum(self, f);
-    class'DXRMenuSelectDifficulty'.static.CreateAutosaveEnum(self, f);
-    class'DXRMenuSelectDifficulty'.static.CreateCrowdControlEnum(self, f);
-    class'DXRMenuSelectDifficulty'.static.CreateOnlineFeaturesEnum(self, f);
-    class'DXRMenuSelectDifficulty'.static.CreateMirroredMapsSlider(self, f);
 
     combatDifficulty = player.combatDifficulty;
     Super.BindControls(action);
@@ -59,7 +52,6 @@ function BindControls(optional string action)
     }
     if( action != "" ) CancelScreen();
 }
-
 
 function EnumListAddButton(DXREnumList list, string title, string val, string help, string prev)
 {
@@ -97,4 +89,5 @@ defaultproperties
     actionButtons(0)=(Align=HALIGN_Left,Action=AB_Cancel,Text="|&Back",Key="BACK")
     actionButtons(1)=(Align=HALIGN_Right,Action=AB_Other,Text="|&Done",Key="DONE")
     actionButtons(2)=(Align=HALIGN_Right,Action=AB_None,Text="",Key="")
+    showMode=False
 }

--- a/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -53,7 +53,7 @@ function BindControls(optional string action)
     local float difficulty;
     local DXRFlags f;
     local string name, help;
-    local int temp, i;
+    local int i;
 
     f = GetFlags();
     if(writing) {
@@ -67,16 +67,8 @@ function BindControls(optional string action)
 
     NewGroup("Customize");
 
-    gamemode_enum = NewMenuItem("Game Mode", "Choose a game mode!"$BR$BR$"For first time Randomizer players we recommend Randomizer Lite, Normal Randomizer, or Mr. Page's Nice Bingo Machine.");
-    for(i=0; i<50; i++) {
-        temp = f.GameModeIdForSlot(i);
-        if(temp==999999) continue;
-        name = f.GameModeName(temp);
-        if(name == "") continue;
-        help = f.GameModeHelpText(temp);
-        EnumOption(name, temp, f.gamemode, help);
-    }
 
+    gamemode_enum = CreateGameModeEnum(self, f);
     loadout_enum = CreateLoadoutEnum(self, f);
 
     if( #defined(vmd) )
@@ -302,6 +294,23 @@ function ResetToDefaults()
     Super.ResetToDefaults();
 }
 
+static function int CreateGameModeEnum(DXRMenuBase slf, DXRFlags f)
+{
+    local int i, e, temp;
+    local string name, help;
+
+    e = slf.NewMenuItem("Game Mode", "Choose a game mode!"$Chr(10)$Chr(10)$ "For first time Randomizer players we recommend Randomizer Lite, Normal Randomizer, or Mr. Page's Nice Bingo Machine.");
+    for(i=0; i<50; i++) {
+        temp = f.GameModeIdForSlot(i);
+        if(temp==999999) continue;
+        name = f.GameModeName(temp);
+        if(name == "") continue;
+        help = f.GameModeHelpText(temp);
+        slf.EnumOption(name, temp, f.gamemode, help);
+    }
+    return e;
+}
+
 static function int CreateLoadoutEnum(DXRMenuBase slf, DXRFlags f)
 {
     local DXRLoadouts loadout;
@@ -463,13 +472,7 @@ function string SetEnumValue(int e, string text)
     if(e == gamemode_enum) {
         f = GetFlags();
         oldZeroRando = f.IsZeroRando();
-        for(i=0; i<50; i++) {
-            temp = f.GameModeIdForSlot(i);
-            if(temp==999999) continue;
-            if(f.GameModeName(temp) == text) {
-                f.gamemode = temp;
-            }
-        }
+        f.SetGameMode(f.GameModeIdForName(text));
         if(f.IsZeroRando() != oldZeroRando) {
             i = 0;
             if( f.VersionIsStable() && !#bool(hx)) {

--- a/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -244,9 +244,7 @@ function bool BindPresets()
 function bool PresetButton(string label, optional string helpText)
 {
     local bool ret;
-    local int i;
     local DXRFlags f;
-    local string sseed, name, help;
     local bool mirrored_maps_files_found;
 
     ret = CollapsibleButtonOnClick(false, label, helpText);
@@ -440,7 +438,7 @@ function string GetHelpText(DXRMenuUIHelpButtonWindow helpButton)
 function string SetEnumValue(int e, string text)
 {
     local int i, temp;
-    local string old, s;
+    local string old;
     local DXRFlags f;
     local bool oldZeroRando;
 

--- a/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuSelectDifficulty.uc
@@ -222,13 +222,13 @@ function bool BindPresets()
     }
     if(dxr.rando_beaten >= 1 && dxr.rando_beaten < 5 && PresetButton("Speedrun Training Mode", f.GameModeHelpText(f.SpeedrunMode))) {
         f.gamemode = f.SpeedrunTraining;
-        f.loadout = 2; // speed enhancement
+        f.loadout = 16; // speed enhancement
         StartPreset();
         return true;
     }
     if(dxr.rando_beaten >= 3 && PresetButton("Speedrun Mode", f.GameModeHelpText(f.SpeedrunMode))) {
         f.gamemode = f.SpeedrunMode;
-        f.loadout = 2; // speed enhancement
+        f.loadout = 16; // speed enhancement
         StartPreset();
         return true;
     }

--- a/src/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
@@ -1,7 +1,8 @@
 class DXRMenuSetupRando extends DXRMenuBase;
 
 var float combatDifficulty;
-var int starting_locations, goals_rando;
+var int gamemode_enum, starting_locations, goals_rando;
+var bool showMode, showLoadout, showAutosave, showCrowdControl, showOnlineFeatures, showMirroredMaps;
 
 var string SplitsBtnTitle, SplitsBtnMessage;
 
@@ -26,6 +27,8 @@ function BindControls(optional string action)
     local bool bMatched;
     f = GetFlags();
 
+    CreateBasicOptions(f);
+
     NewGroup("General");
 
     if( ! #defined(vmd) ) {
@@ -47,15 +50,15 @@ function BindControls(optional string action)
         if(i == 10) continue;// Liberty Island dupe
         s = class'DXRStartMap'.static.GetStartingMapName(i);
         if(s != "") {
-            bMatched = EnumOption(s, i, f.settings.starting_map) || bMatched;
+            bMatched = EnumOption(s, i, f.moresettings.starting_map) || bMatched;
         }
     }
-    if(f.settings.starting_map != 0 && !bMatched) {
-        if(writing) f.settings.starting_map = class'DXRStartMap'.static.ChooseRandomStartMap(f, -1); // reroll to make sure we respect the current seed which could've been changed in the input box above
-        EnumOption("Random", f.settings.starting_map, f.settings.starting_map);
+    if(f.moresettings.starting_map != 0 && !bMatched) {
+        if(writing) f.moresettings.starting_map = class'DXRStartMap'.static.ChooseRandomStartMap(f, -1); // reroll to make sure we respect the current seed which could've been changed in the input box above
+        EnumOption("Random", f.moresettings.starting_map, f.moresettings.starting_map);
     }
     else if(EnumOption("Random", -1)) {
-        f.settings.starting_map = class'DXRStartMap'.static.ChooseRandomStartMap(f, 0);
+        f.moresettings.starting_map = class'DXRStartMap'.static.ChooseRandomStartMap(f, 0);
     }
 
     BreakLine();
@@ -91,12 +94,12 @@ function BindControls(optional string action)
     Slider(f.settings.dancingpercent, 0, 100);
 
     NewMenuItem("Spoiler Buttons", "Allow the use of spoiler buttons (Spoilers remain hidden until you choose to view them).");
-    EnumOption("Available", 1, f.settings.spoilers,GetSpoilerButtonHelpText(1));
-    EnumOption("Disallowed", 0, f.settings.spoilers,GetSpoilerButtonHelpText(0));
+    EnumOption("Available", 1, f.moresettings.spoilers,GetSpoilerButtonHelpText(1));
+    EnumOption("Disallowed", 0, f.moresettings.spoilers,GetSpoilerButtonHelpText(0));
 
     NewMenuItem("Menus Pause Game", "Should the game keep playing while a menu is open?");
-    EnumOption("Pause", 1, f.settings.menus_pause);
-    EnumOption("Don't Pause", 0, f.settings.menus_pause);
+    EnumOption("Pause", 1, f.moresettings.menus_pause);
+    EnumOption("Don't Pause", 0, f.moresettings.menus_pause);
 
     NewMenuItem("Camera Mode", "What camera mode should be used");
     EnumOption("First Person", 0, f.moresettings.camera_mode,GetCameraModeHelpText(0));
@@ -353,7 +356,7 @@ function BindControls(optional string action)
     Slider(f.settings.swapcontainers, 0, 100, GetGenericHelpText("swapcontainers"));
 
     NewMenuItem("Swap Grenades %", "The chance for grenades on walls to have their type randomized.");
-    Slider(f.settings.grenadeswap, 0, 100);
+    Slider(f.moresettings.grenadeswap, 0, 100);
 
     BreakLine();
     NewMenuItem("Min Weapon Damage %", "The minimum damage for weapons.");
@@ -403,8 +406,34 @@ function BindControls(optional string action)
     NewMenuItem("Weapons Removed", "Number of weapons removed per loop.");
     Slider(f.newgameplus_num_removed_weapons, 0, 18);
 
-    if( action == "NEXT" ) HandleNewGameButton();
-    if( action == "RANDOMIZE" ) RandomizeOptions();
+    switch(action) {
+        case "NEXT":
+            HandleNewGameButton();
+            break;
+        case "RANDOMIZE":
+            RandomizeOptions();
+            break;
+        case "RESTORE":
+            RestoreSetup();
+            break;
+        case "SAVE":
+            SaveSetup();
+            break;
+    }
+}
+
+function CreateBasicOptions(DXRFlags f)
+{
+    local int i, temp;
+
+    NewGroup("Basic");
+
+    if (showMode) gamemode_enum = class'DXRMenuSelectDifficulty'.static.CreateGameModeEnum(self, f);
+    if (showLoadout) class'DXRMenuSelectDifficulty'.static.CreateLoadoutEnum(self, f);
+    if (showAutosave) class'DXRMenuSelectDifficulty'.static.CreateAutosaveEnum(self, f);
+    if (showCrowdControl) class'DXRMenuSelectDifficulty'.static.CreateCrowdControlEnum(self, f);
+    if (showOnlineFeatures) class'DXRMenuSelectDifficulty'.static.CreateOnlineFeaturesEnum(self, f);
+    if (showMirroredMaps) class'DXRMenuSelectDifficulty'.static.CreateMirroredMapsSlider(self, f);
 }
 
 function CreateSeedInput(DXRFlags f)
@@ -444,6 +473,81 @@ function RandomizeOptions()
 
     //Scroll to same position again
     winScroll.vScale.SetTickPosition(scrollPos);
+}
+
+function SaveSetup()
+{
+    local DXRSavedSetup savedSetup;
+
+    GetDxr();
+    savedSetup = class'DXRSavedSetup'.static.GetObj(dxr);
+
+    savedSetup.seedStr = GetTextWindowText(GetIdFromLabel("Seed"));
+    savedSetup.startingMapStr = GetEnumValue(GetIdFromLabel("Starting Map"));
+
+    savedSetup.config_version = dxr.flags.config_version;
+    savedSetup.gamemode = dxr.flags.gamemode;
+    savedSetup.loadout = dxr.flags.loadout;
+    savedSetup.autosave = dxr.flags.autosave;
+    savedSetup.mirroredmaps = dxr.flags.mirroredmaps;
+    savedSetup.difficulty = dxr.flags.difficulty;
+
+    savedSetup.bingo_duration = dxr.flags.bingo_duration;
+    savedSetup.bingo_scale = dxr.flags.bingo_scale;
+    savedSetup.newgameplus_max_item_carryover = dxr.flags.newgameplus_max_item_carryover;
+    savedSetup.newgameplus_num_skill_downgrades = dxr.flags.newgameplus_num_skill_downgrades;
+    savedSetup.newgameplus_num_removed_augs = dxr.flags.newgameplus_num_removed_augs;
+    savedSetup.newgameplus_num_removed_weapons = dxr.flags.newgameplus_num_removed_weapons;
+    savedSetup.clothes_looting = dxr.flags.clothes_looting;
+    savedSetup.remove_paris_mj12 = dxr.flags.remove_paris_mj12;
+
+    savedSetup.settings = dxr.flags.settings;
+    savedSetup.moresettings = dxr.flags.moresettings;
+
+    savedSetup.bSaved = true;
+
+    savedSetup.SaveConfig();
+}
+
+function RestoreSetup()
+{
+    local DXRSavedSetup savedSetup;
+    local int scrollPos;
+
+    GetDxr();
+    savedSetup = class'DXRSavedSetup'.static.GetObj(dxr);
+    if (savedSetup.bSaved == false) return;
+
+    scrollPos = winScroll.vScale.GetTickPosition();
+    _BindControls(True);
+
+    dxr.flags.gamemode = savedSetup.gamemode;
+    dxr.flags.loadout = savedSetup.loadout;
+    dxr.flags.autosave = savedSetup.autosave;
+    dxr.flags.mirroredmaps = savedSetup.mirroredmaps;
+    dxr.flags.difficulty = savedSetup.difficulty;
+
+    dxr.flags.bingo_duration = savedSetup.bingo_duration;
+    dxr.flags.bingo_scale = savedSetup.bingo_scale;
+    dxr.flags.newgameplus_max_item_carryover = savedSetup.newgameplus_max_item_carryover;
+    dxr.flags.newgameplus_num_skill_downgrades = savedSetup.newgameplus_num_skill_downgrades;
+    dxr.flags.newgameplus_num_removed_augs = savedSetup.newgameplus_num_removed_augs;
+    dxr.flags.newgameplus_num_removed_weapons = savedSetup.newgameplus_num_removed_weapons;
+    dxr.flags.clothes_looting = savedSetup.clothes_looting;
+    dxr.flags.remove_paris_mj12 = savedSetup.remove_paris_mj12;
+
+    dxr.flags.settings = savedSetup.settings;
+    dxr.flags.moresettings = savedSetup.moresettings;
+
+    #ifndef hx
+        SetDifficulty(dxr.flags.settings.CombatDifficulty);
+    #endif
+
+    _BindControls(False);
+    winScroll.vScale.SetTickPosition(scrollPos); // Scroll to same position again
+
+    SetTextWindowText(GetIdFromLabel("Seed"), savedSetup.seedStr);
+    SetEnumValue(GetIdFromLabel("Starting Map"), savedSetup.startingMapStr);
 }
 
 function SetDifficulty(float newDifficulty)
@@ -496,6 +600,19 @@ event bool BoxOptionSelected(Window button, int buttonNumber)
     }
 
     return Super.BoxOptionSelected(button,buttonNumber);
+}
+
+function string SetEnumValue(int e, string text)
+{
+    local int modeId, i;
+    local DXRFlags f;
+
+    if (e == gamemode_enum) {
+        f = GetFlags();
+        f.SetGameMode(f.GameModeIdForName(text));
+    }
+
+    return Super.SetEnumValue(e, text);
 }
 
 //#region Help Text Fns
@@ -1071,6 +1188,14 @@ defaultproperties
     actionButtons(0)=(Align=HALIGN_Left,Action=AB_Cancel,Text="|&Back")
     actionButtons(1)=(Align=HALIGN_Right,Action=AB_Other,Text="|&Next",Key="NEXT")
     actionButtons(2)=(Align=HALIGN_Right,Action=AB_Other,Text="|&Randomize",Key="RANDOMIZE")
+    actionButtons(3)=(Align=HALIGN_Right,Action=AB_Other,Text="|&Restore Settings",Key="RESTORE")
+    actionButtons(4)=(Align=HALIGN_Right,Action=AB_Other,Text="|&Save Settings",Key="SAVE")
     SplitsBtnTitle="Mismatched Splits!"
     SplitsBtnMessage="It appears that your DXRSplits.ini file is for different settings than this.|n|nThe PB is %s.|n|nAre you sure you want to continue?"
+    showMode=True
+    showLoadout=True
+    showAutosave=True
+    showCrowdControl=True
+    showOnlineFeatures=True
+    showMirroredMaps=True
 }

--- a/src/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRMenuSetupRando.uc
@@ -21,7 +21,7 @@ event InitWindow()
 function BindControls(optional string action)
 {
     local DXRFlags f;
-    local string doors_option, s;
+    local string s;
     local int iDifficulty, i;
     local bool bMatched;
     f = GetFlags();

--- a/src/DXRCore/DeusEx/Classes/DXRVersion.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRVersion.uc
@@ -6,7 +6,7 @@ simulated static function CurrentVersion(optional out int major, optional out in
     major=3;
     minor=7;
     patch=1;
-    build=7;//build can't be higher than 99
+    build=8;//build can't be higher than 99
 }
 
 simulated static function bool VersionIsStable()

--- a/src/DXRCore/DeusEx/Classes/DXRando.uc
+++ b/src/DXRCore/DeusEx/Classes/DXRando.uc
@@ -46,7 +46,6 @@ simulated event PostNetBeginPlay()
 
 simulated event Timer()
 {
-    local int i;
     if( bTickEnabled == true ) return;
 
     if( bLoginReady ) {
@@ -692,7 +691,6 @@ simulated final function int rngraw()
 // ============================================================================
 
 simulated final function CrcInit() {
-
     const CrcPolynomial = 0xedb88320;
 
     local int CrcValue;
@@ -721,7 +719,6 @@ simulated final function CrcInit() {
 // ============================================================================
 // TODO: next compatibility break, delete Crc in favor of MurmurHash3
 simulated final function int Crc(coerce string Text) {
-
     local int CrcValue;
     local int IndexChar;
 

--- a/src/DXRCore/DeusEx/Classes/DataStorage.uc
+++ b/src/DXRCore/DeusEx/Classes/DataStorage.uc
@@ -153,7 +153,6 @@ function bool HasPlaythroughId(int tplaythrough_id)
 simulated function static DataStorage GetObj(DXRando dxr)
 {
     local DataStorage d;
-    local DXRFlags f;
 
     if( dxr == None ) return None;
 

--- a/src/DXRFixes/DeusEx/Classes/ActorDisplayWindow.uc
+++ b/src/DXRFixes/DeusEx/Classes/ActorDisplayWindow.uc
@@ -25,6 +25,7 @@ var bool         bShowWeaponScore;
 var bool         bShowReactions;
 var bool         bShowPatrolPaths;
 var bool         bShowTextures;
+var bool         bShowConvoInfo;
 
 var Color        patrolColours[14];
 
@@ -231,6 +232,16 @@ function bool AreTexturesVisible()
 function ShowTextures(bool bShow)
 {
     bShowTextures = bShow;
+}
+
+function bool IsConvoInfoVisible()
+{
+    return bShowConvoInfo;
+}
+
+function ShowConvoInfo(bool bShow)
+{
+    bShowConvoInfo = bShow;
 }
 
 
@@ -1085,7 +1096,16 @@ function DrawWindow(GC gc)
                 str = str $ "Texture="$ trackActor.Texture $CR();
                 str = str $ "Mesh="$ trackActor.Mesh $CR();
             }
+            //#endregion
 
+            //#region Show Convo Info
+            if (bShowConvoInfo){
+                str = str $ "|ce4a023"; // #e4a023
+                str = str $ "FamiliarName="$ trackActor.FamiliarName $CR();
+                str = str $ "UnfamiliarName="$ trackActor.UnfamiliarName $CR();
+                str = str $ "BindName="$ trackActor.BindName $CR();
+                str = str $ "BarkBindName="$ trackActor.BarkBindName $CR();
+            }
             //#endregion
 
             if (str != "")

--- a/src/DXRFixes/DeusEx/Classes/ActorDisplayWindow.uc
+++ b/src/DXRFixes/DeusEx/Classes/ActorDisplayWindow.uc
@@ -26,7 +26,7 @@ var bool         bShowReactions;
 var bool         bShowPatrolPaths;
 var bool         bShowTextures;
 
-var Color        patrolColours[10];
+var Color        patrolColours[14];
 
 function SetActorRadius(string newRadius)
 {
@@ -1550,14 +1550,18 @@ defaultproperties
     textfont=Font'DXRFontFixedWidthSmall'
     bShowHidden=true
     bShowLineOfSight=false
-    patrolColours(0)=(R=255,G=0,B=0,A=0)     //Red
-    patrolColours(1)=(R=156,G=39,B=176,A=0)  //Purple
-    patrolColours(2)=(R=0,G=0,B=255,A=0)     //Blue
-    patrolColours(3)=(R=255,G=111,B=0,A=0)   //Orange
-    patrolColours(4)=(R=239,G=154,B=154,A=0) //Pink
-    patrolColours(5)=(R=121,G=85,B=72,A=0)   //Brown
-    patrolColours(6)=(R=179,G=229,B=252,A=0) //Sky Blue
-    patrolColours(7)=(R=255,G=255,B=0,A=0)   //Yellow
-    patrolColours(8)=(R=158,G=157,B=36,A=0)  //Olive Green
-    patrolColours(9)=(R=97,G=97,B=97,A=0)    //Gray
+    patrolColours(0)=(R=255,G=0,B=0,A=0)     //Red rgb(255,0,0)
+    patrolColours(1)=(R=156,G=39,B=176,A=0)  //Purple rgb(156,39,176)
+    patrolColours(2)=(R=0,G=0,B=255,A=0)     //Blue rgb(0,0,255)
+    patrolColours(3)=(R=255,G=111,B=0,A=0)   //Orange rgb(255,111,0)
+    patrolColours(4)=(R=239,G=154,B=154,A=0) //Pink rgb(239,154,154)
+    patrolColours(5)=(R=121,G=85,B=72,A=0)   //Brown rgb(121,85,72)
+    patrolColours(6)=(R=179,G=229,B=252,A=0) //Sky Blue rgb(179,229,252)
+    patrolColours(7)=(R=255,G=255,B=0,A=0)   //Yellow rgb(255,255,0)
+    patrolColours(8)=(R=158,G=157,B=36,A=0)  //Olive Green rgb(158,157,36)
+    patrolColours(9)=(R=97,G=97,B=97,A=0)    //Gray rgb(97,97,97)
+    patrolColours(10)=(R=146,G=74,B=98,A=0)    //Grayish pink rgb(146, 74, 98)
+    patrolColours(11)=(R=72,G=230,B=156,A=0)    //Mint Green rgb(72, 230, 156)
+    patrolColours(12)=(R=45,G=95,B=4,A=0)    //Dark Green rgb(45, 95, 4)
+    patrolColours(13)=(R=206,G=60,B=219,A=0)    //Bright pink rgb(206, 60, 219)
 }

--- a/src/DXRFixes/DeusEx/Classes/Animal.uc
+++ b/src/DXRFixes/DeusEx/Classes/Animal.uc
@@ -56,7 +56,7 @@ function Destroyed()
 function PetAnimal(#var(PlayerPawn) petter)
 {
     local DXRCameraModes camera;
-    local float animTime,tweenTime;
+    local float animTime;
     local bool highPet;
 
     if (petter==None) return;

--- a/src/DXRFixes/DeusEx/Classes/AutoTurret.uc
+++ b/src/DXRFixes/DeusEx/Classes/AutoTurret.uc
@@ -786,7 +786,6 @@ auto state Active
     function TakeDamage(int Damage, Pawn EventInstigator, vector HitLocation, vector Momentum, name DamageType)
     {
         if (DamageType == 'NanoVirus') {
-
             HandleScrambler(EventInstigator,Damage);
         }
 

--- a/src/DXRFixes/DeusEx/Classes/Carcass.uc
+++ b/src/DXRFixes/DeusEx/Classes/Carcass.uc
@@ -273,14 +273,21 @@ function bool TryLootItem(DeusExPlayer player, Inventory item)
 
     action = class'DXRLoadouts'.static.GetLootAction(item.class);
 
-    if (action == 2 && Human(player).ConsumableWouldHelp(item) && DeusExPickup(item) != None) { // consume
+    if (action == 2 && Human(player).ConsumableWouldHelp(item) && DeusExPickup(item) != None) { // consume if helpful
         DeleteInventory(item);
         DeusExRootWindow(player.rootWindow).hud.receivedItems.AddItem(item, 1);
         Human(player).InstantlyUseItem(DeusExPickup(item));
         return true;
     }
 
-    if (action > 0) { // drop is 1, also drop autoconsume items that wouldn't help
+    if (
+        action > 0 // drop is 1
+        && ( // don't drop stackable items that are already in the inventory
+            DeusExPickup(item) == None
+            || DeusExPickup(item).bCanHaveMultipleCopies == false
+            || player.FindInventoryType(item.class) == None
+        )
+    ) {
         weap = Weapon(item);
         if (weap != None && weap.AmmoName != class'AmmoNone' && !fakeAmmo) {
             playerAmmo = Ammo(player.FindInventoryType(weap.AmmoName));

--- a/src/DXRFixes/DeusEx/Classes/Carcass.uc
+++ b/src/DXRFixes/DeusEx/Classes/Carcass.uc
@@ -377,7 +377,7 @@ function bool TryLootWeapon(DeusExPlayer player, DeusExWeapon item)
     local DXRando dxr;
     local DXRLoadouts loadout;
     local DeusExWeapon W;
-    local Inventory otheritem;
+    // local Inventory otheritem;
 
     if (item.PickupAmmoCount < 0) {
         DeleteInventory(item);

--- a/src/DXRFixes/DeusEx/Classes/ElectricityEmitter.uc
+++ b/src/DXRFixes/DeusEx/Classes/ElectricityEmitter.uc
@@ -3,7 +3,7 @@ class DXRElectricityEmitter injects #var(prefix)ElectricityEmitter;
 // make sure sprites don't block electricity (smoke, death markers), continue tracing through them
 function CalcTrace(float deltaTime)
 {
-    local vector StartTrace, EndTrace, HitLocation, HitNormal, loc;
+    local vector StartTrace, EndTrace, HitLocation, HitNormal;
     local Rotator rot;
     local actor target;
     local int texFlags;

--- a/src/DXRFixes/DeusEx/Classes/LipSyncPlayer.uc
+++ b/src/DXRFixes/DeusEx/Classes/LipSyncPlayer.uc
@@ -7,7 +7,6 @@ class LipSyncPlayer injects Human;
 function LipSynch(float deltaTime)
 {
     local name animseq;
-    local float rnd;
     local float tweentime;
 
     // update the animation timers that we are using

--- a/src/DXRFixes/DeusEx/Classes/LipSyncScriptedPawn.uc
+++ b/src/DXRFixes/DeusEx/Classes/LipSyncScriptedPawn.uc
@@ -7,7 +7,6 @@ class LipSyncScriptedPawn shims ScriptedPawn;
 function LipSynch(float deltaTime)
 {
     local name animseq;
-    local float rnd;
     local float tweentime;
 
     // update the animation timers that we are using

--- a/src/DXRFixes/DeusEx/Classes/MenuScreenLoadGame.uc
+++ b/src/DXRFixes/DeusEx/Classes/MenuScreenLoadGame.uc
@@ -45,7 +45,7 @@ function String BuildTimeStringSeconds(DeusExSaveInfo s)
 //#region Delete Autosaves
 function ProcessAction(String actionKey)
 {
-    local int t;
+    // local int t;
     if (actionKey == "DELETEAUTOSAVES")
     {
         //t = MB_DeleteAutosaves;

--- a/src/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
+++ b/src/DXRFixes/DeusEx/Classes/ScriptedPawn.uc
@@ -33,7 +33,7 @@ event Destroyed()
 function ThrowInventory(bool gibbed)
 {
     local Inventory item, nextItem;
-    local bool drop, melee;
+    local bool drop;
 
     item = Inventory;
     while( item != None ) {
@@ -59,7 +59,6 @@ function ThrowInventory(bool gibbed)
 function PlayDying(name damageType, vector hitLoc)
 {
     local DeusExPlayer p;
-    local Inventory item, nextItem;
     local bool gibbed;
     local Vector X, Y, Z;
     local float dotp;
@@ -194,7 +193,6 @@ function TakeDamageBase(int Damage, Pawn instigatedBy, Vector hitlocation, Vecto
 {
     local name baseDamageType;
     local DeusExPlayer p;
-    local Human h;
     local bool wasOnFire;
 
     if (damageType == 'FlareFlamed') {
@@ -690,7 +688,7 @@ function SupportActor(Actor standingActor)
 
 function PlayFootStep()
 {
-    local float shakeRadius, shakeMagnitude, shakeAmount, hdDist;
+    local float shakeRadius, shakeMagnitude, shakeAmount;
     local vector shakeStrength;
     local HangingDecoration hd;
     local CCResidentEvilCam cam;
@@ -772,7 +770,7 @@ function MoveAwayFrom(Actor other)
 {
     // DXRando: move away when bumped, similar to state Following
     local Rotator rot;
-    local float extra, dist;
+    local float extra;
     local bool bSuccess;
 
     if(destLoc != vect(0,0,0) && VSize(Velocity)>0) return; // already moving somewhere

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupIntro.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupIntro.uc
@@ -2,7 +2,6 @@ class DXRFixupIntro extends DXRFixup;
 
 function PreFirstEntryMapFixes()
 {
-    local Actor a;
     local #var(DeusExPrefix)Mover dxm;
 
     switch(dxr.localURL) {

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
@@ -344,7 +344,6 @@ function AnyEntryMapFixes()
     local Conversation c;
     local ConEvent ce,before,after;
     local ConEventSpeech ces;
-    local name conName;
     local string afterTextLine;
 
     // if you can talk to gunther then obviously he's been rescued

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM01.uc
@@ -51,6 +51,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)WeaponShuriken tk;
     local #var(prefix)Female2 shannon;
     local #var(prefix)InformationDevices id;
+    local #var(prefix)DatalinkTrigger dlt;
     local bool VanillaMaps;
 #ifdef injections
     local #var(prefix)Newspaper np;
@@ -235,6 +236,12 @@ function PreFirstEntryMapFixes()
                     id.Destroy();
                 }
             }
+        }
+
+        foreach AllActors(class'#var(prefix)DatalinkTrigger',dlt){
+            if (dlt.datalinkTag!='DL_WarmCold') continue;
+            dlt.bTriggerOnceOnly=False;
+            break;
         }
 
         //Spawn some placeholders for new item locations

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM02.uc
@@ -39,7 +39,6 @@ function PreFirstEntryMapFixes()
     local DynamicLight light;
     local DeusExDecoration s;
     local Smuggler smug;
-    local HomeBase hb;
     local DXRReinforcementPoint reinforce;
     local #var(prefix)Poolball pb;
     local #var(prefix)SecurityBot3 bot;

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -677,6 +677,7 @@ function AnyEntryMapFixes()
     local string textAdd;
     local #var(prefix)SecurityCamera cam;
     local #var(prefix)AutoTurret turret;
+    local #var(prefix)NanoKey k;
 
     RevisionMaps = class'DXRMapVariants'.static.IsRevisionMaps(player());
 
@@ -694,6 +695,15 @@ function AnyEntryMapFixes()
 
     case "03_NYC_AIRFIELD":
         CleanUpNSFAfterLebedev(); //Remove clones after meeting Lebedev
+
+        if (dxr.flagbase.GetBool('MeetLebedev_Played') || dxr.flagbase.GetBool('JuanLebedev_Dead')) {
+            foreach AllActors(class'#var(prefix)NanoKey', k) {
+                if (k.Owner != None && k.keyID == 'eastgate') {
+                    ThrowItem(k, 0.1);
+                }
+            }
+        }
+
         break;
     case "03_NYC_HANGAR":
         CleanUpNSFAfterLebedev(); //Remove clones after meeting Lebedev
@@ -732,6 +742,14 @@ function AnyEntryMapFixes()
             }
             foreach AllActors(class'#var(prefix)AutoTurret', turret) {
                 turret.UnTrigger(None, None);
+            }
+        }
+
+        if (dxr.flagbase.GetBool('MeetLebedev_Played') || dxr.flagbase.GetBool('JuanLebedev_Dead')) {
+            foreach AllActors(class'#var(prefix)NanoKey', k) {
+                if (k.Owner != None && k.keyID == 'Sewerdoor') {
+                    ThrowItem(k, 0.1);
+                }
             }
         }
 

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM03.uc
@@ -673,7 +673,6 @@ function AnyEntryMapFixes()
     local ConEventSpeech ces;
     local ConEventChoice cec;
     local ConChoice      cc;
-    local ConEventSetFlag cesf;
     local bool RevisionMaps, knowPass, foundUnderground;
     local string textAdd;
     local #var(prefix)SecurityCamera cam;
@@ -843,7 +842,6 @@ function AddBatteryParkReturnJock()
 {
     local #var(prefix)BlackHelicopter jock;
     local #var(prefix)GoalCompleteTrigger gct;
-    local Dispatcher d;
     local DynamicMapExit exit;
     local InterpolateTrigger it;
 

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM04.uc
@@ -844,7 +844,6 @@ function TimerMapFixes()
 function NYC_04_CheckPaulUndead()
 {
     local PaulDenton paul;
-    local int count;
 
     if( ! class'MenuChoice_BalanceMaps'.static.MinorEnabled() ) return;
     if( ! dxr.flagbase.GetBool('PaulDenton_Dead')) return;
@@ -959,7 +958,7 @@ function NYC_04_MarkPaulSafe()
 
 function NYC_04_LeaveHotel()
 {
-    local FlagTrigger t;
+    // local FlagTrigger t;
     local PaulDenton paul;
 
     if( ! class'MenuChoice_BalanceMaps'.static.MinorEnabled() ) return;

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM06.uc
@@ -107,10 +107,9 @@ function PreFirstEntryMapFixes()
     local #var(prefix)MJ12Commando commando;
     local WaterCooler wc;
     local Rotator rot;
-    local Male1 male;
     local GordonQuick gordon;
-    local DXRReinforcementPoint reinforce;
-    local Dispatcher disp;
+    // local DXRReinforcementPoint reinforce;
+    // local Dispatcher disp;
     local #var(prefix)Trigger t;
     local #var(prefix)ControlPanel panel;
     local #var(prefix)HKHangingLantern lantern;
@@ -938,7 +937,6 @@ function PreFirstEntryMapFixes()
         oot.Tag='Self_Destruct';
 
         if (class'MenuChoice_BalanceMaps'.static.ModerateEnabled()){
-
             //The lockdown door should only close once the UC has been destroyed,
             //so that there's always an exit available.
             foreach AllActors(class'#var(DeusExPrefix)Mover',m,'VirusUploaded'){
@@ -1123,7 +1121,6 @@ function FixMaggieMoveSpeed()
 function AnyEntryMapFixes()
 {
     local Actor a;
-    local ScriptedPawn p;
     local #var(DeusExPrefix)Mover m;
     local bool boolFlag;
     local bool recruitedFlag;

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
@@ -734,7 +734,7 @@ function PreFirstEntryMapFixes()
                 class'MoverToggleTrigger'.static.CreateMTT(self, 'DXRSmugglerElevatorUsed', 'elevatorbutton', 1, 0, 0.0, 9);
             }
             if (VanillaMaps) {
-                foreach RadiusActors(class'Switch1', s1, 0.1, vectm(-59.050560, -1450.105591, 17.855021)) {
+                foreach RadiusActors(class'#var(prefix)Switch1', s1, 0.1, vectm(-59.050560, -1450.105591, 17.855021)) {
                     s1.moverTag = 'elevatorbutton';
                     s1.BeginPlay();
                     break;

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
@@ -475,6 +475,7 @@ function PreFirstEntryMapFixes()
     local #var(prefix)BarrelFire bf;
     local #var(prefix)Keypad2 kp;
     local #var(prefix)SecurityBot3 bot;
+    local #var(prefix)Switch1 s1;
 
 #ifdef injections
     local #var(prefix)Newspaper np;
@@ -729,8 +730,15 @@ function PreFirstEntryMapFixes()
                 SetAllLampsState(false, true, true); // smuggler has one table lamp, upstairs where no one is unless Ford was rescued
             }
 
-            if(#bool(vanilla)) {
+            if (#bool(vanilla)) {
                 class'MoverToggleTrigger'.static.CreateMTT(self, 'DXRSmugglerElevatorUsed', 'elevatorbutton', 1, 0, 0.0, 9);
+            }
+            if (VanillaMaps) {
+                foreach RadiusActors(class'Switch1', s1, 0.1, vectm(-59.050560, -1450.105591, 17.855021)) {
+                    s1.moverTag = 'elevatorbutton';
+                    s1.BeginPlay();
+                    break;
+                }
             }
 
             //Verified in both vanilla and Revision

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
@@ -630,6 +630,8 @@ function PreFirstEntryMapFixes()
                     break;
                 }
 
+                FixHotelPatrolPaths();
+
                 Spawn(class'PlaceholderItem',,, vectm(-732,-2628,75)); //Actual closet
                 Spawn(class'PlaceholderItem',,, vectm(-732,-2712,75)); //Actual closet
                 Spawn(class'PlaceholderItem',,, vectm(-129,-3038,127)); //Bathroom counter
@@ -770,6 +772,47 @@ function PreFirstEntryMapFixes()
     }
 }
 //#endregion
+
+function FixHotelPatrolPaths()
+{
+    local PatrolPoint pp;
+    local #var(prefix)ScriptedPawn sp;
+
+    //First, fix the tags on the patrol points (these tags align with the Transcended map fixes, so should be good regardless?)
+    //Near front desk
+    foreach RadiusActors(class'PatrolPoint',pp, 1, vectm(-379.099670,-1116.226318,-112.900032)){
+        pp.Tag='HotelPatrol2A';
+        pp.NextPatrol='HotelPatrol2B';
+        break;
+    }
+
+    //Near upstairs far door
+    foreach RadiusActors(class'PatrolPoint',pp, 1, vectm(670.092590,-859.416077,79.100044)){
+        pp.Tag='HotelPatrol2B';
+        pp.NextPatrol='HotelPatrol2C';
+        pp.PauseTime=3.0;
+        break;
+    }
+
+    //Near upstairs elevator
+    foreach RadiusActors(class'PatrolPoint',pp, 1, vectm(-420.243744,-1938.531494,79.100182)){
+        pp.Tag='HotelPatrol2C';
+        pp.NextPatrol='HotelPatrol2A';
+        pp.PauseTime=3.0;
+        break;
+    }
+
+    //Now reinitialize all the patrol points
+    foreach AllActors(class'PatrolPoint',pp){
+        pp.PreBeginPlay();
+    }
+
+    //Now kick off the NPCs onto the right paths
+    foreach AllActors(class'#var(prefix)ScriptedPawn',sp){
+        if (sp.Orders!='Patrolling') continue;
+        sp.FollowOrders();
+    }
+}
 
 //#region Post First Entry
 function PostFirstEntryMapFixes()

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM08.uc
@@ -218,7 +218,7 @@ function AddNoRoomToJordanSheaConvo(){
     //When you buy from Jordan in this mission, they got lazy and didn't have a failure path
     //for when you don't have room to accept the candy or booze you buy.  Luckily, there's a
     //line that's good enough that we can yoink from the conversation with Smuggler.
-    local ConEventSpeech ces, origNoRoom, newNoRoom, normalSpeech;
+    local ConEventSpeech origNoRoom, newNoRoom, normalSpeech;
     local Conversation c;
     local ConEvent ce;
     local ConEventTransferObject ceto;
@@ -290,7 +290,6 @@ function RearrangeJockExitDialog()
 {
     local Conversation c;
     local ConEvent ce,prev;
-    local ConEventSpeech ces;
     local ConEventAddSkillPoints ceasp;
     local ConEventAddGoal ceag,goalComplete;
 

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
@@ -69,7 +69,6 @@ function FixJockExplosion()
 function PreFirstEntryMapFixes_Bunker(bool isVanilla)
 {
     local DeusExMover d;
-    local ComputerSecurity c;
     local Keypad k;
     local #var(prefix)Button1 b;
     local Switch2 s2;

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupM15.uc
@@ -452,6 +452,7 @@ function PreFirstEntryMapFixes_Entrance(bool isVanilla)
     local ComputerSecurity c;
     local #var(prefix)FlagTrigger ft;
     local #var(prefix)Nanokey key;
+    local PatrolPoint pp;
 
     //Change break room security computer password so it isn't pre-known
     //This code isn't written anywhere, so you shouldn't have knowledge of it
@@ -514,6 +515,12 @@ function PreFirstEntryMapFixes_Entrance(bool isVanilla)
             key.Description = "Station 5 Hatch Key";
             if(dxr.flags.settings.keysrando > 0)
                 GlowUp(key);
+        }
+
+        foreach AllActors(class'PatrolPoint',pp,'commando1_1'){
+            if (pp.NextPatrol!='commando1_1') continue;
+            pp.NextPatrol='commando1_0'; //Make it point back to the other end, instead of back onto itself
+            pp.PreBeginPlay();
         }
 
         Spawn(class'#var(prefix)Liquor40oz',,, vectm(4585,72,-174)); //Beers on the table in the sleeping quarters

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupParis.uc
@@ -479,7 +479,6 @@ function SpawnLeMerchant(vector loc, rotator rot)
     local DXRNPCs npcs;
     local DXREnemies dxre;
     local ScriptedPawn sp;
-    local Merchant m;
 
     if(dxr.flags.settings.swapitems > 0) {
         // spawn Le Merchant with a hazmat suit because there's no guarantee of one before the highly radioactive area

--- a/src/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
+++ b/src/DXRMapFixups/DeusEx/Classes/DXRFixupVandenberg.uc
@@ -53,7 +53,6 @@ function PreFirstEntryMapFixes()
     local JockHelicopter jockheli;
 #endif
     local DXRHoverHint hoverHint;
-    local ScriptedPawn pawn;
     local #var(prefix)ScriptedPawn sp;
     local #var(prefix)Robot bot;
     local #var(prefix)TiffanySavage tiffany;

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsM01.uc
@@ -46,7 +46,7 @@ function int InitGoals(int mission, string map)
     AddMutualExclusion(jail, hut);
     AddMutualExclusion(topofbase, top);
 
-    // Leo vs boat mutual exclusions
+    // Boat vs Leo/start mutual exclusions
     AddMutualExclusion(boat_pauldock, pauldock);
     AddMutualExclusion(boat_pauldock, unatco);
     AddMutualExclusion(boat_harleydock, harleydock);
@@ -125,7 +125,7 @@ function int InitGoalsRev(int mission, string map)
     AddMutualExclusion(jail, hut);
     AddMutualExclusion(topofbase, top);
 
-    // Leo vs boat mutual exclusions
+    // Boat vs Leo/start mutual exclusions
     AddMutualExclusion(boat_pauldock, pauldock);
     AddMutualExclusion(boat_pauldock, unatco);
     AddMutualExclusion(boat_harleydock, harleydock);

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsM03.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsM03.uc
@@ -3,7 +3,7 @@ class DXRMissionsM03 extends DXRMissions;
 
 function int InitGoals(int mission, string map)
 {
-    local int goal, loc, loc2;
+    local int goal, loc;
 
     switch(map) {
     case "03_NYC_BATTERYPARK":
@@ -125,7 +125,7 @@ function int InitGoals(int mission, string map)
 
 function int InitGoalsRev(int mission, string map)
 {
-    local int goal, loc, loc2;
+    local int goal, loc;
 
     switch(map) {
     case "03_NYC_BATTERYPARK":

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsM04.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsM04.uc
@@ -3,7 +3,7 @@ class DXRMissionsM04 extends DXRMissions;
 
 function int InitGoals(int mission, string map)
 {
-    local int goal, loc, loc2;
+    local int goal;
 
     // GOAL_TYPE1 for the dish computer, 2 for transmitter, 3 for Anna
     AddGoal("04_NYC_NSFHQ", "Dish Alignment Computer", GOAL_TYPE1, 'ComputerPersonal3', PHYS_Falling);
@@ -30,7 +30,7 @@ function int InitGoals(int mission, string map)
 
 function int InitGoalsRev(int mission, string map)
 {
-    local int goal, loc, loc2;
+    local int goal;
 
     // GOAL_TYPE1 for the dish computer, 2 for transmitter, 3 for Anna
     AddGoal("04_NYC_NSFHQ", "Dish Alignment Computer", GOAL_TYPE1, 'ComputerPersonal3', PHYS_Falling);

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsM05.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsM05.uc
@@ -277,8 +277,6 @@ function PreFirstEntryMapFixes()
 function AddMissionGoals()
 {
     local #var(prefix)DataLinkTrigger dlt;
-    local Inventory item;
-    local DeusExGoal newGoal;
 
     if(dxr.localURL != "05_NYC_UNATCOMJ12LAB") return;
 

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsM08.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsM08.uc
@@ -6,7 +6,7 @@ class DXRMissionsM08 extends DXRMissions;
 
 function int InitGoals(int mission, string map)
 {
-    local int goal, loc, loc2, bar1, bar2;
+    local int goal, bar1, bar2;
     local bool bMemes;
 
     bMemes = (dxr.flags.settings.goals != 200);

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsM09.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsM09.uc
@@ -3,7 +3,7 @@ class DXRMissionsM09 extends DXRMissions;
 
 function int InitGoals(int mission, string map)
 {
-    local int goal, loc, loc2;
+    local int goal, loc;
     local bool bMemes;
 
     bMemes = (dxr.flags.settings.goals != 200);
@@ -154,7 +154,7 @@ function int InitGoals(int mission, string map)
 
 function int InitGoalsRev(int mission, string map)
 {
-    local int goal, loc, loc2;
+    local int goal, loc;
     local bool bMemes;
 
     bMemes = (dxr.flags.settings.goals != 200);

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsParis.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsParis.uc
@@ -3,7 +3,7 @@ class DXRMissionsParis extends DXRMissions;
 
 function int InitGoals(int mission, string map)
 {
-    local int goal, loc, loc2;
+    local int goal, loc;
 
     switch(map) {
     case "10_PARIS_CATACOMBS_TUNNELS":
@@ -83,7 +83,7 @@ function int InitGoals(int mission, string map)
 
 function int InitGoalsRev(int mission, string map)
 {
-    local int goal, loc, loc2;
+    local int goal, loc;
 
     switch(map) {
     case "10_PARIS_CATACOMBS_TUNNELS":

--- a/src/DXRMissions/DeusEx/Classes/DXRMissionsVandenberg.uc
+++ b/src/DXRMissions/DeusEx/Classes/DXRMissionsVandenberg.uc
@@ -5,7 +5,7 @@ var bool WaltonAppeared;
 function int InitGoals(int mission, string map)
 {
     local int goal, loc;
-    local int front_gate_start;
+    // local int front_gate_start;
     local int howard_cherry, howard_meeting, howard_radio, howard_computer, howard_machine_shop;
     local int jock_vanilla, jock_cherry, jock_tower, jock_computer;
     local int computer_vanilla, computer_radio, computer_meeting, computer_machine_shop;

--- a/src/DXRModules/DeusEx/Classes/DXRAugmentations.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRAugmentations.uc
@@ -173,7 +173,7 @@ static function LogAugArray(/*const*/ out class<Augmentation> augs[50], int numA
 
     class'DXRando'.default.dxr.l("LogAugArray()");
     for (i = 0; i < numAugs; i++) {
-        class'DXRando'.default.dxr.l("  augs [" $ PadString(i $ "]: ", 5) $ augs[i].name);
+        class'DXRando'.default.dxr.l("  augs[" $ PadString(i $ "]: ", 5) $ augs[i].name);
     }
 }
 

--- a/src/DXRModules/DeusEx/Classes/DXRAugmentations.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRAugmentations.uc
@@ -123,10 +123,10 @@ simulated function RandoAugSlotsWeighted()
 
 simulated function RandoAugSlotsBalanced()
 {
-    local class<Augmentation> augClasses[50], augClass;
+    local class<Augmentation> augClasses[50];
     local int numAugClasses;
     local int augLocations[9], augLocIdx, numRemainingLocs;
-    local int i, j, k;
+    local int i, j;
     local Augmentation aug;
 
     SetGlobalSeedNew("RandoAugSlotsBalanced");
@@ -428,7 +428,6 @@ function static UpgradeRandomAug(DXRando dxr, DeusExPlayer p)
     local class<Augmentation> augs[12];
     local int numAugs, i;
     local Augmentation anAug;
-    local bool wasActive;
 
     numAugs = 0;
     anAug = p.AugmentationSystem.FirstAug;
@@ -891,7 +890,7 @@ static simulated function FixAugHotkeys(PlayerPawn player, bool verbose)
 
 simulated function RemoveRandomAug(#var(PlayerPawn) p, optional bool singleSlot, optional byte slotToRemove)
 {
-    local Augmentation a, b, augs[64];
+    local Augmentation a, augs[64];
     local AugmentationManager am;
     local DXRLoadouts loadouts;
     local int numAugs, slot;

--- a/src/DXRModules/DeusEx/Classes/DXRBacktracking.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRBacktracking.uc
@@ -336,7 +336,6 @@ function ParisMetroAnyEntry()
     local GuntherHermann gunther;
     local NicoletteDuClare nicolette;
     local FlagBase flags;
-    local MapExit exit;
     local Vehicles chopper;
 
     flags = dxr.flagbase;

--- a/src/DXRModules/DeusEx/Classes/DXRBingoCampaign.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRBingoCampaign.uc
@@ -468,7 +468,7 @@ function HandleBingoGoal()
 function HandleBingoWin(int numBingos, int oldBingos)
 {
     local name blockerFlag1, blockerFlag2;
-    local int expiration, nextMission;
+    local int expiration;
 
     if (numBingos > oldBingos) {
         player().ClientMessage("You have enough bingo lines to proceed!");
@@ -483,7 +483,7 @@ function HandleBingoWin(int numBingos, int oldBingos)
  static function string GetBingoHoverHintText(DXRando dxr, string hintText)
  {
     local string bingoText;
-    local int bingosRemaining, spaces;
+    local int bingosRemaining;
 
     if (!dxr.flags.IsBingoCampaignMode() || !IsBingoEnd(dxr.dxInfo.missionNumber, dxr.flags.bingo_duration)) {
          return hintText;

--- a/src/DXRModules/DeusEx/Classes/DXRBrightness.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRBrightness.uc
@@ -142,7 +142,6 @@ function ApplyEpilepsySafe(bool enabled)
 
 function IncreaseBrightness(int brightness)
 {
-    local ZoneInfo z;
     local DXRStoredZoneInfo szi;
 
     if (dxr.localURL == "ENDGAME4" || dxr.localURL == "ENDGAME4REV"){

--- a/src/DXRModules/DeusEx/Classes/DXRCrowdControl.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRCrowdControl.uc
@@ -432,7 +432,6 @@ function InitStupidQuestions() {
 
 function getRandomQuestion(out string question, out int numAnswers,
                            out string ansOne, out string ansTwo, out string ansThree) {
-
     curStupidQuestion++;
     curStupidQuestion = curStupidQuestion % numStupidQuestions;
 

--- a/src/DXRModules/DeusEx/Classes/DXRDatacubes.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRDatacubes.uc
@@ -2049,7 +2049,6 @@ simulated function bool InfoDevsHasPass(#var(prefix)InformationDevices id, optio
 simulated function ProcessText(DeusExTextParser parser, out int hasPass[64], out int numHasPass)
 {
     local string text;
-    local int i;
     local byte tag;
 
     while(parser.ProcessText()) {
@@ -2122,7 +2121,6 @@ function bool InfoPositionGood(#var(prefix)InformationDevices id, vector newpos,
     local #var(prefix)Keypad k;
     local #var(injectsprefix)InformationDevices injectID;
     local String TextTag;
-    local String mapname;
     local int i;
 
     TextTag = class'#var(injectsprefix)InformationDevices'.static.GetTextTag(id);
@@ -2164,7 +2162,6 @@ function bool InfoPositionGood(#var(prefix)InformationDevices id, vector newpos,
 //#region Human Text Tags
 static function string GetHumanTextTagName(string texttag, string textpackage)
 {
-
     local string prefix,fullTag,s1;
     local int i;
 

--- a/src/DXRModules/DeusEx/Classes/DXREnemies.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREnemies.uc
@@ -10,8 +10,6 @@ const Police = 5;
 
 function CheckConfig()
 {
-    local int i;
-
     enemy_multiplier = 1;
     min_rate_adjust = 0.3;
     max_rate_adjust = 4.0;

--- a/src/DXRModules/DeusEx/Classes/DXREnemiesBase.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREnemiesBase.uc
@@ -97,7 +97,6 @@ function ReadConfig()
 {
     local int i, nums[32], nummelees[8], numsides[8], totalweaps, totalmelees, totalsides;
     local float total, f, c, totals[16];
-    local class<Actor> a;
     local DeusExWeapon w;
 
     // count existing in level

--- a/src/DXRModules/DeusEx/Classes/DXREnemyRespawn.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREnemyRespawn.uc
@@ -34,7 +34,7 @@ var config name dont_respawn[8];
 function PostFirstEntry()
 {
     local ScriptedPawn p;
-    local int i, a;
+    local int i;
     Super.PostFirstEntry();
 
     if( dxr.flags.settings.enemyrespawn <= 0 ) return;
@@ -115,7 +115,6 @@ function SaveRespawn(ScriptedPawn p, out int i)
 
 function AnyEntry()
 {
-    local int i;
     Super.AnyEntry();
 
     if( dxr.flags.IsHordeMode() ) return;
@@ -146,7 +145,6 @@ function Timer()
 function ScriptedPawn Respawn(out OriginalEnemy enemy)
 {
     local DXREnemies dxre;
-    local DXRNames dxrn;
     local ScriptedPawn p;
     local int i;
 

--- a/src/DXRModules/DeusEx/Classes/DXREntranceRando.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREntranceRando.uc
@@ -322,7 +322,6 @@ function bool ValidateConnections()
     local int numMaps;
     local int numPasses;
     local int i,j,k;
-    local bool foundMap;
 
     local string canvisit[15];
     local int visitable, oldVisitable;
@@ -1248,7 +1247,7 @@ function ExtendedTests()
 
 function BasicTests()
 {
-    local int i;
+    // local int i;
     local string old_dead_end;
 
     numXfers = 0;
@@ -1415,8 +1414,6 @@ function TestAllMissions(int newseed)
 
 function TestDependencies()
 {
-    local int i;
-
     numXfers = 0;
     numFixedConns = 0;
 

--- a/src/DXRModules/DeusEx/Classes/DXREventsBase.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREventsBase.uc
@@ -335,7 +335,6 @@ simulated function InitPoolBalls()
 
 simulated function bool CheckForNanoKey(String keyID)
 {
-
     local name keyName;
 
     if (player()==None){
@@ -561,7 +560,6 @@ function Trigger(Actor Other, Pawn Instigator)
 function SendFlagEvent(coerce string eventname, optional bool immediate, optional string extra)
 {
     local string j;
-    local int i;
     local class<Json> js;
     js = class'Json';
 
@@ -744,7 +742,6 @@ function _AddPawnDeath(ScriptedPawn victim, optional Actor Killer, optional coer
     local string classname;
     local #var(PlayerPawn) p;
     local bool dead, isRobot;
-    local int i;
 
     p = player();
     dead = !CanKnockUnconscious(victim, damageType);
@@ -1292,7 +1289,6 @@ function bool AddTestGoal(
     local int bingoIdx;
     local string desc;
     local bool do_not_scale, append_max;
-    local float f;
 
     if (event == "") return false;
     for (bingoIdx = 0; bingoIdx < ArrayCount(bingo_options); bingoIdx++)
@@ -1340,7 +1336,6 @@ simulated function _CreateBingoBoard(PlayerDataItem data, int starting_map, int 
     local int progress, max, missions, starting_mission_mask, starting_mission, end_mission_mask, end_mission, maybe_mission_mask, masked_missions, maybe_masked_missions, real_duration;
     local int options[ArrayCount(bingo_options)], num_options, slot, free_spaces;
     local bool bPossible, do_not_scale, append_max;
-    local float f;
 
     if(dxr.flags.gamemode == dxr.flags.OneGoal) {
         _CreateOneGoalBingoBoard(data);
@@ -1563,7 +1558,7 @@ simulated function int ScaleBingoGoalMax(int max, int bingoScale, float randMin,
 }
 
 simulated function int HandleMutualExclusion(MutualExclusion m, int options[ArrayCount(bingo_options)], int num_options) {
-    local int a, b, overwrite;
+    local int a, b;
 
     for(a=0; a<num_options; a++) {
         if( bingo_options[options[a]].event == m.e1 ) break;

--- a/src/DXRModules/DeusEx/Classes/DXREventsHelpText.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREventsHelpText.uc
@@ -41,7 +41,6 @@ static simulated function bool IsPawnDeathSuffix(string suffix)
 static simulated function string GetBingoGoalHelpText(string event,int mission, bool FemJC)
 {
     local string prefix,suffix,msg;
-    local int idx;
 
     //Get the prefix and suffix
     FindEventPrefixSuffix(event,prefix,suffix);
@@ -562,7 +561,6 @@ static simulated function string GetBingoHelpTextConversations(string event,int 
 //#region Items Used
 static simulated function string GetBingoHelpTextItemsUsed(string event,int mission, bool FemJC)
 {
-    local string msg;
     local DXRando dxr;
     local bool RevisionMaps;
 
@@ -743,7 +741,6 @@ static simulated function string GetBingoHelpTextImages(string event,int mission
 //#region NanoKeys
 static simulated function string GetBingoHelpNanoKeys(string event,int mission, bool FemJC)
 {
-    local string msg;
     local DXRando dxr;
     local bool RevisionMaps;
 

--- a/src/DXRModules/DeusEx/Classes/DXRFixup.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFixup.uc
@@ -390,7 +390,6 @@ function float H2V(float hdeg, float asp)
 
 function float GetRatio()
 {
-	local int p;
 	local int resX;
 	local int resWidth, resHeight;
 	local string CurrentRes;
@@ -1618,7 +1617,6 @@ function UpdateDefaultSecurityComputerPassword(string newpass, optional string n
     local DXRPasswords passwords;
     local #var(prefix)ComputerSecurity comp;
     local string notePassword,finalpassword;
-    local int i;
 
     if( class'MenuChoice_BalanceMaps'.static.ModerateEnabled() || class'MenuChoice_PasswordAutofill'.static.ShowKnownAccounts() ) {
         foreach AllActors(class'#var(prefix)ComputerSecurity',comp){

--- a/src/DXRModules/DeusEx/Classes/DXRFlags.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlags.uc
@@ -67,7 +67,7 @@ simulated function PlayerAnyEntry(#var(PlayerPawn) p)
         f.SetBool('AchievementsDisabled', true,, 999);
     }
 
-    l("starting map is set to "$settings.starting_map);
+    l("starting map is set to "$moresettings.starting_map);
 }
 
 simulated function SetGlobals()
@@ -188,11 +188,11 @@ function CheckConfig()
     difficulty_settings[i].max_weapon_shottime = 150;
     difficulty_settings[i].bingo_win = 0;
     difficulty_settings[i].bingo_freespaces = 1;
-    difficulty_settings[i].spoilers = 1;
+    more_difficulty_settings[i].spoilers = 1;
     difficulty_settings[i].health = 200;
     difficulty_settings[i].energy = 200;
-    difficulty_settings[i].starting_map = 0;
-    difficulty_settings[i].grenadeswap = 100;
+    more_difficulty_settings[i].starting_map = 0;
+    more_difficulty_settings[i].grenadeswap = 100;
     more_difficulty_settings[i].newgameplus_curve_scalar = -1;// disable NG+ for faster testing, gamemode can override
     more_difficulty_settings[i].camera_mode = 0;
     more_difficulty_settings[i].enemies_weapons = 100;
@@ -265,11 +265,11 @@ function CheckConfig()
     difficulty_settings[i].max_weapon_shottime = 150;
     difficulty_settings[i].bingo_win = 0;
     difficulty_settings[i].bingo_freespaces = 1;
-    difficulty_settings[i].spoilers = 1;
+    more_difficulty_settings[i].spoilers = 1;
     difficulty_settings[i].health = 100;
     difficulty_settings[i].energy = 100;
-    difficulty_settings[i].starting_map = 0;
-    difficulty_settings[i].grenadeswap = 100;
+    more_difficulty_settings[i].starting_map = 0;
+    more_difficulty_settings[i].grenadeswap = 100;
     more_difficulty_settings[i].newgameplus_curve_scalar = 100;
     more_difficulty_settings[i].camera_mode = 0;
     more_difficulty_settings[i].enemies_weapons = 100;
@@ -341,11 +341,11 @@ function CheckConfig()
     difficulty_settings[i].max_weapon_shottime = 150;
     difficulty_settings[i].bingo_win = 0;
     difficulty_settings[i].bingo_freespaces = 1;
-    difficulty_settings[i].spoilers = 1;
+    more_difficulty_settings[i].spoilers = 1;
     difficulty_settings[i].health = 100;
     difficulty_settings[i].energy = 100;
-    difficulty_settings[i].starting_map = 0;
-    difficulty_settings[i].grenadeswap = 100;
+    more_difficulty_settings[i].starting_map = 0;
+    more_difficulty_settings[i].grenadeswap = 100;
     more_difficulty_settings[i].newgameplus_curve_scalar = 100;
     more_difficulty_settings[i].camera_mode = 0;
     more_difficulty_settings[i].enemies_weapons = 100;
@@ -417,11 +417,11 @@ function CheckConfig()
     difficulty_settings[i].max_weapon_shottime = 150;
     difficulty_settings[i].bingo_win = 0;
     difficulty_settings[i].bingo_freespaces = 1;
-    difficulty_settings[i].spoilers = 1;
+    more_difficulty_settings[i].spoilers = 1;
     difficulty_settings[i].health = 100;
     difficulty_settings[i].energy = 100;
-    difficulty_settings[i].starting_map = 0;
-    difficulty_settings[i].grenadeswap = 100;
+    more_difficulty_settings[i].starting_map = 0;
+    more_difficulty_settings[i].grenadeswap = 100;
     more_difficulty_settings[i].newgameplus_curve_scalar = 100;
     more_difficulty_settings[i].camera_mode = 0;
     more_difficulty_settings[i].enemies_weapons = 100;
@@ -493,11 +493,11 @@ function CheckConfig()
     difficulty_settings[i].max_weapon_shottime = 150;
     difficulty_settings[i].bingo_win = 0;
     difficulty_settings[i].bingo_freespaces = 1;
-    difficulty_settings[i].spoilers = 1;
+    more_difficulty_settings[i].spoilers = 1;
     difficulty_settings[i].health = 90;
     difficulty_settings[i].energy = 80;
-    difficulty_settings[i].starting_map = 0;
-    difficulty_settings[i].grenadeswap = 100;
+    more_difficulty_settings[i].starting_map = 0;
+    more_difficulty_settings[i].grenadeswap = 100;
     more_difficulty_settings[i].newgameplus_curve_scalar = 100;
     more_difficulty_settings[i].camera_mode = 0;
     more_difficulty_settings[i].enemies_weapons = 100;
@@ -506,7 +506,7 @@ function CheckConfig()
     i++;
 
     for(i=0; i<ArrayCount(difficulty_settings); i++) {
-        difficulty_settings[i].menus_pause = 1;
+        more_difficulty_settings[i].menus_pause = 1;
         if(#defined(hx)) {
             difficulty_settings[i].startinglocations = 0;
             difficulty_settings[i].merchants = 0;
@@ -639,7 +639,7 @@ function SetDifficulty(int new_difficulty)
             settings.repairbotamount = 0;
             settings.medbotuses = 0;
             settings.repairbotuses = 0;
-            settings.grenadeswap = 0;
+            moresettings.grenadeswap = 0;
             // disable NG+ by default
             moresettings.newgameplus_curve_scalar = -1;
         } else {
@@ -684,7 +684,7 @@ function SetDifficulty(int new_difficulty)
             }
         } else {
             // realtime menus, not for training mode
-            settings.menus_pause = 0;
+            moresettings.menus_pause = 0;
         }
         if(gamemode==SpeedShuffle) {
             bingo_duration = 5;
@@ -749,7 +749,7 @@ function SetDifficulty(int new_difficulty)
 
         if(newgameplus_loops == 0) { // this gets overwritten by LoadFlags anyways, but the logging is noisy
             l("applying WaltonWare, DXRando: " $ dxr @ dxr.seed);
-            settings.starting_map = class'DXRStartMap'.static.ChooseRandomStartMap(self, -1); // avoid Liberty Island first
+            moresettings.starting_map = class'DXRStartMap'.static.ChooseRandomStartMap(self, -1); // avoid Liberty Island first
         }
     }
     else if (IsBingoCampaignMode()) {
@@ -915,11 +915,11 @@ simulated function string DescribeDifficulty()
     FlagInt('Rando_bingo_win', settings.bingo_win, mode, str);
     FlagInt('Rando_bingo_freespaces', settings.bingo_freespaces, mode, str);
 
-    FlagInt('Rando_menus_pause', settings.menus_pause, mode, str);
+    FlagInt('Rando_menus_pause', moresettings.menus_pause, mode, str);
     FlagInt('Rando_health', settings.health, mode, str);
     FlagInt('Rando_energy', settings.energy, mode, str);
 
-    FlagInt('Rando_grenadeswap', settings.grenadeswap, mode, str);
+    FlagInt('Rando_grenadeswap', moresettings.grenadeswap, mode, str);
 
     FlagInt('Rando_newgameplus_max_item_carryover', newgameplus_max_item_carryover, mode, str);
     FlagInt('Rando_num_skill_downgrades', newgameplus_num_skill_downgrades, mode, str);
@@ -927,6 +927,19 @@ simulated function string DescribeDifficulty()
     FlagInt('Rando_num_removed_weapons', newgameplus_num_removed_weapons, mode, str);
 
     return str;
+}
+
+function int GameModeIdForName(string modeName)
+{
+    local int i, modeId;
+
+    for (i = 0; i < 50; i++) {
+        modeId = GameModeIdForSlot(i);
+        if (modeId != 999999 && GameModeName(modeId) == modeName) {
+            return modeId;
+        }
+    }
+    return 999999;
 }
 
 function int GameModeIdForSlot(int slot)
@@ -1232,6 +1245,12 @@ function string GameModeHelpText(int gamemode)
 }
 //#endregion
 
+function SetGameMode(int modeId)
+{
+    if (modeId == 999999) return;
+    gamemode = modeId;
+}
+
 //#region IsGameModes
 function bool IsHordeMode()
 {
@@ -1311,7 +1330,7 @@ function bool IsSpeedShuffleMode()
 
 function int GetStartingMap()
 {
-    return settings.starting_map & 0xFF;
+    return moresettings.starting_map & 0xFF;
 }
 
 simulated function AddDXRCredits(CreditsWindow cw)
@@ -1415,7 +1434,7 @@ simulated function TutorialDisableRandomization(bool enableSomeRando)
 
     settings.aug_value_rando = 0;*/
 
-    settings.grenadeswap = 0;
+    moresettings.grenadeswap = 0;
 }
 
 //Nothing fancy happening here, but gives a consistent place to change how we want to clamp across
@@ -1512,7 +1531,7 @@ function int ScoreFlags()
     //settings.max_weapon_shottime = 150;
     //settings.bingo_win = 0;
     //settings.bingo_freespaces = 1;
-    //settings.spoilers = 1;
+    //moresettings.spoilers = 1;
     score -= settings.health;
     score -= settings.energy;
     score -= remove_paris_mj12;
@@ -1533,8 +1552,8 @@ function ExtendedTests()
     moresettings.splits_overlay = 50;// testing for struct size
     SetDifficulty(0);
     testint(settings.bingo_freespaces, 1, "SetDifficulty check bingo_freespaces");
-    testint(Settings.spoilers, 1, "SetDifficulty check spoilers");
-    testint(Settings.menus_pause, 1, "SetDifficulty check menus_pause");
+    testint(moresettings.spoilers, 1, "SetDifficulty check spoilers");
+    testint(moresettings.menus_pause, 1, "SetDifficulty check menus_pause");
     testint(settings.health, 200, "SetDifficulty check health");
     testint(settings.energy, 200, "SetDifficulty check energy");
     testint(moresettings.splits_overlay, 0, "SetDifficulty check splits_overlay");

--- a/src/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -71,16 +71,16 @@ struct FlagsSettings {
     var int prison_pocket;// just for Heinki, keep your items when getting captured
     var int bingo_win; //Number of bingo lines to beat the game
     var int bingo_freespaces; //Number of bingo free spaces
-    var int spoilers; //0=Disallowed, 1=Available
-    var int menus_pause; // 0=no pause, 1=vanilla
-    var int starting_map; // one byte for each historical start
-    var int grenadeswap;
 
     // leave these at the end for the automated tests
     var int health, energy;// normally just 100
 };
 
 struct MoreFlagsSettings{
+    var int spoilers; //0=Disallowed, 1=Available
+    var int menus_pause; // 0=no pause, 1=vanilla
+    var int starting_map; // one byte for each historical start
+    var int grenadeswap;
     var int newgameplus_curve_scalar;
     var int empty_medbots;
     var int camera_mode;
@@ -439,13 +439,13 @@ simulated function string BindFlags(int mode, optional string str)
     FlagInt('Rando_bingo_win', settings.bingo_win, mode, str);
     FlagInt('Rando_bingo_freespaces', settings.bingo_freespaces, mode, str);
 
-    FlagInt('Rando_spoilers', settings.spoilers, mode, str);
-    FlagInt('Rando_menus_pause', settings.menus_pause, mode, str);
+    FlagInt('Rando_spoilers', moresettings.spoilers, mode, str);
+    FlagInt('Rando_menus_pause', moresettings.menus_pause, mode, str);
     FlagInt('Rando_health', settings.health, mode, str);
     FlagInt('Rando_energy', settings.energy, mode, str);
 
-    FlagInt('Rando_starting_map', settings.starting_map, mode, str);
-    FlagInt('Rando_grenadeswap', settings.grenadeswap, mode, str);
+    FlagInt('Rando_starting_map', moresettings.starting_map, mode, str);
+    FlagInt('Rando_grenadeswap', moresettings.grenadeswap, mode, str);
 
     FlagInt('Rando_newgameplus_max_item_carryover', newgameplus_max_item_carryover, mode, str);
     FlagInt('Rando_num_skill_downgrades', newgameplus_num_skill_downgrades, mode, str);
@@ -1156,7 +1156,7 @@ simulated function LoadNoFlags()
 
             //Initialize the starting_map value based on the map selected when starting
             //the server.  This is mostly for the purposes of generating a bingo board.
-            settings.starting_map = class'DXRStartMap'.static.GetHXStartMapVal(dxr.LocalURL);
+            moresettings.starting_map = class'DXRStartMap'.static.GetHXStartMapVal(dxr.LocalURL);
         }
     }
 #endif

--- a/src/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlagsBase.uc
@@ -702,7 +702,6 @@ simulated function string flagNameToHumanName(name flagname){
 
 simulated function string flagValToHumanVal(name flagname, int val){
     local DXRLoadouts loadout;
-    local string ret;
 
     switch(flagname){
         //Basic true/false

--- a/src/DXRModules/DeusEx/Classes/DXRFlagsNGPMaxRando.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlagsNGPMaxRando.uc
@@ -200,14 +200,14 @@ function NewGamePlus()
     newgameplus_loops++;
     bingoBoardRoll=0;
     p.saveCount=0;
-    randomStart = settings.starting_map;
+    randomStart = moresettings.starting_map;
 
     if(gamemode != DXRFlags(self).GroundhogDay) {
         NGPlusFlags(p);
     }
     SetGlobalSeed("NewGamePlus " $ dxr.seed);
     if (randomStart!=0 && gamemode != DXRFlags(self).GroundhogDay){
-        settings.starting_map = class'DXRStartMap'.static.ChooseRandomStartMap(self, randomStart);
+        moresettings.starting_map = class'DXRStartMap'.static.ChooseRandomStartMap(self, randomStart);
     }
 
     if (p.KeyRing != None)
@@ -307,7 +307,7 @@ simulated function NGPlusFlags(#var(PlayerPawn) p)
         bingo_scale = old_bingo_scale;
         bingo_duration = old_bingo_duration;
         moresettings.newgameplus_curve_scalar = oldmoresettings.newgameplus_curve_scalar;
-        settings.menus_pause = oldsettings.menus_pause;
+        moresettings.menus_pause = oldmoresettings.menus_pause;
         moresettings.aug_loc_rando = oldmoresettings.aug_loc_rando;
         moresettings.splits_overlay = oldmoresettings.splits_overlay;
         clothes_looting = old_clothes_looting;

--- a/src/DXRModules/DeusEx/Classes/DXRFlagsNGPMaxRando.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRFlagsNGPMaxRando.uc
@@ -526,12 +526,12 @@ function float NewGamePlusVal(float val, float curve, float exp, float min, floa
 
 function ExtendedTests()
 {
-    local int val, i, j, oldSeed, prev, iterations;
+    local int val, i, oldSeed, prev, iterations;
     local float fval, old_scaling;
     local string s;
     local class<Weapon> weaps[24];
     local int weapSelectedCount[24];
-    local int selectedIdx, selectedHash, thisIdx, thisHash, baseSeed, numWeaps;
+    local int selectedIdx, selectedHash, thisIdx, thisHash, baseSeed;
 
     Super.ExtendedTests();
 

--- a/src/DXRModules/DeusEx/Classes/DXRGrenades.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRGrenades.uc
@@ -102,14 +102,14 @@ function FirstEntry()
     local Actor oldOwner;
 
     Super.FirstEntry();
-    if(dxr.flags.settings.grenadeswap <= 0) return;
+    if(dxr.flags.moresettings.grenadeswap <= 0) return;
 
     SetSeed("RandoGrenades");
 
     i=0;
     foreach AllActors(class'#var(prefix)ThrownProjectile',gren)
     {
-        if (gren.Owner==None && chance_single(dxr.flags.settings.grenadeswap)) {
+        if (gren.Owner==None && chance_single(dxr.flags.moresettings.grenadeswap)) {
             grens[i++]=gren;
         }
     }

--- a/src/DXRModules/DeusEx/Classes/DXRHalloween.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRHalloween.uc
@@ -127,7 +127,6 @@ function MapFixes()
     local #var(DeusExPrefix)Carcass carc;
     local class<#var(DeusExPrefix)Carcass> carcclass;
     local ScriptedPawn sp;
-    local float dist;
 
     if(bSafeStalkers()) {
         //Make people fearless so they don't get spooked by Mr. H
@@ -349,11 +348,10 @@ function SpawnSpiderweb(vector loc)
     local ZoneInfo zone;
     local class<Spiderweb> webClass;
     // Used for texture trace
-    local vector  EndTrace, StartTrace, HitLocation, HitNormal;
+    local vector  EndTrace, HitLocation, HitNormal;
     local actor   target;
     local int     texFlags;
     local name    texName, texGroup;
-    local bool    bInvisibleWall;
 
     loc.X += rngfn() * 256.0;// 16 feet in either direction
     loc.Y += rngfn() * 256.0;// 16 feet in either direction
@@ -400,7 +398,7 @@ function bool GetSpiderwebLocation(out vector loc, out rotator rot, float size)
     local bool found_ceiling, found_floor;
     local LocationNormal ceiling, floor, ceiling_or_floor, wall1, wall2;
     local vector norm;
-    local float dist, f;
+    local float f;
     local FMinMax distrange;
 
     ceiling.loc = loc;

--- a/src/DXRModules/DeusEx/Classes/DXRHints.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRHints.uc
@@ -117,11 +117,11 @@ simulated function InitHints()
         AddHint("Have you tried shooting the camera?", "Maybe you can get a better view!");
     }
 
-    if (dxr.flags.settings.spoilers>0) {
+    if (dxr.flags.moresettings.spoilers>0) {
         AddHint("Spoiler buttons are available on the Goals screen!", "Give them a shot if you get really stuck!");
     }
 
-    if (dxr.flags.settings.menus_pause==0) {
+    if (dxr.flags.moresettings.menus_pause==0) {
         AddHint("The game won't pause when you enter menus!", "Watch out!");
     }
 

--- a/src/DXRModules/DeusEx/Classes/DXRHordeMode.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRHordeMode.uc
@@ -350,7 +350,6 @@ function AnyEntry()
     local Teleporter t;
     local DeusExMover d;
     local DXREnemies dxre;
-    local Inventory item;
     local int i;
     local #var(prefix)SkillAwardTrigger sat;
     local bool new_game;
@@ -442,7 +441,6 @@ function AnyEntry()
 function PlayerAnyEntry(#var(PlayerPawn) p)
 {
     local DXRMapVariants mapvariants;
-    local string m;
 
     mapvariants = DXRMapVariants(dxr.FindModule(class'DXRMapVariants'));
     if(mapvariants != None) {
@@ -758,7 +756,7 @@ function float GenerateEnemy(DXREnemies dxre)
     local class<ScriptedPawn> c;
     local ScriptedPawn p;
     local int i;
-    local float difficulty, dist, r;
+    local float difficulty, r;
     local vector loc;
 
     r = initchance();
@@ -909,7 +907,6 @@ function GenerateItem()
     local vector loc;
     local #var(prefix)AugmentationCannister aug;
     local Barrel1 barrel;
-    local DeusExMover d;
     local HordeModeCrate hmc;
     local float r;
     local bool success;

--- a/src/DXRModules/DeusEx/Classes/DXRKillBobPage.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRKillBobPage.uc
@@ -17,10 +17,9 @@ function CheckConfig()
 
 function FirstEntry()
 {
-    local MapExit exit;
     local NavigationPoint p;
     //local NYPoliceBoat b;
-    local int i ,slot, num;
+    local int slot, num;
     local string map;
 
     if( dxr.flags.gamemode != 100 ) return;

--- a/src/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -1302,21 +1302,32 @@ function class<Inventory> _GetRandomUtilityItem()
 
 function _RandoStartingEquipment(#var(PlayerPawn) player, DXREnemies dxre, bool bFrob)
 {
-    local int i;
+    local int i, slot;
     local Inventory item;
     local class<Inventory> iclass;
+    local HUDObjectBelt belt;
 
     if(dxre != None) {
+        belt = DeusExRootWindow(player.rootWindow).hud.belt;
+        slot = class'MenuChoice_MeleeSlot'.default.StartingMeleeSlot;
         for(i=0; i<100; i++) {
-            iclass = dxre.GiveRandomWeaponClass(player, true);
+            iclass = dxre.GiveRandomMeleeWeaponClass(player, false);
             if(iclass == None || is_banned(iclass)) continue;
+
             item = GiveItem(player, iclass);
             item = _GiveRandoStartingItem(player, item, bFrob);
-            if(item != None) break;
+            if(item == None) continue;
+
+            if(belt.IsValidPos(slot) && belt.GetObjectFromBelt(slot) == None) {
+                belt.RemoveObjectFromBelt(item);
+                belt.AddObjectToBelt(item, slot, false);
+            }
+
+            break;
         }
 
         for(i=0; i<100; i++) {
-            iclass = dxre.GiveRandomMeleeWeaponClass(player, false);
+            iclass = dxre.GiveRandomWeaponClass(player, true);
             if(iclass == None || is_banned(iclass)) continue;
             item = GiveItem(player, iclass);
             item = _GiveRandoStartingItem(player, item, bFrob);

--- a/src/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -910,7 +910,7 @@ function string GetName(int i)
 //#region AnyEntry
 function AnyEntry()
 {
-    local ConEventTransferObject c;
+    // local ConEventTransferObject c;
 
     Super.AnyEntry();
 
@@ -1039,8 +1039,6 @@ function bool is_starting_equipment(Inventory eqpt, optional bool allow_subclass
 
 function bool ban(DeusExPlayer player, Inventory item)
 {
-    local bool bFixGlitches;
-
     if(IsMeleeWeapon(item) && Carcass(item.Owner) != None && player.FindInventoryType(item.class) != None) {
         return true;
     } else if ( _is_banned( item_set, item.class) ) {
@@ -1344,7 +1342,7 @@ function SpawnItems()
     local Actor a;
     local class<Actor> aclass;
     local DXRReduceItems reducer;
-    local int i, j, chance, max;
+    local int i, j, chance;
 
     if(dxr.dxInfo.MissionNumber < 0) return;
 

--- a/src/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -1229,7 +1229,7 @@ function RandoStartingEquipment(#var(PlayerPawn) player, bool respawn)
 
     start_amount = dxr.flags.settings.equipment;
 
-    if (dxr.flags.settings.starting_map != 0) {
+    if (dxr.flags.moresettings.starting_map != 0) {
         start_amount += 1 + dxr.flags.GetStartingMap() / 30;
     }
 

--- a/src/DXRModules/DeusEx/Classes/DXRMachines.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRMachines.uc
@@ -316,8 +316,6 @@ function bool GetLazyCameraLocation(out vector loc, int max_range)
 function bool MoveCamera(#var(prefix)SecurityCamera c, vector loc)
 {
     local rotator rotation;
-    local int i;
-    local bool success;
 
     if( GetCameraLocation(loc, rotation) == false ) {
         warning("MoveCamera("$loc$") "$c$" failed to GetCameraLocation");
@@ -335,8 +333,6 @@ function #var(prefix)SecurityCamera SpawnCamera(vector loc)
 {
     local #var(prefix)SecurityCamera c;
     local rotator rotation;
-    local int i;
-    local bool success;
 
     if( GetCameraLocation(loc, rotation) == false ) {
         warning("SpawnCamera("$loc$") failed to GetCameraLocation");
@@ -366,7 +362,6 @@ function #var(injectsprefix)ComputerSecurity SpawnSecurityComputer(vector loc, o
 {
     local #var(injectsprefix)ComputerSecurity c;
     local LocationNormal locnorm;
-    local int i;
     local FMinMax distrange;
     local DXRPasswords pass;
 

--- a/src/DXRModules/DeusEx/Classes/DXRMapInfo.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRMapInfo.uc
@@ -4,7 +4,6 @@ var config string maps[128];
 
 function CheckConfig()
 {
-    local int i;
     if( config_version < 4 ) {
         GetAllMaps(maps);
     }

--- a/src/DXRModules/DeusEx/Classes/DXRMapVariants.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRMapVariants.uc
@@ -141,9 +141,7 @@ static function string GetDirtyMapName(string map, vector v)
 
 static function bool IsRevisionMaps(#var(PlayerPawn) player, optional Bool init)
 {
-#ifndef revision
-    return False;
-#else
+#ifdef revision
     local RevMenuChoice_Maps mapMenu;
     local Bool rc;
     local DXRando dxr;
@@ -169,6 +167,10 @@ static function bool IsRevisionMaps(#var(PlayerPawn) player, optional Bool init)
         //player.ClientMessage("RevisionMapsCache: "$rc);
     }
     return rc;
+#elseif vmd2
+    return class'DeusEx.VMDStaticFunctions'.Static.GetIntendedMapStyle(player)==1;
+#else
+    return False;
 #endif
 }
 
@@ -176,6 +178,9 @@ static function bool IsVanillaMaps(#var(PlayerPawn) player)
 {
     if(#defined(vanillamaps)) return true;
     if(#defined(revision)) return !IsRevisionMaps(player);
+#ifdef vmd2
+    return class'DeusEx.VMDStaticFunctions'.Static.GetIntendedMapStyle(player)==0;
+#endif
     return false;
 }
 

--- a/src/DXRModules/DeusEx/Classes/DXRMemes.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRMemes.uc
@@ -54,7 +54,6 @@ function RandomLiberty()
 {
     local NYLiberty liberty;
     local NYLibertyTop top;
-    local int i;
 
     foreach AllActors(class'NYLibertyTop',top){
         if(IsHalloweenSeason()) {
@@ -105,7 +104,6 @@ function RandomLiberty()
 function RandomBobPage()
 {
     local BobPageAugmented bob;
-    local int i;
 
     foreach AllActors(class'BobPageAugmented',bob){
         SetGlobalSeed("RandomBobPage");
@@ -822,11 +820,11 @@ function FixEndgameEndCamera()
 function PostFirstEntry()
 {
     local ScriptedPawn sp;
-    local InterpolationPoint p;
+    // local InterpolationPoint p;
     local LuciusDeBeers lucius;
     local #var(prefix)SignFloor sf;
-    local vector v;
-    local rotator r;
+    // local vector v;
+    // local rotator r;
 
     Super.PostFirstEntry();
 
@@ -1508,8 +1506,8 @@ function RandomizeDialog()
 {
     local ConSpeech speech[100];
     local ConEventSpeech ces;
-    local int i, j, num, soundID;
-    local string subtitle, strConName;
+    local int i, j, num;
+    local string strConName;
     local bool checkGender;
     local bool isFemale,femConv;
     //local Conversation conv;
@@ -1559,9 +1557,8 @@ function RandomizeDialogConversation(Conversation conv)
 {
     local ConEvent co;
     local ConEventSpeech es;
-    local ConSpeech s, speech[100];
-    local int i, j, num, soundID;
-    local string subtitle;
+    local ConSpeech speech[100];
+    local int i, j, num;
 
     SetSeed("RandomizeDialogConversation "$conv.conName);
     for(co=conv.eventList; co!=None; co=co.nextEvent) {

--- a/src/DXRModules/DeusEx/Classes/DXRMissions.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRMissions.uc
@@ -566,7 +566,7 @@ function MoveActorsIn(int goalsToLocations[32])
 
 function bool _ChooseGoalLocations(out int goalsToLocations[32])
 {
-    local int i, a, g, g1, g2, r, loc, _num_locs, _num_starts, _num_goal_locs;
+    local int i, a, g, g1, r, loc, _num_locs, _num_starts, _num_goal_locs;
     local int availLocs[64], goalsOrder[32], goalLocs[64];
 
     // build list of availLocs based on flags, also count _num_starts
@@ -1108,7 +1108,7 @@ static function bool IsCloseToStart(DXRando dxr, vector loc)
 //tests to ensure that there are more goal locations than movable actors for each map
 function RunTests()
 {
-    local int i, total;
+    local int i;
     Super.RunTests();
 
     i = NORMAL_GOAL | VANILLA_START;

--- a/src/DXRModules/DeusEx/Classes/DXRMusic.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRMusic.uc
@@ -29,7 +29,7 @@ var int last_skipped_song;
 
 function CheckConfig()
 {
-    local int i, g;
+    local int i;
     local string gamesongs[100];
 
     if( ConfigOlderThan(3,2,5,1) ) {

--- a/src/DXRModules/DeusEx/Classes/DXRMusicPlayer.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRMusicPlayer.uc
@@ -580,9 +580,6 @@ function EnterAmbient()
 
 function bool InCombat()
 {
-    local ScriptedPawn npc;
-    local Pawn CurPawn;
-
     if(!allowCombat) return false;
     if(CombatSection == LevelSongSection) return false;
 

--- a/src/DXRModules/DeusEx/Classes/DXRNPCs.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRNPCs.uc
@@ -142,7 +142,6 @@ function ItemPurchase SelectRandomPurchaseChoice(out ItemPurchase choices[75], o
 
 function RandomizeItems(out ItemPurchase items[8], optional int forced, optional int priceLimit)
 {
-    local float r;
     local int i, k, num, numChoices;
     local class<Inventory> iclass;
     local ItemPurchase choices[75];
@@ -523,9 +522,7 @@ function ConEventTrigger AddMerchantBingo(Conversation c, ConEvent prev, ItemPur
 {
     local ConEventTrigger e;
     local MerchantPurchaseBingoTrigger mpbt;
-    local string tagName, j;
-    local class<Json> js;
-    local int k;
+    local string tagName;
 
     if (i==MERCH_TELEM_NO_BUY || i==MERCH_TELEM_NO_ROOM || i==MERCH_TELEM_NO_MONEY){
         //Invalid item
@@ -631,9 +628,7 @@ function ConEventTrigger AddTransferRepairTrigger(Conversation c, ConEvent prev)
 {
     local ConEventTrigger e;
     local RepairConObjTransferTrigger rt;
-    local string tagName, j;
-    local class<Json> js;
-    local int k;
+    local string tagName;
 
     tagName="ConEventTransferObjectRepair"$c.conName; //Append the bindname to the end
 

--- a/src/DXRModules/DeusEx/Classes/DXRPasswords.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRPasswords.uc
@@ -245,7 +245,8 @@ function FixMolePeoplePhoneboothCode()
 
 function FixCodes(int mode)
 {
-    local string newpassword, replacement;
+    local string newpassword;
+    // local string replacement;
     local int i;
 
     for(i=0; i<ArrayCount(yes_passwords); i++) {

--- a/src/DXRModules/DeusEx/Classes/DXRPasswordsBase.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRPasswordsBase.uc
@@ -135,7 +135,6 @@ function FirstEntry()
 function AnyEntry()
 {
     local DataStorage ds;
-    local ConSpeech c;
     Super.AnyEntry();
 
     LogAll();
@@ -148,7 +147,7 @@ function AnyEntry()
 simulated function PlayerAnyEntry(#var(PlayerPawn) p)
 {
     local ConSpeech c;
-    local ConEventAddNote cn;
+    // local ConEventAddNote cn;
     Super.PlayerAnyEntry(p);
 
     if( p == player() )

--- a/src/DXRModules/DeusEx/Classes/DXRReduceItems.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRReduceItems.uc
@@ -122,7 +122,7 @@ function PostFirstEntry()
 
 function OneItemMode()
 {
-    local Inventory item, nextItem, items[1024];
+    local Inventory item, items[1024];
     local #var(prefix)Containers d;
     local class<Actor> contents[1024];
     local class<Inventory> newclass;

--- a/src/DXRModules/DeusEx/Classes/DXRReplaceActors.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRReplaceActors.uc
@@ -172,8 +172,6 @@ function class<inventory> ReplaceClassName(class<inventory> inv)
 
 function ReplaceContainerContents(#var(prefix)Containers a)
 {
-    local int i;
-
     a.contents = ReplaceClassName(a.contents);
     a.content2 = ReplaceClassName(a.content2);
     a.content3 = ReplaceClassName(a.content3);
@@ -296,7 +294,6 @@ function ReplaceButton1(#var(prefix)Button1 a)
 function ReplaceFaucet(#var(prefix)Faucet a)
 {
     local DXRFaucet n;
-    local DeusExPlayer dxp;
     if(a.IsA('DXRFaucet'))
         return;
 
@@ -403,7 +400,6 @@ function ReplaceOrdersTrigger(#var(prefix)OrdersTrigger a)
 function ReplaceShakeTrigger(#var(prefix)ShakeTrigger a)
 {
     local DXRShakeTrigger n;
-    local int i;
     n = DXRShakeTrigger(SpawnReplacement(a, class'DXRShakeTrigger'));
     if(n == None)
         return;
@@ -647,7 +643,6 @@ function #var(DeusExPrefix)Pickup ReplacePickup(#var(DeusExPrefix)Pickup a, #var
 {
     local ScriptedPawn owner;
     local #var(PlayerPawn) player;
-    local bool bWasDrawn;
     owner = ScriptedPawn(a.Owner);
     player = #var(PlayerPawn)(a.Owner);
     a.Destroy();
@@ -811,7 +806,6 @@ function ReplaceComputerPublic(#var(prefix)ComputerPublic a)
 function ReplaceComputerPersonal(#var(prefix)ComputerPersonal a)
 {
     local DXRComputerPersonal n;
-    local int i;
 
     n = DXRComputerPersonal(SpawnReplacement(a, class'DXRComputerPersonal'));
     if(n == None)

--- a/src/DXRModules/DeusEx/Classes/DXRSavedSetup.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRSavedSetup.uc
@@ -1,0 +1,26 @@
+class DXRSavedSetup extends DXRFlagsBase transient config(DXRSavedSetup);
+
+var config #var(flagvarprefix) string seedStr;
+var config #var(flagvarprefix) string startingMapStr;
+
+var config #var(flagvarprefix) int bingo_duration;
+var config #var(flagvarprefix) int bingo_scale;
+var config #var(flagvarprefix) int newgameplus_max_item_carryover;
+var config #var(flagvarprefix) int newgameplus_num_skill_downgrades;
+var config #var(flagvarprefix) int newgameplus_num_removed_augs;
+var config #var(flagvarprefix) int newgameplus_num_removed_weapons;
+var config #var(flagvarprefix) int clothes_looting;
+var config #var(flagvarprefix) int remove_paris_mj12;
+
+var config #var(flagvarprefix) FlagsSettings settings;
+var config #var(flagvarprefix) MoreFlagsSettings moresettings;
+
+var config #var(flagvarprefix) bool bSaved;
+
+static function DXRSavedSetup GetObj(Actor a)
+{
+    local DXRSavedSetup savedSetup;
+
+    foreach a.AllActors(class'DXRSavedSetup', savedSetup) return savedSetup;
+    return a.Spawn(class'DXRSavedSetup');
+}

--- a/src/DXRModules/DeusEx/Classes/DXRSkills.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRSkills.uc
@@ -218,20 +218,20 @@ static simulated function string DescriptionLevelExtended(Actor act, int i, out 
 
         if(#bool(vanilla) || #bool(revision)) {
             if(class'MenuChoice_BalanceSkills'.static.IsEnabled()) {
-                shortDisplay = string(int( (1 - (f * 1.1 + 0.3)) * 100.0 ));
+                shortDisplay = PadString(int( (1 - (f * 1.1 + 0.3)) * 100.0 ), 3,, true);
                 r = r $ shortDisplay $ p $ " / "; // passive is * 1.1 + 0.3
             } else {
-                shortDisplay = string(int( (1 - f * 0.75) * 100.0 ));
+                shortDisplay = PadString(int( (1 - f * 0.75) * 100.0 ), 3,, true);
             }
             r = r $ int( (1 - f * 0.75) * 100.0 ) $ p $ " / ";// hazmat is * 0.75
             r = r $ int( (1 - f * 0.5) * 100.0 ) $ p;//  ballistic armor is * 0.5
         } else if(#bool(vmd)) {
             f = (f + 1) / 2;// VMD nerfed enviro skill
-            shortDisplay = string(int( (1 - f * 0.75) * 100.0 ));
+            shortDisplay = PadString(int( (1 - f * 0.75) * 100.0 ), 3,, true);
             r = r $ shortDisplay $ p $ " / ";// hazmat is * 0.75
             r = r $ int( (1 - f * 0.5) * 100.0 ) $ p;//  ballistic armor is * 0.5
         } else {
-            shortDisplay = string(int( (1 - f * 0.75) * 100.0 ));
+            shortDisplay = PadString(int( (1 - f * 0.75) * 100.0 ), 3,, true);
             r = r $ shortDisplay $ p $ " / ";// hazmat is * 0.75
             r = r $ int( (1 - f * 0.5) * 100.0 ) $ p;//  ballistic armor is * 0.5
         }

--- a/src/DXRModules/DeusEx/Classes/DXRSkills.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRSkills.uc
@@ -11,8 +11,6 @@ replication
 
 function CheckConfig()
 {
-    local int i;
-
     min_skill_weaken = 0.3;
     max_skill_str = 1.0;
     skill_cost_curve = 2;
@@ -277,7 +275,6 @@ static simulated function string DescriptionLevelExtended(Actor act, int i, out 
 simulated function RandoSkillLevel(Skill aSkill, int i, float parent_percent)
 {
     local float percent;
-    local int m;
     local float f, perk;
     local bool banAllowed;
     local DXRLoadouts loadout;

--- a/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -10,7 +10,7 @@ function PlayerLogin(#var(PlayerPawn) p)
 {
     Super.PlayerLogin(p);
 
-    if (dxr.flags.settings.starting_map == 0) return;
+    if (dxr.flags.moresettings.starting_map == 0) return;
 
     //Add extra skill points to make available once you enter the game
     AddStartingSkillPoints(dxr,p);
@@ -1702,7 +1702,7 @@ static function AddStartingAugs(DXRando dxr, #var(PlayerPawn) player, SkillAward
 {
     local int i, numAugs, numUpgrades;
 
-    if (dxr.flags.settings.starting_map !=0 ){
+    if (dxr.flags.moresettings.starting_map !=0 ){
         numAugs = GetStartMapAugBonus(dxr);
         class'DXRAugmentations'.static.AddRandomAugs(dxr,player,numAugs);
 

--- a/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -807,6 +807,7 @@ function PreFirstEntryStartMapFixes(#var(PlayerPawn) player, FlagBase flagbase, 
         case 37:
             GiveImage(player, class'Image03_NYC_Airfield');
             MarkConvPlayed("DL_LebedevKill", bFemale);
+            GiveKey(player, 'eastgate', "East Gate key");
         case 36: // fallthrough
             GiveKey(player, 'Sewerdoor', "Sewer Door");
         case 35: // fallthrough

--- a/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRStartMap.uc
@@ -20,7 +20,6 @@ function PlayerLogin(#var(PlayerPawn) p)
 
 function PlayerAnyEntry(#var(PlayerPawn) p)
 {
-    local string m;
     if(dxr.flags.IsHordeMode()) return;// let horde mode handle it, partly because we don't want to give skillpoints and augs
     p.strStartMap = GetStartMap(self, dxr.flags.GetStartingMap()); // this also calls DXRMapVariants.VaryURL()
 #ifdef vmd

--- a/src/DXRModules/DeusEx/Classes/DXRStats.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRStats.uc
@@ -34,6 +34,10 @@ function AnyEntry()
 
     Super.AnyEntry();
 
+    if(dxr.dxInfo.MissionNumber == 98) { // clear flags backup of datastorage timers when playing intro
+        ClearTimerFlags();
+    }
+
     for(i=1; i<ArrayCount(missions_times); i++) {
         missions_times[i] = GetCompleteMissionTime(i);
         missions_menu_times[i] = GetCompleteMissionMenuTime(i);
@@ -80,6 +84,22 @@ simulated function PlayerAnyEntry(#var(PlayerPawn) p)
     }
     if(str != "") {
         info("PlayerAnyEntry " $ timestamp $ " skills/augs:" $ str);
+    }
+}
+
+function ClearTimerFlags()
+{
+    local string flagname;
+    local name flag;
+    local int mission;
+
+    for(mission=0; mission<=15; mission++) {
+        flagname = "DXRando_Mission"$mission$"_Complete_Timer";
+        flag = StringToName(flagname);
+        dxr.flagbase.DeleteFlag(flag, FLAG_Int);
+        flagname = "DXRando_Mission"$mission$"_Complete_Menu_Timer";
+        flag = StringToName(flagname);
+        dxr.flagbase.DeleteFlag(flag, FLAG_Int);
     }
 }
 

--- a/src/DXRModules/DeusEx/Classes/DXRTelemetry.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRTelemetry.uc
@@ -103,7 +103,6 @@ function CheckOfflineUpdates()
 function Timer()
 {
     local int numActors, numObjects;
-    local Actor a;
     local Object o, last;
     local name names[4096], fixed[16], n;
     local int counts[4096], slot, i;
@@ -203,7 +202,6 @@ function HTTPError(int Code)
 
 function ReceivedData(string data)
 {
-    local string status;
     local Json tjs;
 
     if(Len(data) > 500 && j==None) {
@@ -312,7 +310,7 @@ function MessageBoxClicked(int button, int callbackId){
 }
 
 function CheckDeaths(Json j, int oldCount) {
-    local string k, t;
+    local string k;
     local int i;
     local vector loc;
 

--- a/src/DXRModules/DeusEx/Classes/DXRZombies.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRZombies.uc
@@ -189,7 +189,7 @@ static function bool ReanimateCorpse(DXRActorsBase module, #var(DeusExPrefix)Car
     local class<Actor> livingClass;
     local vector respawnLoc, desiredRespawnLoc, hitNormal;
     local Actor hitActor;
-    local ScriptedPawn sp,otherSP;
+    local ScriptedPawn sp;
     local class<DeusExFragment> fragClass;
     local int i, numFrags;
     local Inventory item, nextItem;
@@ -197,7 +197,6 @@ static function bool ReanimateCorpse(DXRActorsBase module, #var(DeusExPrefix)Car
     #ifndef vmd
     local DXRFashionManager fashion;
     #endif
-    local bool removeItem;
     local string s;
 
     if(carc==None || carc.bDeleteMe) return False;

--- a/src/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminal.uc
+++ b/src/DXRNonVanilla/DeusEx/Classes/DXRNetworkTerminal.uc
@@ -4,7 +4,7 @@ static function bool GetNoPause(NetworkTerminal terminal) {
     local DXRFlags flags;
 
     foreach terminal.Player.AllActors(class'DXRFlags', flags) {
-        if(flags.settings.menus_pause == 0)
+        if(flags.moresettings.menus_pause == 0)
             return true;
     }
 

--- a/src/DXRNonVanilla/DeusEx/Classes/DXRandoRootWindow.uc
+++ b/src/DXRNonVanilla/DeusEx/Classes/DXRandoRootWindow.uc
@@ -34,7 +34,7 @@ function bool GetNoPause(bool bNoPause) {
     local DXRFlags flags;
 
     foreach parentPawn.AllActors(class'DXRFlags', flags) {
-        if(flags.settings.menus_pause == 0)
+        if(flags.moresettings.menus_pause == 0)
             bNoPause = true;
     }
 

--- a/src/DXRNonVanilla/DeusEx/Classes/DXRandoRootWindow.uc
+++ b/src/DXRNonVanilla/DeusEx/Classes/DXRandoRootWindow.uc
@@ -235,7 +235,6 @@ function bool ProcessDataVaultSelection(EInputKey key)
 
 function bool IsKeyAssigned(EInputKey key, String function)
 {
-    local int pos;
     local string InputKeyName;
     local string AllAlias,Alias;
     local DeusExPlayer player;

--- a/src/DXRNonVanilla/DeusEx/Classes/RevRandoPlayer.uc
+++ b/src/DXRNonVanilla/DeusEx/Classes/RevRandoPlayer.uc
@@ -73,7 +73,6 @@ function RandomizeAugStates()
     local DXRBase dxrb;
 
     for(aug = AugmentationSystem.FirstAug; aug!=None; aug = aug.next){
-
         //Skip synthetic heart since deactivating it turns off all your augs
         //(Maybe this could only skip it for deactivation?)
         if (aug.bHasIt && !aug.bAlwaysActive && (AugHeartLung(aug)==None)) {

--- a/src/DXRVanilla/DeusEx/Classes/AlarmLight.uc
+++ b/src/DXRVanilla/DeusEx/Classes/AlarmLight.uc
@@ -29,7 +29,6 @@ simulated function Timer()
 function SpawnDXRando(DeusExPlayer player)
 {
     local DeusExLevelInfo DeusExLevelInfo;
-    local PlayerStart ps;
 
     class'DeusExLevelInfo'.default.MapName = "ENDGAME4";
     class'DeusExLevelInfo'.default.missionNumber = 99;

--- a/src/DXRVanilla/DeusEx/Classes/BarkManager.uc
+++ b/src/DXRVanilla/DeusEx/Classes/BarkManager.uc
@@ -9,7 +9,6 @@ function bool StartBark(DeusExRootWindow newRoot, ScriptedPawn newBarkPawn, EBar
     local Float        barkDuration;
     local bool         bBarkStarted;
     local ConPlayBark  conPlayBark;
-    local String       conSpeechString;
     local ConSpeech    conSpeech;
     local Sound        speechAudio;
     local bool         bHaveSpeechAudio;

--- a/src/DXRVanilla/DeusEx/Classes/ComputerUIWindow.uc
+++ b/src/DXRVanilla/DeusEx/Classes/ComputerUIWindow.uc
@@ -36,7 +36,6 @@ function ProcessDeusExTextTag(DeusExTextParser parser, optional TextWindow winTe
 {
     local String text;
     local byte tag;
-    local int i;
 
     tag  = parser.GetTag();
 

--- a/src/DXRVanilla/DeusEx/Classes/ConPlayBase.uc
+++ b/src/DXRVanilla/DeusEx/Classes/ConPlayBase.uc
@@ -367,7 +367,6 @@ log("  event.transferCount = " $ event.transferCount);
 	// increment the count
 	else if ((invItemTo.IsA('DeusExPickup')) && (DeusExPickup(invItemTo).bCanHaveMultipleCopies))
 	{
-
 		//RANDO: It may be possible that you can carry less of the item than the game wants to give you.
 		//Reduce the number of items to be transferred to prevent a softlock
 		if (event.transferCount > DeusExPickup(invItemTo).maxCopies) {

--- a/src/DXRVanilla/DeusEx/Classes/DXRNetworkTerminal.uc
+++ b/src/DXRVanilla/DeusEx/Classes/DXRNetworkTerminal.uc
@@ -7,7 +7,7 @@ function bool GetNoPause() {
     local DXRFlags flags;
 
     foreach Player.AllActors(class'DXRFlags', flags) {
-        if(flags.settings.menus_pause == 0)
+        if(flags.moresettings.menus_pause == 0)
             return true;
     }
 

--- a/src/DXRVanilla/DeusEx/Classes/DXRShowClassWindow.uc
+++ b/src/DXRVanilla/DeusEx/Classes/DXRShowClassWindow.uc
@@ -20,6 +20,8 @@ var ToolCheckboxWindow	chkWeaponScore;
 var ToolCheckboxWindow	chkReactions;
 var ToolCheckboxWindow	chkPatrolPaths;
 var ToolCheckboxWindow	chkTextures;
+var ToolCheckboxWindow	chkPhysics;
+var ToolCheckboxWindow	chkConvoInfo;
 
 event InitWindow()
 {
@@ -103,6 +105,9 @@ function CreateDXRandoControls()
     chkReactions  = CreateToolCheckbox(middleX, middleY,  "Show Reactions", actorDisplay.AreReactionsVisible());
     middleY += 25;
 
+    chkConvoInfo  = CreateToolCheckbox(middleX, middleY,  "Show Conversation Info", actorDisplay.IsConvoInfoVisible());
+    middleY += 25;
+
 
 ////////////////////////////////////////////////////////
 
@@ -157,6 +162,10 @@ function CreateDXRandoControls()
     chkTextures = CreateToolCheckbox(rightX, rightY,  "Show Textures", actorDisplay.AreTexturesVisible());
     rightY += 25;
 
+    // Show Physics
+    chkPhysics = CreateToolCheckbox(rightX, rightY,  "Show Physics", actorDisplay.ArePhysicsVisible());
+    rightY += 25;
+
 
 //////////////////////////////////////////////////
 }
@@ -190,6 +199,7 @@ function SaveSettings()
     actorDisplay.default.bShowAcceleration= actorDisplay.IsAccelerationVisible();
     actorDisplay.default.bShowLastRendered = actorDisplay.IsLastRenderedVisible();
     actorDisplay.default.bShowEnemyResponse = actorDisplay.IsEnemyResponseVisible();
+    actorDisplay.default.bShowConvoInfo = actorDisplay.IsConvoInfoVisible();
     // actorDisplay.default.maxPoints = actorDisplay.maxPoints;
     // actorDisplay.default.sinTable = actorDisplay.sinTable;
 
@@ -230,6 +240,10 @@ function SaveSettings()
     actorDisplay.default.bShowPatrolPaths = actorDisplay.ArePatrolPathsVisible();
     actorDisplay.ShowTextures(chkTextures.GetToggle());
     actorDisplay.default.bShowTextures = actorDisplay.AreTexturesVisible();
+    actorDisplay.ShowPhysics(chkPhysics.GetToggle());
+    actorDisplay.default.bShowPhysics = actorDisplay.ArePhysicsVisible();
+    actorDisplay.ShowConvoInfo(chkConvoInfo.GetToggle());
+    actorDisplay.default.bShowConvoInfo = actorDisplay.IsConvoInfoVisible();
 
     actorDisplay.LimitRadius(chkLimitRadius.GetToggle());
     actorDisplay.default.bLimitRadius = actorDisplay.IsRadiusLimited();

--- a/src/DXRVanilla/DeusEx/Classes/DataLinkPlay.uc
+++ b/src/DXRVanilla/DeusEx/Classes/DataLinkPlay.uc
@@ -102,8 +102,6 @@ function FastForward()
 
 function Bool StartConversation(DeusExPlayer newPlayer, optional Actor newInvokeActor, optional bool bForcePlay)
 {
-    local Actor tempActor;
-
     if ( Super(ConPlayBase).StartConversation(newPlayer, newInvokeActor, bForcePlay) == False )
         return False;
 

--- a/src/DXRVanilla/DeusEx/Classes/DeusExHUD.uc
+++ b/src/DXRVanilla/DeusEx/Classes/DeusExHUD.uc
@@ -28,10 +28,10 @@ function ConfigurationChanged()
     local float hitWidth, hitHeight;
     local float infoX, infoY, infoTop, infoBottom;
     local float infoWidth, infoHeight, maxInfoWidth, maxInfoHeight;
-    local float itemsWidth, itemsHeight;
+    local float itemsWidth;
     local float damageWidth, damageHeight;
     local float conHeight;
-    local float barkWidth, barkHeight;
+    local float barkHeight;
     local float recWidth, recHeight, recPosY;
 
     //DXRando:

--- a/src/DXRVanilla/DeusEx/Classes/Mission02.uc
+++ b/src/DXRVanilla/DeusEx/Classes/Mission02.uc
@@ -10,8 +10,6 @@ function Timer()
     local BumMale bum;
     local BlackHelicopter chopper;
     local Doctor doc;
-    local BarrelAmbrosia barrel;
-    local ScriptedPawn pawn;
     local DeusExCarcass carc2;
     local GuntherHermann Gunther;
     local Actor A;

--- a/src/DXRVanilla/DeusEx/Classes/OATMenuAugsSelectorDXRando.uc
+++ b/src/DXRVanilla/DeusEx/Classes/OATMenuAugsSelectorDXRando.uc
@@ -17,7 +17,7 @@ function CreateControls()
 function bool BuildAugList()
 {
 	local Augmentation TAug, AllAugs[32];
-    local int total, i, j, num;
+    local int total, i, num;
 
 	if (Player == None) return false;
 

--- a/src/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/src/DXRVanilla/DeusEx/Classes/Player.uc
@@ -830,7 +830,7 @@ exec function bool DropItem(optional Inventory inv, optional bool bDrop)
 	local Inventory previousItemInHand;
     local DeusExPickup existingStack; //DXRando added
 	local Vector X, Y, Z, dropVect;
-	local float size, mult;
+	local float mult;
 	local bool bDropped;
 	local bool bRemovedFromSlots;
 	local int  itemPosX, itemPosY;
@@ -1493,7 +1493,6 @@ exec function slowmo(float s)
 exec function animtrack()
 {// a single command to start work on DXRAnimTracker
     local DXRAnimTracker a;
-    local int i;
 
     slowmo(0.1);
     SetPause(true);
@@ -1782,7 +1781,6 @@ function Bool IsFiring()
 function bool IsThemeAdded(Class<ColorTheme> themeClass)
 {
     local ColorTheme curTheme;
-    local ColorTheme prevTheme;
     local Bool bDeleted;
 
     bDeleted    = False;
@@ -1810,7 +1808,6 @@ function AddColorTheme(Class<ColorTheme> themeClass)
 
 function CreateColorThemeManager()
 {
-    local ColorTheme theme;
     Super.CreateColorThemeManager();
 
     AddColorTheme(Class'ColorThemeHUD_HotDogStand');
@@ -2451,7 +2448,6 @@ function bool ConsumableWouldHelp(Inventory item) {
 function InvokeUIScreen(Class<DeusExBaseWindow> windowClass)
 {
     local DeusExRootWindow root;
-    local Window w;
     root = DeusExRootWindow(rootWindow);
     if (root != None)
     {

--- a/src/DXRVanilla/DeusEx/Classes/Player.uc
+++ b/src/DXRVanilla/DeusEx/Classes/Player.uc
@@ -2386,6 +2386,18 @@ exec function PlayerRot()
     ClientMessage("Player rotation: (" $ Rotation.pitch $ ", " $ Rotation.yaw $ ", " $ Rotation.roll $ ")");
 }
 
+// log the Location of the Actor looked at, so you don't have to type it manually
+exec function LookedLoc()
+{
+    local Actor act;
+
+    act = class'DXRInfo'.static.ActorLookedAt(self);
+    if (act == None)
+        ClientMessage("No Actor looked at.");
+    else
+        ClientMessage("Looking at " $ act $ " at Location (" $ act.Location.x $ ", " $ act.Location.y $ ", " $ act.Location.z $ ")");
+}
+
 exec function LootActions()
 {
     local string lootActions, msg;

--- a/src/DXRVanilla/DeusEx/Classes/RootWindow.uc
+++ b/src/DXRVanilla/DeusEx/Classes/RootWindow.uc
@@ -262,7 +262,6 @@ function bool ProcessDataVaultSelection(EInputKey key)
 
 function bool IsKeyAssigned(EInputKey key, String function)
 {
-    local int pos;
     local string InputKeyName;
     local string AllAlias,Alias;
     local DeusExPlayer player;

--- a/src/DXRVanilla/DeusEx/Classes/RootWindow.uc
+++ b/src/DXRVanilla/DeusEx/Classes/RootWindow.uc
@@ -25,7 +25,7 @@ function bool GetNoPause(bool bNoPause) {
     local DXRFlags flags;
 
     foreach parentPawn.AllActors(class'DXRFlags', flags) {
-        if(!bNoPause && flags.settings.menus_pause == 0) {
+        if(!bNoPause && flags.moresettings.menus_pause == 0) {
             bNoPause = true;
             PartialHideHud();
         }

--- a/src/DXRando/DeusEx/Classes/BobbyPossessionEffect.uc
+++ b/src/DXRando/DeusEx/Classes/BobbyPossessionEffect.uc
@@ -71,7 +71,7 @@ function BeginPlay()
     local ZoneInfo z;
     local BobbyPossessionEffect effect;
     local int i;
-    local LitData data;
+    // local LitData data;
     local ZoneData zdata;
 
     lastPossessionTime = Level.TimeSeconds;

--- a/src/DXRando/DeusEx/Classes/CCResidentEvilCam.uc
+++ b/src/DXRando/DeusEx/Classes/CCResidentEvilCam.uc
@@ -84,9 +84,6 @@ function BindPlayer(DeusExPlayer play)
 
 function Tick(float deltaTime)
 {
-    local float ang;
-    local Rotator rot;
-
     Super(#var(prefix)HackableDevices).Tick(deltaTime);
 
     if (p==None){
@@ -130,10 +127,8 @@ function Tick(float deltaTime)
 
 function UpdateCameraRoll()
 {
-    local Rotator rot, drugRot;
+    local Rotator rot;
     local float roll,drugRoll,Mult, maxRoll, levelTimeSin, drunkSkew;
-    local DataStorage datastorage;
-    local int ccRollAmount;
 
     roll = 0;
 

--- a/src/DXRando/DeusEx/Classes/DXRAnimTracker.uc
+++ b/src/DXRando/DeusEx/Classes/DXRAnimTracker.uc
@@ -41,7 +41,6 @@ static function DXRAnimTracker Create(Pawn owner, string part)
 
 function Init(string part)
 {
-    local rotator rot;
     local int a, i;
 
     if(#bool(debug)) SaveConfig();// create/update the config file

--- a/src/DXRando/DeusEx/Classes/DXRBinoculars.uc
+++ b/src/DXRando/DeusEx/Classes/DXRBinoculars.uc
@@ -51,7 +51,7 @@ static function PeepTimer(#var(PlayerPawn) peeper, out int watchTime, out Actor 
     local Actor target;
     local bool newPeepee, newPeepTex, hitMirror;
     local name texName,texGroup;
-    local int flags, i, distRemaining;
+    local int flags, distRemaining;
 
     if(peeper == None) return;
     Level = peeper.Level;

--- a/src/DXRando/DeusEx/Classes/DXRStatLog.uc
+++ b/src/DXRando/DeusEx/Classes/DXRStatLog.uc
@@ -10,7 +10,7 @@ function LogEventString( string EventString )
 //this won't actually trigger again (It's just adding to the stack count).
 function LogPickup(Inventory Item, Pawn Other)
 {
-    local DeusExPlayer dxp;
+    // local DeusExPlayer dxp;
 
     if ( (Other == None) || (Other.PlayerReplicationInfo == None) || (Item == None) )
         return;

--- a/src/DXRando/DeusEx/Classes/DXRStoredLightFog.uc
+++ b/src/DXRando/DeusEx/Classes/DXRStoredLightFog.uc
@@ -9,7 +9,6 @@ var byte VolumeRadius;
 
 static function DXRStoredLightFog Init(Light l)
 {
-    local int i;
     local DXRStoredLightFog slf;
 
     //Only store information for lights that generate fog

--- a/src/DXRando/DeusEx/Classes/DXRStoredLightType.uc
+++ b/src/DXRando/DeusEx/Classes/DXRStoredLightType.uc
@@ -7,7 +7,6 @@ var ELightType origLightType;
 
 static function DXRStoredLightType Init(Light l)
 {
-    local int i;
     local DXRStoredLightType slf;
 
     //Only store information for lights that have problematic light types

--- a/src/DXRando/DeusEx/Classes/DXRandoCrowdControlEffects.uc
+++ b/src/DXRando/DeusEx/Classes/DXRandoCrowdControlEffects.uc
@@ -159,7 +159,6 @@ function MoveCCPawn(DXRandoCrowdControlPawn ccp, vector Location)
 //#region Periodic Updates
 function PeriodicUpdates()
 {
-
     if (dxr.OnTitleScreen()){
         return;
     }
@@ -669,7 +668,6 @@ function InitOnEnter() {
 //Effects should revert to default before exiting a level
 //so that they can be cleanly re-applied next time you enter
 function CleanupOnExit() {
-
     if (dxr==None || dxr.OnTitleScreen()){
         return;
     }
@@ -1071,7 +1069,6 @@ function class<#var(DeusExPrefix)Weapon> getWeaponClass(string type) {
 //This can also return better status messages for crowd control
 function int GiveAug(Class<Augmentation> giveClass, string viewer) {
     local Augmentation anAug;
-    local bool wasActive;
 
     // Checks to see if the player already has it.  If so, we want to
     // increase the level
@@ -1762,7 +1759,6 @@ function doNudge(string viewer) {
 }
 
 function AskRandomQuestion(String viewer) {
-
     local string question;
     local string answers[3];
     local int numAnswers;
@@ -1785,7 +1781,6 @@ function startEarthquake(float time) {
 }
 
 function int Earthquake(String viewer, int duration) {
-
     startEarthquake(duration);
 
     PlayerMessage(viewer@"set off an earthquake!");
@@ -1957,7 +1952,6 @@ function int ClonePlayer(string viewer, bool friendly)
     local vector loc;
     local rotator rot;
     local int num;
-    local Inventory pInv,newInv;
     local #var(DeusExPrefix)Ammo dxAmmo,newAmmo;
     local #var(DeusExPrefix)Weapon dxWeap,newWeap;
     local ScriptedPawn o;
@@ -2040,8 +2034,6 @@ function int SpawnPawnNearPlayer(DeusExPlayer p, class<ScriptedPawn> newclass, b
     local float radius;
     local vector loc, loc_offset;
     local rotator rot;
-    local Inventory inv;
-    local NanoKey k1, k2;
 
     if( p == None ) {
         err("p == None?");
@@ -2992,7 +2984,6 @@ function int StopCrowdControlEvent(string code, optional bool bKnownStop)
 //#region Handle Event
 function int doCrowdControlEvent(string code, string param[5], string viewer, int type, int duration) {
     local int i;
-    local ColorTheme theme;
 
     //Effects can't start on the title screen
     if (dxr.OnTitleScreen()){

--- a/src/DXRando/DeusEx/Classes/DXRandoCrowdControlLink.uc
+++ b/src/DXRando/DeusEx/Classes/DXRandoCrowdControlLink.uc
@@ -78,7 +78,6 @@ function Init( DXRando tdxr, DXRCrowdControl cc, string addr, bool anonymous, bo
 }
 
 function Timer() {
-
     ticker++;
     if (IsConnected()) {
         if (effectsDisabled==False){
@@ -305,7 +304,6 @@ function int RandomOfflineEffects() {
 }
 
 function bool isCrowdControl(string msg) {
-    local string tmp;
     //Check to see if it looks like it has the right fields in it
 
     //id field
@@ -393,7 +391,6 @@ function sendReply(int id, int status) {
 
 
 function handleMessage(string msg) {
-
     local int id,type,duration;
     local string code,viewer;
     local string param[5];

--- a/src/DXRando/DeusEx/Classes/IntercomPhone.uc
+++ b/src/DXRando/DeusEx/Classes/IntercomPhone.uc
@@ -19,7 +19,6 @@ function Timer()
 
 function Frob(actor Frobber, Inventory frobWith)
 {
-    local float rnd;
     local Pawn p;
 
     Super(#var(prefix)ElectronicDevices).Frob(Frobber, frobWith);

--- a/src/DXRando/DeusEx/Classes/LavaFire.uc
+++ b/src/DXRando/DeusEx/Classes/LavaFire.uc
@@ -46,7 +46,6 @@ function Timer()
 
 static function vector GetLocation(#var(PlayerPawn) p)
 {
-
     local float spawnRange;
     local vector loc, PlayerHead, HitLocation, HitNormal,EndTrace;
     local Actor HitActor;

--- a/src/DXRando/DeusEx/Classes/PoolTableManager.uc
+++ b/src/DXRando/DeusEx/Classes/PoolTableManager.uc
@@ -36,7 +36,6 @@ static function PoolTableManager Init(#var(prefix)Poolball cue)
 {
     local PoolTableManager ptm;
     local #var(prefix)Poolball ball;
-    local int index;
 
     ptm = cue.Spawn(class'PoolTableManager',,,cue.Location);
 

--- a/src/DXRando/DeusEx/Classes/WHPiano.uc
+++ b/src/DXRando/DeusEx/Classes/WHPiano.uc
@@ -99,7 +99,6 @@ simulated function Tick(float deltaTime)
     if (bUsing){
         LastRenderTime = Level.TimeSeconds; //Hack to keep it out of stasis while it's playing (bAlwaysTick doesn't help)
         if (PlayDoneTime<=Level.TimeSeconds) {
-
             if (!PianoIsBroken() && SongPlayed[currentSong]==0){
                 SongPlayed[currentSong]++;
                 class'DXREvents'.static.MarkBingo("PianoSong"$currentSong$"Played");
@@ -147,7 +146,6 @@ function bool PianoIsBroken()
 
 function Frob(actor Frobber, Inventory frobWith)
 {
-    local int rnd;
     local float duration;
     local Sound SelectedSound;
 

--- a/src/DXRando/DeusEx/Classes/WeaponWhip.uc
+++ b/src/DXRando/DeusEx/Classes/WeaponWhip.uc
@@ -5,10 +5,7 @@ var transient DXRAnimTracker tracker;
 
 simulated function Tick(float deltaTime)
 {
-    local vector loc;
-    local rotator rot;
     local Pawn pawn;
-    local Vector offset, X, Y, Z;
 
     pawn = Pawn(Owner);
 
@@ -33,7 +30,6 @@ simulated function Tick(float deltaTime)
 simulated function PlaySelectiveFiring()
 {
     local Pawn aPawn;
-    local float rnd;
     local Name anim;
 
     anim = 'Attack';

--- a/src/GUI/DeusEx/Classes/AugDisplayWindow.uc
+++ b/src/GUI/DeusEx/Classes/AugDisplayWindow.uc
@@ -1107,7 +1107,6 @@ function DrawSpyDroneAugmentation(GC gc)
         //Balanced SpyDrone costs 10 energy to detonate.  Display a message if you don't have enough
         //See "DroneExplode" in DXRBalance/BalancePlayer.uc
         if (Player.Energy < 10 && class'MenuChoice_BalanceAugs'.static.IsEnabled()){
-
             //Find the useful coords of the drone window
             boxH = height/4;
             boxCX = width/8 + margin;

--- a/src/GUI/DeusEx/Classes/ComputerScreenATM.uc
+++ b/src/GUI/DeusEx/Classes/ComputerScreenATM.uc
@@ -2,8 +2,6 @@ class DXRComputerScreenATM injects #var(prefix)ComputerScreenATM;
 
 function CloseScreen(String action)
 {
-    local int compIndex;
-
     if (action=="LOGIN")
     {
         //Mark the account as known

--- a/src/GUI/DeusEx/Classes/ComputerScreenLogin.uc
+++ b/src/GUI/DeusEx/Classes/ComputerScreenLogin.uc
@@ -2,8 +2,6 @@ class DXRComputerScreenLogin injects #var(prefix)ComputerScreenLogin;
 
 function CloseScreen(String action)
 {
-    local int compIndex;
-
     if (action=="LOGIN")
     {
 #ifdef injections

--- a/src/GUI/DeusEx/Classes/CreditsLeaderboardWindow.uc
+++ b/src/GUI/DeusEx/Classes/CreditsLeaderboardWindow.uc
@@ -15,8 +15,7 @@ function InitStats(DXRStats newstats)
 event DrawWindow(GC gc)
 {
     local color c;
-    local float p;
-    local int i, yPos;
+    local int yPos;
 
     c.R = 255;
     c.G = 255;

--- a/src/GUI/DeusEx/Classes/CreditsTimerWindow.uc
+++ b/src/GUI/DeusEx/Classes/CreditsTimerWindow.uc
@@ -30,7 +30,6 @@ function AddMissionTime(string missionNum, string missionName, string dyingTime,
 event DrawWindow(GC gc)
 {
     local color c;
-    local float p;
     local int i, yPos;
 
     c.R = 255;

--- a/src/GUI/DeusEx/Classes/DXRBigMessage.uc
+++ b/src/GUI/DeusEx/Classes/DXRBigMessage.uc
@@ -16,7 +16,6 @@ const kpColumn1X = 0.20;
 const kpColumn2X = 0.60;
 
 static function DXRBigMessage GetCurrentBigMessage(#var(PlayerPawn) player) {
-    local DXRBigMessage m;
     local DeusExRootWindow root;
 
     root = DeusExRootWindow(player.rootWindow);
@@ -176,9 +175,7 @@ function string FindKeyBinding(string binding)
 function string GetKeyAssigned(EInputKey key)
 {
     // based on DeusExRootWindow.IsKeyAssigned
-    local int pos;
     local string InputKeyName;
-    local string Alias;
 
     InputKeyName = mid(string(GetEnum(enum'EInputKey',key)),3);
 

--- a/src/GUI/DeusEx/Classes/DXRComputerScreenATMWithdraw.uc
+++ b/src/GUI/DeusEx/Classes/DXRComputerScreenATMWithdraw.uc
@@ -20,15 +20,13 @@ function bool IsDuplicateATM(ATM a1, ATM a2)
 
 function bool IsATMEmpty(ATM a)
 {
-    local int i;
-
     return a.GetBalance(-1,1.0) <= 0;
 }
 
 
 function WithdrawCredits(#switch(gmdx: optional bool bWithdrawAll))
 {
-    local int balance,userIdx;
+    local int userIdx;
     local bool wasEmpty,emptyAfter;
     local ATM a;
 

--- a/src/GUI/DeusEx/Classes/DXRHUDConWindowFirst.uc
+++ b/src/GUI/DeusEx/Classes/DXRHUDConWindowFirst.uc
@@ -4,8 +4,6 @@ class DXRHUDConWindowFirst injects HUDConWindowFirst;
 function DisplayText(string text, Actor speakingActor)
 {
     local TextWindow newText;
-    local float txtWidth;
-    local GC gc;
 
     newText = TextWindow(lowerConWindow.NewChild(Class'TextWindow'));
     newText.SetTextAlignments( HALIGN_Left, VALIGN_Center);

--- a/src/GUI/DeusEx/Classes/DXRHUDMultiSkills.uc
+++ b/src/GUI/DeusEx/Classes/DXRHUDMultiSkills.uc
@@ -89,9 +89,9 @@ function DrawSkillsScreen(GC gc)
 {
     local Skill askill;
     local float curx, cury, w, h;
-    local String str, costStr, word;
+    local String str, costStr;
     local int index, i;
-    local float barLen, costx, levelx, curvaluex, nextvaluex, val, defaultval;
+    local float barLen, costx, levelx, curvaluex, nextvaluex, val;
     local DXRSkills dxrs;
     local String levelValuesDisplay[4];
 
@@ -219,10 +219,10 @@ function DrawAugsScreen(GC gc)
 {
     local Augmentation anaug;
     local float curx, cury, w, h;
-    local String str, costStr;
+    local String str;
     local int index, i, numUpgrades;
     local int trueLevel,trueMax;
-    local float barLen, levelx, curvaluex, nextvaluex, val, defaultval;
+    local float barLen, levelx, curvaluex, nextvaluex, val;
     local DXRAugmentations dxra;
     local String levelValuesDisplay[5];
 
@@ -480,7 +480,6 @@ function bool AttemptUpgradeAug( DeusExPlayer thisPlayer, Augmentation anAug )
 
     if (anAug!=None)
     {
-
         class'DXRAugmentations'.static.GetTrueAugLevels(anAug,trueLevel,trueMax);
 
         if (trueLevel==trueMax){

--- a/src/GUI/DeusEx/Classes/DXRMenuScreenNewGame.uc
+++ b/src/GUI/DeusEx/Classes/DXRMenuScreenNewGame.uc
@@ -42,8 +42,6 @@ static function bool HasLDDPInstalled()
 
 event InitWindow()
 {
-    local int i;
-
     bFemaleEnabled = HasLDDPInstalled();
 
     Super(MenuUIScreenWindow).InitWindow();
@@ -242,7 +240,7 @@ function CreateSkillsListWindow()
 function ProcessAction(String actionKey)
 {
     local DeusExPlayer		localPlayer;
-    local String			localStartMap;
+    // local String			localStartMap;
     local String            playerName;
 
     localPlayer   = player;

--- a/src/GUI/DeusEx/Classes/FrobDisplayWindow.uc
+++ b/src/GUI/DeusEx/Classes/FrobDisplayWindow.uc
@@ -51,7 +51,6 @@ function bool CheckHighlighted(Actor frobTarget)
 
 function CheckSettings()
 {
-
     if( player == None || player.FlagBase == None ) return;
 
     dxr = class'DXRando'.default.dxr;
@@ -194,10 +193,9 @@ function DrawWindowBase(GC gc, actor frobTarget)
 {
     local float     infoX, infoY, infoW, infoH;
     local string    strInfo;
-    local float     boxCX, boxCY, boxTLX, boxTLY, boxBRX, boxBRY, boxW, boxH;
+    local float     boxTLX, boxTLY, boxBRX, boxBRY, boxW, boxH;
     local float     corner;
     local int       i, offset, numLines;
-    local Color     col;
 
     // move the box in and out based on time
     offset = (24.0 * (frobTarget.Level.TimeSeconds % 0.3));

--- a/src/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
+++ b/src/GUI/DeusEx/Classes/HUDSpeedrunSplits.uc
@@ -96,7 +96,7 @@ function string ReplaceVariables(string s)
     local DXRando dxr;
     local DXRFlags f;
     local DXRLoadouts loadouts;
-    local int i, id;
+    local int id;
 
     dxr = stats.dxr;
     f = dxr.flags;
@@ -294,7 +294,7 @@ function CompletedRun(int total)
 
 function UpdatePos()
 {
-    local float hudWidth, hudHeight, beltWidth, beltHeight;
+    local float beltHeight;
 
 #ifdef injections
     local DeusExHUD hud;
@@ -380,10 +380,7 @@ function DrawWindow(GC gc)
 
 function DrawHeader(GC gc)
 {
-    local int i, prev, prevprev, curTime, next, time, total, prevTotal;
-    local float f, delta;
-    local string msg, msg2;
-    local Color cmpColor;
+    local int total;
 
     total = TotalTime();
     if(left_col == 0) {
@@ -475,7 +472,6 @@ function DrawWaltonWare(GC gc)
 function DrawSplits(GC gc, int cur)
 {
     local int i, prev, prevprev, curTime, next, time, total, prevTotal;
-    local float f, delta;
     local string msg, msg2;
     local Color cmpColor;
     local bool bShuffle;
@@ -607,7 +603,7 @@ function string MissionName(int mission)
 
 function DrawTextLine(GC gc, string header, string msg, Color c, int x, int y, optional string extra, optional bool small)
 {
-    local float w, h, column;
+    local float w, h;
 
     x += x_pos;
     y += ty_pos;
@@ -686,7 +682,7 @@ function string fmtTimeDiff(int diff)
 
 function int BalancedSplit(int m)
 {
-    local int i, balanced_split_time;
+    local int balanced_split_time;
     local int total_goal;
     local int typical_split_time, typical_total_time;
     local int timesave, total_timesave;

--- a/src/GUI/DeusEx/Classes/MenuChoice_BalanceItems.uc
+++ b/src/GUI/DeusEx/Classes/MenuChoice_BalanceItems.uc
@@ -2,6 +2,6 @@ class MenuChoice_BalanceItems extends MenuChoice_BalanceEtc;
 
 defaultproperties
 {
-    HelpText="Balance changes to items and weapons"
+    HelpText="Balance changes for items and weapons."
     actionText="Items Balance Changes"
 }

--- a/src/GUI/DeusEx/Classes/MenuChoice_ColorVision.uc
+++ b/src/GUI/DeusEx/Classes/MenuChoice_ColorVision.uc
@@ -205,7 +205,6 @@ static function Color GetNeutralColor()
 //Friendly laser is normally green
 static function Texture GetFriendlyLaserColor()
 {
-
     switch(Default.Value){
         case VIS_REDGREEN:
             return Texture'Extension.SolidGreen';
@@ -221,8 +220,6 @@ static function Texture GetFriendlyLaserColor()
 //Hostile is normally red
 static function Texture GetHostileLaserColor()
 {
-    local Color c;
-
     switch(Default.Value){
         case VIS_REDGREEN:
             return Texture'Extension.SolidRed';
@@ -238,8 +235,6 @@ static function Texture GetHostileLaserColor()
 //Neutral (aiming at an object or neutral person) is normally yellow
 static function Texture GetNeutralLaserColor()
 {
-    local Color c;
-
     switch(Default.Value){
         case VIS_REDGREEN:
             return Texture'Extension.SolidYellow';
@@ -255,8 +250,6 @@ static function Texture GetNeutralLaserColor()
 //Nothing (not aiming at an Actor) is normally white
 static function Texture GetNothingLaserColor()
 {
-    local Color c;
-
     switch(Default.Value){
         case VIS_REDGREEN:
             return Texture'Extension.Solid';
@@ -272,8 +265,6 @@ static function Texture GetNothingLaserColor()
 //Aiming with grenade at a wall (in range) is normally light blue
 static function Texture GetGrenadePlantLaserColor()
 {
-    local Color c;
-
     switch(Default.Value){
         case VIS_REDGREEN:
             return Texture'Extension.VisionBlue';

--- a/src/GUI/DeusEx/Classes/MenuChoice_MeleeSlot.uc
+++ b/src/GUI/DeusEx/Classes/MenuChoice_MeleeSlot.uc
@@ -1,0 +1,91 @@
+//=============================================================================
+// MenuChoice_MeleeSlot
+//=============================================================================
+
+class MenuChoice_MeleeSlot extends MenuUIChoiceSlider config(DXRandoOptions);
+
+var config int StartingMeleeSlot;
+
+// ----------------------------------------------------------------------
+// LoadSetting()
+// ----------------------------------------------------------------------
+
+function LoadSetting()
+{
+	saveValue = float(StartingMeleeSlot);
+    SetValue(saveValue);
+}
+
+// // ----------------------------------------------------------------------
+// // CancelSetting()
+// // ----------------------------------------------------------------------
+
+function CancelSetting()
+{
+	StartingMeleeSlot = int(saveValue);
+	SaveConfig();
+}
+
+// // ----------------------------------------------------------------------
+// // ResetToDefault()
+// // ----------------------------------------------------------------------
+
+function ResetToDefault()
+{
+    StartingMeleeSlot = int(defaultValue);
+    SetValue(defaultValue);
+    SaveConfig();
+}
+
+function SetEnumerators()
+{
+	local int enumIndex;
+
+	for (enumIndex = 0; enumIndex < 9; enumIndex++) {
+		SetEnumeration(enumIndex, enumIndex + 1);
+    }
+}
+
+// ----------------------------------------------------------------------
+// ScalePositionChanged() : Called when an ancestor scale window's
+//                          position is moved
+// ----------------------------------------------------------------------
+
+event bool ScalePositionChanged(Window scale, int newTickPosition,
+                                float newValue, bool bFinal)
+{
+	// Don't do anything while initializing as we get several
+	// ScalePositionChanged() events before LoadSetting() is called.
+
+	if (bInitializing)
+		return False;
+
+	StartingMeleeSlot = int(GetValue());
+
+    if(bFinal){
+        SaveConfig();
+    }
+
+	return false;
+}
+
+function CreateActionButton()
+{
+    Super.CreateActionButton();
+    SetActionButtonWidth(179);
+}
+
+// ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+
+defaultproperties
+{
+    numTicks=9
+    startValue=1
+    endValue=9
+    defaultValue=2
+    StartingMeleeSlot=2
+    choiceControlPosX=203
+    actionText="Starting Melee Belt Slot"
+    HelpText="Which belt slot your starting melee weapon gets put on."
+}

--- a/src/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
+++ b/src/GUI/DeusEx/Classes/MenuScreenRandoOptionsGameplay.uc
@@ -42,6 +42,7 @@ function CreateChoices()
         CreateChoice(class'MenuChoice_BalanceMaps');
         CreateChoice(class'MenuChoice_BalanceEtc');
     }
+    //CreateChoice(class'MenuChoice_MeleeSlot');
 }
 
 defaultproperties

--- a/src/GUI/DeusEx/Classes/PersonaScreenBingo.uc
+++ b/src/GUI/DeusEx/Classes/PersonaScreenBingo.uc
@@ -133,12 +133,12 @@ static function string GetNextStartingMap(DXRando dxr)
     local string nextStartName;
     local DXRStartMap m;
 
-    if(dxr.flags.settings.starting_map == 0) return "";
+    if(dxr.flags.moresettings.starting_map == 0) return "";
 
     m = DXRStartMap(class'DXRStartMap'.static.Find());
     if(m == None) return "";
     dxr.seed++;
-    nextStartNum = m.ChooseRandomStartMap(m, dxr.flags.settings.starting_map);
+    nextStartNum = m.ChooseRandomStartMap(m, dxr.flags.moresettings.starting_map);
     dxr.seed--;
     nextStartName = m.GetStartingMapNameCredits(nextStartNum);
     return nextStartName;

--- a/src/GUI/DeusEx/Classes/PersonaScreenGoals.uc
+++ b/src/GUI/DeusEx/Classes/PersonaScreenGoals.uc
@@ -56,7 +56,7 @@ function CreateControls()
             btnGoalHints.SetSensitivity(true);
 
             //CreateShowSpoilersCheckbox();
-            if (dxr.flags.settings.spoilers==1){
+            if (dxr.flags.moresettings.spoilers==1){
                 CreateShowSpoilersButton(); //A button makes a confirmation window easier
             }
 
@@ -69,7 +69,7 @@ function CreateControls()
             btnEntranceLocs.SetWindowAlignments(HALIGN_Left, VALIGN_Top, 220, 411);
             btnEntranceLocs.SetSensitivity(true);
 
-            if (dxr.flags.settings.spoilers==1){
+            if (dxr.flags.moresettings.spoilers==1){
                 btnEntranceSpoilers = PersonaActionButtonWindow(winClient.NewChild(Class'DXRPersonaActionButtonWindow'));
                 btnEntranceSpoilers.SetButtonText("Entrance Spoilers");
                 btnEntranceSpoilers.SetWindowAlignments(HALIGN_Left, VALIGN_Top, 300, 411);

--- a/src/GUI/DeusEx/Classes/PersonaScreenHealth.uc
+++ b/src/GUI/DeusEx/Classes/PersonaScreenHealth.uc
@@ -48,7 +48,6 @@ function int ApplyGeneralHealing(int healAmount)
 // ----------------------------------------------------------------------
 function int HealAllParts()
 {
-	local MedKit medkit;
 	local int    healPointsAvailable;
 	local int    healPointsRemaining;
 	local int    pointsHealed;

--- a/src/GUI/DeusEx/Classes/PersonaScreenImages.uc
+++ b/src/GUI/DeusEx/Classes/PersonaScreenImages.uc
@@ -199,7 +199,7 @@ function EnableButtons()
     //Check if image has hint information available from DXRMissions
     if (dxrMissions!=None && dxrMissions.dxr.flags.settings.goals > 0){
         if (dxrMissions.MapHasGoalMarkers(image.class)){
-            if (dxrMissions.dxr.flags.settings.spoilers==1){
+            if (dxrMissions.dxr.flags.moresettings.spoilers==1){
                 btnShowSpoilers.Show(True);
             }
             btnGoalLocations.Show(True);

--- a/src/GUI/DeusEx/Classes/PersonaScreenImages.uc
+++ b/src/GUI/DeusEx/Classes/PersonaScreenImages.uc
@@ -35,8 +35,6 @@ event DestroyWindow()
 
 function CreateButtons()
 {
-    local PersonaButtonBarWindow winActionButtons;
-
     Super.CreateButtons();
 
     winGoalHintButtons = PersonaButtonBarWindow(winClient.NewChild(Class'PersonaButtonBarWindow'));

--- a/src/GUI/DeusEx/Classes/PersonaScreenLogs.uc
+++ b/src/GUI/DeusEx/Classes/PersonaScreenLogs.uc
@@ -15,7 +15,6 @@ function PopulateLog()
 
     local string finalLogLines[10];
     local int numLines,i, strLen;
-    local bool moreText;
 
 
 	// Now loop through all the conversations and add them to the list

--- a/src/HXRandomizer/Classes/HXRandoGameInfo.uc
+++ b/src/HXRandomizer/Classes/HXRandoGameInfo.uc
@@ -63,9 +63,6 @@ event PostLogin(playerpawn NewPlayer)
 event AcceptInventory(pawn PlayerPawn)
 {
     local HXPlayerPawn Human;
-    local HXNanoKeyInfo aKey;
-    local int PointsSpent;
-    local class<HXMissionScript> HXScript;
     local Inventory Inv;
 
     // First remark all inventory spaces as occupied,
@@ -126,7 +123,6 @@ event AcceptInventory(pawn PlayerPawn)
 
 function ProcessServerTravel( string URL, bool bItems )
 {
-    local int i;
     local DeusExNote note;
     local DataStorage ds;
     log(Self$".ProcessServerTravel PreTravel dxr: "$dxr);

--- a/src/Pawns/DeusEx/Classes/BobbyFake.uc
+++ b/src/Pawns/DeusEx/Classes/BobbyFake.uc
@@ -87,7 +87,6 @@ function ImpartMomentum(Vector momentum, Pawn instigatedBy)
 function Explode(vector HitLocation)
 {
     local int i;
-    local Vector loc;
     local DeusExFragment s;
     local ExplosionLight light;
     local ExplosionSmall exp;

--- a/src/Pawns/DeusEx/Classes/CrowdControlClone.uc
+++ b/src/Pawns/DeusEx/Classes/CrowdControlClone.uc
@@ -99,7 +99,6 @@ function CloneInventory(#var(PlayerPawn) p)
     local Inventory pInv,newInv;
     local #var(DeusExPrefix)Ammo dxAmmo,newAmmo;
     local #var(DeusExPrefix)Weapon dxWeap,newWeap;
-    local DXRando dxr;
     local DXRActorsBase dxrab;
 
     dxrab = DXRActorsBase(class'DXRActorsBase'.static.Find());

--- a/src/Pawns/DeusEx/Classes/Merchant.uc
+++ b/src/Pawns/DeusEx/Classes/Merchant.uc
@@ -26,7 +26,6 @@ function bool FilterDamageType(Pawn instigatedBy, Vector hitLocation,
 
 function EnterConversationState(bool bFirstPerson, optional bool bAvoidState)
 {
-    local DXRando dxr;
     local DXRHints hints;
     local Conversation con;
     local ConEvent ce;

--- a/src/Pawns/DeusEx/Classes/Stalker.uc
+++ b/src/Pawns/DeusEx/Classes/Stalker.uc
@@ -60,7 +60,6 @@ function InitializePawn()
 {
     local NavigationPoint p, closest;
     local float dist, minDist;
-    local int i;
 
     Super.InitializePawn();
 

--- a/src/Pawns/DeusEx/Classes/WeepingAnna.uc
+++ b/src/Pawns/DeusEx/Classes/WeepingAnna.uc
@@ -139,7 +139,7 @@ function Destroyed()
 
 function CheckWakeup(float deltaSeconds)
 {
-    local bool bSeen, inConv;
+    local bool inConv;
     local #var(PlayerPawn) seer;
     local name StateName;
 

--- a/src/Triggers/DeusEx/Classes/BarkBindTrigger.uc
+++ b/src/Triggers/DeusEx/Classes/BarkBindTrigger.uc
@@ -23,7 +23,6 @@ function Trigger(Actor Other, Pawn Instigator)
 
 function BindBarkNameEvent()
 {
-    local DXRando dxr;
     local ScriptedPawn a;
 
     foreach AllActors(class'ScriptedPawn',a,event)

--- a/src/Triggers/DeusEx/Classes/BingoTrigger.uc
+++ b/src/Triggers/DeusEx/Classes/BingoTrigger.uc
@@ -38,7 +38,6 @@ function Untrigger(Actor Other, Pawn Instigator)
 
 function Touch(Actor Other)
 {
-
     if (TriggerType!=TT_Shoot && !bPeepable && !bCrouchCheck && IsRelevant(Other))
     {
         if (DoBingoThing()){
@@ -95,7 +94,7 @@ function int GetSelfTouchCount()
 
 function int GetTouchingCount()
 {
-    local Actor a;
+    // local Actor a;
     local BingoTrigger bt;
     local int count;
 
@@ -130,7 +129,6 @@ function bool DoBingoThing()
     }
 
     if (TriggerType==TT_ClassProximity && touchLimit>1){
-
         //Not enough items touching the bingo trigger
         if (GetTouchingCount() < touchLimit){
             return false;

--- a/src/Triggers/DeusEx/Classes/DXRTelemetryTrigger.uc
+++ b/src/Triggers/DeusEx/Classes/DXRTelemetryTrigger.uc
@@ -9,7 +9,6 @@ function string GetTelemMessage()
 
 function Trigger(Actor Other, Pawn Instigator)
 {
-    local Actor a;
     local DXRando dxr;
 
     Super.Trigger(Other, Instigator);

--- a/src/Triggers/DeusEx/Classes/DrawWeaponTrigger.uc
+++ b/src/Triggers/DeusEx/Classes/DrawWeaponTrigger.uc
@@ -25,7 +25,6 @@ function DrawWeapon()
     local name cloneevent;
 
     if (Event != '') {
-
         foreach AllActors(class '#var(prefix)ScriptedPawn', sp, Event) {
             sp.SetupWeapon(true,true);
             if (bKeepWeaponDrawn) sp.bKeepWeaponDrawn=true;

--- a/src/Triggers/DeusEx/Classes/MerchantPurchaseBingoTrigger.uc
+++ b/src/Triggers/DeusEx/Classes/MerchantPurchaseBingoTrigger.uc
@@ -6,9 +6,6 @@ var int              purchasePrice;
 
 function bool DoBingoThing()
 {
-    local DXRando dxr;
-    local BingoTrigger bt;
-
     if (purchaseItem==None){
         return false;
     }

--- a/src/notes/patchv3.7.1.md
+++ b/src/notes/patchv3.7.1.md
@@ -75,4 +75,5 @@
 - Fix patrol points in the 'Ton Hotel in Mission 8 so that the riot cops actually patrol the hotel.
 - "Getting Colder..." infolink from Alex in Mission 1 UNATCO HQ actually works if you leave his office without talking to him.
 - Values in the Environmental Training skill description align better.
+- Smuggler's elevator button in the final New York mission no longer moves around.
 </details>

--- a/src/notes/patchv3.7.1.md
+++ b/src/notes/patchv3.7.1.md
@@ -73,4 +73,5 @@
 - Enemies will no longer use a PS40 at extremely close range.
 - More reliable timer storage across crashes.
 - Fix patrol points in the 'Ton Hotel in Mission 8 so that the riot cops actually patrol the hotel.
+- "Getting Colder..." infolink from Alex in Mission 1 UNATCO HQ actually works if you leave his office without talking to him.
 </details>

--- a/src/notes/patchv3.7.1.md
+++ b/src/notes/patchv3.7.1.md
@@ -64,6 +64,7 @@
 - "AL" will now appear over the oxygen meter when swimming underwater while Aqualung is active (Manually or automatically).
 - The electrical panel in the basement of the NSF Warehouse (Mission 2) near the sewer entrance will properly disable the nearby laser triggers, as well as disable the rest of the basement lasers (Without disabling unrelated lasers elsewhere in the map).
 - Items that don't exist in the inventory grid will not be counted for the purposes of removing items beyond the "Max Item Carryover" limit.  For example, with a "Max Item Carryover" of 5, you can wear 1 ballistic armor through the end of a loop while holding 5 unused ballistic armors in your inventory and not lose any of them due to the limit.
+- In Mission 3, the Sewer Door and East Gate keys now drop from enemies before they're removed after dealing with Lebedev.
 - Charged Pickups (things like ballistic armor, thermoptic camo, tech goggles) no longer count down their timers while in cutscenes (Like game endings or helicopter rides).
 - Items like fire extinguishers or armors that are in use when finishing the game will be removed when starting New Game Plus.
 - Items should no longer be lost sometimes when dropped and picked up again quickly (GEP Gun juggling, for example).

--- a/src/notes/patchv3.7.1.md
+++ b/src/notes/patchv3.7.1.md
@@ -74,4 +74,5 @@
 - More reliable timer storage across crashes.
 - Fix patrol points in the 'Ton Hotel in Mission 8 so that the riot cops actually patrol the hotel.
 - "Getting Colder..." infolink from Alex in Mission 1 UNATCO HQ actually works if you leave his office without talking to him.
+- Values in the Environmental Training skill description align better.
 </details>

--- a/src/notes/patchv3.7.1.md
+++ b/src/notes/patchv3.7.1.md
@@ -76,4 +76,5 @@
 - "Getting Colder..." infolink from Alex in Mission 1 UNATCO HQ actually works if you leave his office without talking to him.
 - Values in the Environmental Training skill description align better.
 - Smuggler's elevator button in the final New York mission no longer moves around.
+- Added buttons for Save Settings and Restore Settings on the Advanced New Game screen.
 </details>

--- a/src/notes/patchv3.7.1.md
+++ b/src/notes/patchv3.7.1.md
@@ -77,4 +77,5 @@
 - Values in the Environmental Training skill description align better.
 - Smuggler's elevator button in the final New York mission no longer moves around.
 - Added buttons for Save Settings and Restore Settings on the Advanced New Game screen.
+- Stackable items marked as Junk will now get picked up if they're already in your inventory.
 </details>

--- a/src/notes/patchv3.7.1.md
+++ b/src/notes/patchv3.7.1.md
@@ -72,4 +72,5 @@
 - New Loadout: "No Rifles".  Assault Rifle, Assault Shotgun, Sniper Rifle, and Sawed-Off Shotgun are banned, along with their associated ammos.
 - Enemies will no longer use a PS40 at extremely close range.
 - More reliable timer storage across crashes.
+- Fix patrol points in the 'Ton Hotel in Mission 8 so that the riot cops actually patrol the hotel.
 </details>


### PR DESCRIPTION
# Changes Since v3.7.1.7 Alpha:

- Fixed speedrun presets loadout to speed enhancement
- Fixed timer reset on new game
- In Mission 3, the Sewer Door and East Gate keys now drop from enemies before they're removed after dealing with Lebedev.
- Fix patrol points in the 'Ton Hotel in Mission 8 so that the riot cops actually patrol the hotel.
- "Getting Colder..." infolink from Alex in Mission 1 UNATCO HQ actually works if you leave his office without talking to him.
- Values in the Environmental Training skill description align better.
- Smuggler's elevator button in the final New York mission no longer moves around.
- Added buttons for Save Settings and Restore Settings on the Advanced New Game screen.
- Stackable items marked as Junk will now get picked up if they're already in your inventory.
- Added an option to choose which belt slot your starting melee weapon starts on. Add these lines to DXRandoOptions.ini, replacing `N` with a number from 1 to 9:
  ```
  [DeusEx.MenuChoice_MeleeSlot]
  StartingMeleeSlot=N
  ```

# Overall Changes Since v3.7:

## Major Changes

- New game mode: Speedrun Shuffle!  This is the same as Speedrun Mode, but the order of the missions is shuffled.
- New game mode: Mr. Page's Nice Bingo Machine!  This is a combination of Normal Randomizer and the Mean Bingo Machine, making it a great starting point for people to learn bingo.
- The new game screen now shows recommended presets.
- You can pet the robots! (Except for Medical and Repair Bots)

## Minor Changes

<details>
<summary>Click to expand Minor Changes</summary>

- Robots can now be randomly given a pistol weapon or a radioactive weapon.
- Updated speedrun splits notes defaults.
- In vanilla, bingo goals for destroying robots can now also be completed by disabling the robots as well.
- Area 51 sniper in tower is activated immediately if you start in the tower instead of starting to move after 9 seconds.
- Improved some RNG to be more evenly distributed.
- Rando Lite no longer has added merchants.
- "Songs Played" count on piano highlight info no longer shows if Memes are disabled, since this also disables the additional songs to be played.
- Some doors that have pneumatic sounds now break into metal fragments instead of wood, such as the Ocean Lab surface map sub bay doors.
- Fixed the size of some objects that replace the Earth being grasped by the hand statue.
- The 350 skill points for redirecting the missile in Silo (Mission 14) can no longer be acquired by walking in the right spot in the command center.  The skill points will now be properly given only when actually redirecting the missile from the launch computer.
- Changes to October Cosmetics settings
  - Spooks (spiderwebs and jack-o'-lanterns) and red screen tint can now be turned on or off separately in global settings
  - Spooks are now correctly turned off in Halloween modes, when disabled in global settings
  - Spooks are now correctly turned on when not in Halloween mode or October, when enabled in global settings
- Improved faction detection when cloning enemies.  Bots in the Airfield (Mission 3) should now clone NSF-related enemies, and spiderbots in the Vandenberg Tunnels (Mission 12) should now spawn MJ12-related enemies.
- Enemies cloned from the NSF in Mission 3 will now be cleaned up better in non-vanilla versions of the randomizer.
- "Send him back to the people" bingo goal now gets marked as failed as soon as Leo Gold disappears from the game.
- Bingo help window now shows the available missions as a list with human readable names.  If the goal is active in the current mission, the mission will be clearly marked in the window.  In Zero Rando, missions beyond the current one will only be listed as ??? to avoid spoilers.
- New Bingo Goals:
  - "Spoils of War": Buy something from Tech Sergeant Kaplan in Mission 1.
  - "We're Cops": Tell Tech Sergeant Kaplan you're going to take a minimum-force approach in Mission 1.
  - "Bench Warmer": Sit on 3 benches scattered around Liberty Island (Mission 1).
  - "Peace Keeping Occupation": Speak to Gunther after completing a mission (Mission 2, 3, or 4).
  - "Who will help the widow's son?": Speak to the Freemason in the Free Clinic (Mission 2).
  - "Pet x Cleaner Bots": Pet enough cleaner bots (Missions 1, 2, 3, 4, 8).
  - "Pet x Commercial Grade Security Bots": Pet enough commercial grade security bots (Missions 1, 2, 3, 4, 8, 11, 15).
  - "Crawl under the super freighter helipad": Crawl through the tunnel connecting the electrical room to the helipad (Mission 9).
  - "Raise the bridge in engineering": Use the keypad next to the bridge in the superfreighter engine room to raise it.
  - "Our Country 'Tis of Thee": Listen to the bum in Battery Park sing his whole rendition of My Country 'Tis of Thee (Mission 2)
- Mission starts inside the Ocean Lab or at Silo (Mission 14) will now start with the sub bay doors open in the Sub Base.  Silo starts will also start with the sub bay doors open in the Ocean Lab itself.
- Randomly placed datacubes (such as Medbot or Repairbot hints) should no longer be able to get placed in unreachable areas (Such as underneath the shanty town huts in Mission 2 Battery Park).
- Synthetic Heart aug improvements and fixes:
  - Aug levels are always shown as the actual level, instead of the effective level if being boosted by Synthetic Heart (In other words, an aug will show the same level whether Synthetic Heart is active or not).  The extra level from Synthetic Heart is shown as a plus sign next to the aug level when the aug is being boosted.
  - It is now possible to fully upgrade an aug while Synthetic Heart is active.
  - Augs that are removed (Such as at the end of a game or if removed at a Medical Bot) while being boosted by Synthetic Heart will no longer be already in a boosted state when reinstalled, resulting in them being at an effective level 0.  This is most obvious when Synthetic Heart is active when the aug is reinstalled.
  - Crowd Control can no longer downgrade an aug to level 0 if it is being boosted by Synthetic Heart.
- New Aug Slot Rando option: Balanced. Keeps the proportional number of augs per slot as close to default as possible.
- Zombies raised from corpses of the player (or corpses of Crowd Control player clones) now get the proper face skin and hit sounds.
- Troops that are fleeing during the apartment raid in Mission 4 are now considered dead for the purposes of stopping the raid (So you won't need to hunt down that one troop hiding in a corner to have it counted as being completed).
- Paul's fashion should now be immaculate after uncloaking and in death.
- Paul and JC's corpses will now correctly use the "floating" mesh if clothes are changed while the body is in the water
- "Who Needs Rock?" bingo goal progress is now properly marked when trading zyme to Lenny after getting a LAM from El Rey.
- Karkians in the MJ12 Lab (Mission 5) will now properly go hostile and try to escape regardless of how the door is opened.
- Player clones spawned by Crowd Control can now use defensive augs, speed, cloak, medkits, biocells, and fire extinguishers that the player had when the clone was spawned.
- Smuggler's bot starts "standing" instead of "idle", which means he will still react to threats when Smuggler knows you (and he becomes pettable).
- Paul actually disappears after talking to you and going to the train in Mission 2.
- Conversations that play while in first person will now try to trigger other events that happen after a voice line gets interrupted.  This fixes/improves some cases where you get items, notes, or flags get set after the voice line plays (for example, the trooper that gives you LAMs in the training mission, or Nicolette giving a password note when in the study of Chateau DuClare).
- The Crowd Control setting will now automatically be enabled if there is a session connected when starting a new game.
- When playing with Toggle Crouch disabled, you can now crouch while jumping.  This was already possible when Toggle Crouch was enabled.
- "Let Aimee and Le Merchant Live" bingo goal now gets properly marked as completed when traveling to another map other than Denfert-Rochereau.  This fixes the goal with Entrance Randomization, where it would previously only be marked completed when you get to the Catacombs tunnels.
- Open Aug Tree can no longer be opened on the title screen.
- "AL" will now appear over the oxygen meter when swimming underwater while Aqualung is active (Manually or automatically).
- The electrical panel in the basement of the NSF Warehouse (Mission 2) near the sewer entrance will properly disable the nearby laser triggers, as well as disable the rest of the basement lasers (Without disabling unrelated lasers elsewhere in the map).
- Items that don't exist in the inventory grid will not be counted for the purposes of removing items beyond the "Max Item Carryover" limit.  For example, with a "Max Item Carryover" of 5, you can wear 1 ballistic armor through the end of a loop while holding 5 unused ballistic armors in your inventory and not lose any of them due to the limit.
- In Mission 3, the Sewer Door and East Gate keys now drop from enemies before they're removed after dealing with Lebedev.
- Charged Pickups (things like ballistic armor, thermoptic camo, tech goggles) no longer count down their timers while in cutscenes (Like game endings or helicopter rides).
- Items like fire extinguishers or armors that are in use when finishing the game will be removed when starting New Game Plus.
- Items should no longer be lost sometimes when dropped and picked up again quickly (GEP Gun juggling, for example).
- Adjustments to the alliances of everybody in the Versalife offices.  Security guards should now spawn police-related clones, and the commandos that show up later will spawn MJ12-related clones.  Workers with weapons will spawn more generic clones.
- Zombies will now resurrect with the same head gear as they had before (Helmets, visors, or lack thereof).
- New Loadout: "No Rifles".  Assault Rifle, Assault Shotgun, Sniper Rifle, and Sawed-Off Shotgun are banned, along with their associated ammos.
- Enemies will no longer use a PS40 at extremely close range.
- More reliable timer storage across crashes.
- Fix patrol points in the 'Ton Hotel in Mission 8 so that the riot cops actually patrol the hotel.
- "Getting Colder..." infolink from Alex in Mission 1 UNATCO HQ actually works if you leave his office without talking to him.
- Values in the Environmental Training skill description align better.
- Smuggler's elevator button in the final New York mission no longer moves around.
- Added buttons for Save Settings and Restore Settings on the Advanced New Game screen.
- Stackable items marked as Junk will now get picked up if they're already in your inventory.
</details>
