### PR TITLE
Ban goals that require you to create corpses with "Grenades Only" and  "Explosives Only" loadouts

### DIFF
--- a/src/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -2871,12 +2871,16 @@ function bool BingoGoalImpossibleByFlags(string bingo_event, int starting_missio
 ///////////////////////////////////////////////////
 
         case "IgnitedPawn":
-            if(loadout!=None) {
-                if(loadout.is_banned(class'#var(prefix)WeaponFlamethrower')
-                    && (!#bool(injections) || loadout.is_banned(class'#var(prefix)WeaponMiniCrossbow') || loadout.is_banned(class'#var(prefix)AmmoDartFlare'))
-                ) {
-                    return true;
-                }
+            if (
+                loadout != None
+                && loadout.is_banned(class'#var(prefix)WeaponFlamethrower')
+                && (
+                    !#bool(injections)
+                    || loadout.is_banned(class'#var(prefix)WeaponMiniCrossbow')
+                    || loadout.is_banned(class'#var(prefix)AmmoDartFlare')
+                )
+            ) {
+                return true;
             }
             break; //Let this fall through to later checks
 
@@ -2925,32 +2929,19 @@ function bool BingoGoalImpossibleByFlags(string bingo_event, int starting_missio
 /////////////////////////////////////////////////////////////////////
     //Ban goals that require the use of drugs or alcohol as appropriate
         case "DrinkAlcohol_Activated": //Only impossible if *all* alcohol is banned
-            if(loadout!=None) {
-                if(loadout.is_banned(class'#var(prefix)Liquor40oz') &&
-                   loadout.is_banned(class'#var(prefix)LiquorBottle') &&
-                   loadout.is_banned(class'#var(prefix)WineBottle')
-                   ) {
-                    return true;
-                }
-            }
-            return false;
+            return (
+                loadout != None
+                && loadout.is_banned(class'#var(prefix)Liquor40oz')
+                && loadout.is_banned(class'#var(prefix)LiquorBottle')
+                && loadout.is_banned(class'#var(prefix)WineBottle')
+            );
 
         case "JockSecondStory": //Jock only wants beers
-            if(loadout!=None) {
-                if(loadout.is_banned(class'#var(prefix)Liquor40oz')) {
-                    return true;
-                }
-            }
-            return false;
+            return loadout != None && loadout.is_banned(class'#var(prefix)Liquor40oz');
 
         case "GiveZyme_ConvoFlag": //Need zyme to give zyme
         case "SoldRenaultZyme":    //Need zyme to sell zyme
-            if(loadout!=None) {
-                if(loadout.is_banned(class'#var(prefix)VialCrack')) {
-                    return true;
-                }
-            }
-            return false;
+            return loadout != None && loadout.is_banned(class'#var(prefix)VialCrack');
 
 /////////////////////////////////////////////////////////////////////
     //Ban goals that require progress when you *don't* need to progress
@@ -2960,18 +2951,14 @@ function bool BingoGoalImpossibleByFlags(string bingo_event, int starting_missio
 /////////////////////////////////////////////////////////////////////
     //Ban goals that require hacking (By the Book stuff)
         case "ComputerHacked":    //Need to be able to hack to hack computers
-            if(loadout!=None) {
-                if(loadout.is_skill_banned(class'SkillComputer')) {
-                    return true;
-                }
+            if (loadout != None && loadout.is_skill_banned(class'SkillComputer')) {
+                return true;
             }
             break;
 
         case "AlarmUnitHacked":    //Need to be able to use multitools to hack alarm panels
-            if(loadout!=None) {
-                if(loadout.is_banned(class'#var(prefix)Multitool')) {
-                    return true;
-                }
+            if (loadout != None && loadout.is_banned(class'#var(prefix)Multitool')) {
+                return true;
             }
             break;
 
@@ -2980,29 +2967,25 @@ function bool BingoGoalImpossibleByFlags(string bingo_event, int starting_missio
         case "GibbedPawn":
         case "IgnitedPawn":
         case "AlliesKilled":
-            if (loadout!=None){
-                if (loadout.IsLoadoutPureNonLethal()){
-                    return true;
-                }
+            if (loadout != None && loadout.IsLoadoutPureNonLethal()) {
+                return true;
             }
             break;
 
         case "BurnTrash":
-            //If the board only covers a single mission
-            if (real_duration==1 && loadout!=None) {
+            return (
+                real_duration == 1 //If the board only covers a single mission
                 //No way to burn via weapons
-                if(loadout.is_banned(class'#var(prefix)WeaponFlamethrower') //Obviously this can burn
-                   && loadout.is_banned(class'#var(prefix)WeaponPlasmaRifle') //Plasma can ignite
-                   && loadout.is_banned(class'#var(prefix)WeaponHideAGun') //Plasma can ignite
-                   && (!#bool(injections) || loadout.is_banned(class'#var(prefix)WeaponMiniCrossbow') || loadout.is_banned(class'#var(prefix)AmmoDartFlare')) //Flare darts can set things on fire
-                ) {
-                    //No burning barrel in M09 to ignite the trash
-                    if (starting_mission==9){
-                        return true;
-                    }
-                }
-            }
-            return false;
+                && loadout != None
+                && loadout.is_banned(class'#var(prefix)WeaponFlamethrower') //Obviously this can burn
+                && loadout.is_banned(class'#var(prefix)WeaponHideAGun') //Plasma can ignite
+                && loadout.is_banned(class'#var(prefix)WeaponHideAGun') //Plasma can ignite
+                && ( //Flare darts can set things on fire
+                    !#bool(injections)
+                    || loadout.is_banned(class'#var(prefix)WeaponMiniCrossbow')
+                    || loadout.is_banned(class'#var(prefix)AmmoDartFlare')
+                )
+            );
 
 /////////////////////////////////////////////////////////////////////
     //Ban goals that aren't possible on Revision maps

--- a/src/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -2974,7 +2974,8 @@ function bool BingoGoalImpossibleByFlags(string bingo_event, int starting_missio
 
         case "BurnTrash":
             return (
-                real_duration == 1 //If the board only covers a single mission
+                starting_mission == 9 //No burning barrel in M09 to ignite the trash
+                && real_duration == 1 //If the board only covers a single mission
                 //No way to burn via weapons
                 && loadout != None
                 && loadout.is_banned(class'#var(prefix)WeaponFlamethrower') //Obviously this can burn

--- a/src/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -2987,6 +2987,12 @@ function bool BingoGoalImpossibleByFlags(string bingo_event, int starting_missio
                 )
             );
 
+    //Ban goals that require you to create specific corpses
+        case "LeoToTheBar":
+        case "SewerSurfin":
+            return loadout != None && loadout.IsLoadoutNoCorpses();
+        break;
+
 /////////////////////////////////////////////////////////////////////
     //Ban goals that aren't possible on Revision maps
         case "LibertyBenches":

--- a/src/DXRModules/DeusEx/Classes/DXREvents.uc
+++ b/src/DXRModules/DeusEx/Classes/DXREvents.uc
@@ -2874,10 +2874,7 @@ function bool BingoGoalImpossibleByFlags(string bingo_event, int starting_missio
             if (
                 loadout != None
                 && loadout.is_banned(class'#var(prefix)WeaponFlamethrower')
-                && (
-                    !#bool(injections)
-                    || loadout.is_banned(class'#var(prefix)WeaponMiniCrossbow')
-                    || loadout.is_banned(class'#var(prefix)AmmoDartFlare')
+                && (!#bool(injections) || loadout.is_banned(class'#var(prefix)WeaponMiniCrossbow') || loadout.is_banned(class'#var(prefix)AmmoDartFlare')
                 )
             ) {
                 return true;

--- a/src/DXRModules/DeusEx/Classes/DXRLoadouts.uc
+++ b/src/DXRModules/DeusEx/Classes/DXRLoadouts.uc
@@ -19,9 +19,11 @@ struct loadouts
     var int                 lethality;
 };
 
-const PURE_LETHAL     =  1; //No weapons to do knockouts
-const PURE_NONLETHAL  = -1; //No weapons to do kills
-const VAGUE_LETHALITY =  0; //Neither purely lethal nor non-lethal
+const PURE_LETHAL     = 1; //No weapons to do knockouts
+const PURE_NONLETHAL  = 2; //No weapons to do kills
+const NO_CORPSES      = 4; //No corpses can be created
+
+const VAGUE_LETHALITY = 0; //Neither purely lethal nor non-lethal
 
 var loadouts item_set;
 
@@ -324,6 +326,7 @@ function string LoadoutInfo(int loadout, optional bool get_name)
         AddItemSpawn(class'#var(package).WeaponRubberBaton',10);
         AddStandardAugSet();
         SetLoadoutPureLethal();
+        SetLoadoutNoCorpses();
         return name;
     //#endregion
 /////////////////////////////////////////////////////////////////
@@ -424,6 +427,7 @@ function string LoadoutInfo(int loadout, optional bool get_name)
         AddItemSpawn(class'#var(prefix)Ammo20mm',100);
         AddStandardAugSet();
         SetLoadoutPureLethal();
+        SetLoadoutNoCorpses();
         return name;
     //#endregion
 /////////////////////////////////////////////////////////////////
@@ -704,12 +708,17 @@ function AddLoadoutPlayerMsg(string msg)
 
 function SetLoadoutPureLethal()
 {
-    item_set.lethality = PURE_LETHAL;
+    item_set.lethality = item_set.lethality | PURE_LETHAL;
 }
 
 function SetLoadoutPureNonLethal()
 {
-    item_set.lethality = PURE_NONLETHAL;
+    item_set.lethality = item_set.lethality | PURE_NONLETHAL;
+}
+
+function SetLoadoutNoCorpses()
+{
+    item_set.lethality = item_set.lethality | NO_CORPSES;
 }
 
 function SetLoadoutDefaultLethal()
@@ -719,12 +728,17 @@ function SetLoadoutDefaultLethal()
 
 function bool IsLoadoutPureLethal()
 {
-    return item_set.lethality==PURE_LETHAL;
+    return bool(item_set.lethality & PURE_LETHAL);
 }
 
 function bool IsLoadoutPureNonLethal()
 {
-    return item_set.lethality==PURE_NONLETHAL;
+    return bool(item_set.lethality & PURE_NONLETHAL);
+}
+
+function bool IsLoadoutNoCorpses()
+{
+    return bool(item_set.lethality & NO_CORPSES);
 }
 
 function AddInvBan(class<Inventory> inv)

--- a/src/notes/patchv3.7.1.md
+++ b/src/notes/patchv3.7.1.md
@@ -79,4 +79,5 @@
 - Smuggler's elevator button in the final New York mission no longer moves around.
 - Added buttons for Save Settings and Restore Settings on the Advanced New Game screen.
 - Stackable items marked as Junk will now get picked up if they're already in your inventory.
+- Goals that require you to create dead or unconscious bodies ("Bring the terrorist commander to a bar" and "Sewer Surfin'") are now banned with "Grenades Only" and "Explosives Only" loadouts.
 </details>


### PR DESCRIPTION
This includes "LeoToTheBar" and "SewerSurfin". "PaulToTong" isn't blocked because his corpse gets spawned for you.

In the process, `loadouts.lethality` is changed to a bitmask with a `NO_CORPSES` setting. (In the future, it might be shared with a hypothetical pacifist mode or "Ultimate Run" mode.)

Also, several multi-branching conditionals in `BingoGoalImpossibleByFlags()` are simplified to single- or non-branching ones... because I couldn't bear not to.